### PR TITLE
Update /design:plan to use story-sized issue grouping

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -7,7 +7,7 @@ argument-hint: [spec-name or SPEC-XXXX] [--review] [--project <name>] [--no-proj
 
 # Plan Sprint from Specification
 
-You are breaking down an existing specification into trackable work items (epics, tasks, sub-tasks) in the user's issue tracker.
+You are breaking down an existing specification into trackable work items (epics and story-sized issues) in the user's issue tracker. Instead of creating one issue per requirement, you group related requirements into 3-4 story-sized issues by functional area, with task checklists in the issue body for requirement traceability. See ADR-0011 and SPEC-0010.
 
 ## Process
 
@@ -97,30 +97,58 @@ You are breaking down an existing specification into trackable work items (epics
 
    **5.1: Create an epic.** Create an epic (or equivalent) for the specification itself, titled "Implement {Capability Title}" with a body referencing the spec number and linking to the spec/design files.
 
-   **5.2: Create tasks from requirements.** For each `### Requirement:` section in the spec:
-   - Create a task as a child of the epic
-   - Title: the requirement name
+   **5.2: Group requirements into stories.** Instead of creating one issue per requirement, group all `### Requirement:` sections into 3-4 story-sized issues by functional area. This is governed by SPEC-0010 and ADR-0011.
+
+   **Grouping process:**
+   1. Scan all `### Requirement:` sections in the spec and identify the functional areas they affect (e.g., data model, API endpoints, validation, configuration, setup).
+   2. Cluster requirements by functional area cohesion — requirements that affect the same part of the system belong in the same story.
+   3. Apply coupling analysis — requirements that modify the same files or share data structures MUST be placed in the same story.
+   4. Apply dependency ordering — prerequisites go in earlier stories, dependents in later stories.
+   5. Target 3-4 stories for a spec with 10-15 requirements (3-5 requirements per story). For specs with 4 or fewer requirements, create 1-2 stories. For a single-requirement spec, create 1 story.
+   6. Each story SHOULD target a PR in the 200-500 line range. This is a heuristic — functional cohesion takes priority over line-count targets. Do NOT split functionally cohesive requirements across stories solely to meet the line-count target.
+
+   **Creating story issues:**
+   - Title: a descriptive name reflecting the story's functional area (e.g., "Setup & Configuration", "Core Auth Flow", "Validation & Error Handling")
    - Body MUST include:
-     - A reference to the spec and requirement (e.g., "Implements SPEC-0003, Requirement: JWT Token Generation")
-     - Acceptance criteria derived from the requirement's WHEN/THEN scenarios
-     - Links to governing ADRs if the spec references them in its Overview
-   - For complex requirements with multiple scenarios, create sub-tasks for each scenario
+     - A short description of what this story implements and its governing spec/ADR references
+     - A `## Requirements` section containing a task checklist (see step 5.3)
+     - Acceptance criteria summarized at the end
    - **After creating the issue** (to obtain the issue number), unless `--no-branches` is set, update the issue body to append a `### Branch` section:
-     - Tasks: `` `feature/{issue-number}-{slug}` `` (or custom prefix from `--branch-prefix` or `.design.json` `branches.prefix`)
+     - Stories: `` `feature/{issue-number}-{slug}` `` (or custom prefix from `--branch-prefix` or `.design.json` `branches.prefix`)
      - Epics: `` `epic/{issue-number}-{slug}` `` (or custom prefix from `--branch-prefix` or `.design.json` `branches.epic_prefix`)
-     - The slug MUST be derived from the requirement name using kebab-case, max 50 chars (or `.design.json` `branches.slug_max_length`)
+     - The slug MUST be derived from the story title using kebab-case, max 50 chars (or `.design.json` `branches.slug_max_length`)
      - This requires a two-pass approach: create the issue first to get the number, then update the body
 
-   **5.3: Write acceptance criteria.** Each issue MUST include:
-   ```
+   **5.3: Write task checklists.** Each story issue body MUST include a `## Requirements` section with a task checklist. The format varies by tracker:
+
+   **For GitHub, Gitea, GitLab, Jira, and Linear** — use markdown task checklists:
+   ```markdown
+   ## Requirements
+
+   - [ ] **REQ "{Requirement Name}"** (SPEC-XXXX): {normative statement from the requirement}
+     - WHEN {trigger from key scenario} THEN {expected outcome}
+     - WHEN {trigger from another scenario} THEN {expected outcome}
+   - [ ] **REQ "{Another Requirement}"** (SPEC-XXXX): {normative statement}
+     - WHEN {trigger} THEN {outcome}
+
    ## Acceptance Criteria
-   - [ ] Per SPEC-XXXX REQ "Requirement Name": {normative statement from requirement}
-   - [ ] Per SPEC-XXXX Scenario "Scenario Name": WHEN {trigger} THEN {outcome}
+   - [ ] Per SPEC-XXXX REQ "{Req 1}": {summary}
+   - [ ] Per SPEC-XXXX REQ "{Req 2}": {summary}
    - [ ] Governing: ADR-XXXX ({decision title})
    ```
 
-   After acceptance criteria, unless `--no-branches` is set, append a `### PR Convention` section:
-   - Include the tracker-specific close keyword referencing the issue number
+   - The requirement name MUST match the `### Requirement:` heading in the spec exactly
+   - The SPEC reference MUST use the spec's number (e.g., `SPEC-0010`)
+   - WHEN/THEN pairs MUST be derived from the requirement's scenarios, not invented
+   - Every requirement in the spec MUST appear in exactly one story's task checklist
+
+   **For Beads** — use native subtasks:
+   - Create subtasks for each requirement using `bd subtask add`, linking each subtask to the parent story
+   - Each subtask SHALL be titled with the requirement name
+   - Each subtask body SHALL include the normative statement, WHEN/THEN scenarios, and spec reference
+
+   After the requirements and acceptance criteria sections, unless `--no-branches` is set, append a `### PR Convention` section:
+   - Include the tracker-specific close keyword referencing the story issue number
    - Include a reference to the parent epic and governing spec
    - Tracker-specific close keywords:
      - **GitHub/Gitea**: `Closes #{issue-number}`
@@ -130,12 +158,12 @@ You are breaking down an existing specification into trackable work items (epics
      - **Linear**: `{TEAM}-{number}` reference
    - Use `.design.json` `pr_conventions` settings when available (close_keyword, ref_keyword, include_spec_reference)
 
-   **5.4: Set up dependencies.** Where requirements have logical ordering (e.g., setup before implementation, core before extensions), set up dependency relationships using the tracker's native features. If using Beads, use `bd dep add`.
+   **5.4: Set up dependencies between stories.** Where stories have logical ordering (e.g., setup before core logic, core before extensions), set up dependency relationships between story issues using the tracker's native features. If using Beads, use `bd dep add`.
 
    **5.5: Gather tracker-specific config.** If the tracker requires configuration not already saved (e.g., repo owner/name for GitHub, project key for Jira), use `AskUserQuestion` to ask the user. Offer to save the config to `.design.json`.
 
    **5.6: Project grouping.** Unless `--no-projects` is set:
-   - **Default (per-epic)**: For each epic, create a tracker-native project and add the epic and its child tasks:
+   - **Default (per-epic)**: For each epic, create a tracker-native project and add the epic and its child stories:
      - **GitHub**: Projects V2 via `gh project create` CLI or MCP tools, then `gh project item-add` to add issues. **After creating the project, MUST link it to the repository** using `gh project link {project-number} --owner {owner} --repo {owner}/{repo}` so it appears in the repository's Projects tab.
      - **Gitea**: Project via MCP tools (use `ToolSearch` to discover). MUST ensure the project is associated with the repository.
      - **GitLab**: Milestone or board
@@ -185,7 +213,7 @@ You are breaking down an existing specification into trackable work items (epics
 
 8. **Report the plan.** Summarize what was created:
    - Which tracker was used (or tasks.md fallback)
-   - Number of epics, tasks, and sub-tasks created
+   - Number of epics and stories created, with how many requirements were grouped into each story
    - Number of project groupings created (or "skipped" if `--no-projects` was set)
    - Whether branch naming conventions were included in issue bodies (or "skipped" if `--no-branches`)
    - Whether PR conventions were included in issue bodies (or "skipped" if `--no-branches`)
@@ -194,12 +222,13 @@ You are breaking down an existing specification into trackable work items (epics
 
 ## Team Handoff Protocol (only for `--review` mode)
 
-1. The planner creates the full issue breakdown (or tasks.md draft) and sends it to the reviewer
+1. The planner creates the full story breakdown (or tasks.md draft) and sends it to the reviewer
 2. The reviewer checks:
-   - Every spec requirement has at least one corresponding issue/task
-   - Acceptance criteria correctly reference WHEN/THEN scenarios
-   - Dependency ordering is logical (setup → core → extensions → testing)
-   - Issue scope is session-sized (not too large, not too granular)
+   - Every spec requirement appears in exactly one story's task checklist
+   - Story groupings are functionally cohesive (coupled requirements are in the same story)
+   - Task checklist items correctly reference requirement names, spec numbers, and WHEN/THEN scenarios
+   - Dependency ordering between stories is logical (setup → core → extensions → testing)
+   - Story scope targets 200-500 line PRs (heuristic, not hard constraint)
 3. The reviewer either:
    a. Sends "APPROVED" to the lead, or
    b. Sends specific revision requests to the planner
@@ -209,19 +238,23 @@ You are breaking down an existing specification into trackable work items (epics
 ## Rules
 
 - MUST read both spec.md and design.md before creating any issues
-- Every `### Requirement:` section in the spec MUST produce at least one issue/task
-- Every issue MUST reference the spec number and requirement name
-- Acceptance criteria MUST be derived from the spec's WHEN/THEN scenarios, not invented
+- MUST group requirements into 3-4 story-sized issues by functional area — NEVER create one issue per requirement (Governing: SPEC-0010 REQ "Requirement Grouping", ADR-0011)
+- Every `### Requirement:` section in the spec MUST appear in exactly one story's task checklist
+- Every story MUST contain a `## Requirements` section with a task checklist referencing the spec number, requirement names, normative statements, and WHEN/THEN scenarios
+- Task checklist WHEN/THEN pairs MUST be derived from the spec's scenarios, not invented
+- For Beads, MUST use native subtasks (`bd subtask add`) instead of markdown checklists
+- Story groupings SHOULD target 200-500 line PRs — functional cohesion takes priority over line-count targets (Governing: SPEC-0010 REQ "PR Size Target")
+- Coupled requirements (same files, shared data structures) MUST be placed in the same story (Governing: SPEC-0010 REQ "Grouping Heuristics")
 - MUST use `ToolSearch` to discover tracker MCP tools at runtime — never assume specific tools are available
 - MUST check `.design.json` for saved tracker preference before running detection
 - MUST offer to save tracker preference when a tracker is selected for the first time
 - When merging into `.design.json`, preserve existing keys — only update changed sections
-- Sub-tasks are OPTIONAL — only create them for complex requirements with 3+ scenarios
-- Dependency ordering SHOULD reflect logical implementation order, not spec document order
+- Dependency ordering between stories SHOULD reflect logical implementation order, not spec document order
 - Project grouping failures MUST NOT prevent issue creation
 - MUST link created projects to the repository for trackers that support project-repository associations (e.g., GitHub Projects V2 via `gh project link`, Gitea). Without linking, projects are invisible from the repository's Projects tab.
-- Branch slug MUST be derived from requirement name (kebab-case, max 50 chars), not invented
+- Branch slug MUST be derived from the story title (kebab-case, max 50 chars), not invented
 - PR close keywords MUST match the detected tracker
 - MUST use `ToolSearch` for project tools at runtime
 - `--project` and `--no-projects` are mutually exclusive; if both provided, warn and use `--no-projects`
 - `--no-branches` disables both `### Branch` AND `### PR Convention` sections
+- Story issues MUST be consumable by `/design:work` and `/design:review` — they use the same `### Branch` and `### PR Convention` structural sections (Governing: SPEC-0010 REQ "Downstream Compatibility")


### PR DESCRIPTION
## Summary
- Replaces per-requirement issue creation in `/design:plan` with story-sized grouping by functional area (3-4 stories per spec instead of 10-15 per-requirement issues)
- Adds task checklist format in story bodies with REQ names, spec references, and WHEN/THEN scenarios (markdown checklists for most trackers, Beads native subtasks)
- Preserves all backward compatibility: tracker detection, project grouping, branch naming, PR conventions, `.design.json` schema

Closes #29
Closes #30
Closes #31
Part of #28 | SPEC-0010

## Test plan
- [ ] Run `/design:plan` against a spec with 10+ requirements — verify it produces 3-4 stories instead of 10+ issues
- [ ] Verify each story's task checklist references all grouped requirements with correct SPEC numbers and WHEN/THEN scenarios
- [ ] Verify every spec requirement appears in exactly one story's task checklist
- [ ] Verify `### Branch` and `### PR Convention` sections use story issue numbers
- [ ] Run `/design:plan --review` — verify reviewer validates story groupings
- [ ] Run `/design:plan --no-branches` — verify branch/PR sections are omitted
- [ ] Run `/design:work` against story-sized issues — verify workers consume them correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)