### PR TITLE
Security Defaults: Mandatory security section in web specs, security checklists in issues

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -177,6 +177,32 @@ Ordered for implementation (dependencies respected):
      - The slug MUST be derived from the story title using kebab-case, max 50 chars (or `.claude-plugin-design.json` `branches.slug_max_length`)
      - This requires a two-pass approach: create the issue first to get the number, then update the body
 
+   **5.2.1: Detect HTTP endpoint stories for security checklist injection.**
+
+   <!-- Governing: ADR-0018 (Security-by-Default), SPEC-0016 REQ "Security Checklist in Issues" -->
+
+   After grouping requirements into stories, determine which stories involve HTTP endpoints. A story involves HTTP endpoints if ANY of the following are true:
+
+   - The story implements, modifies, or tests HTTP endpoint handlers or route registrations
+   - The grouped requirements reference endpoints, routes, middleware, request/response handling, or API paths
+   - The spec's Security Requirements section (if present) applies to the story's functional area
+   - The story title or description references: API, endpoint, route, handler, middleware, controller, HTTP, REST, webhook
+
+   A story does NOT involve HTTP endpoints if it exclusively involves: database migrations, background jobs, CLI commands, library refactoring, configuration setup, CI/CD pipelines, or documentation.
+
+   For each story that involves HTTP endpoints, you MUST append a **## Security Checklist** section to the issue body, placed after the `## Acceptance Criteria` section and before any `### Branch` or `### PR Convention` sections. Use this template:
+
+   ```markdown
+   ## Security Checklist
+   - [ ] Authentication middleware applied
+   - [ ] Input validation for all request parameters and body fields
+   - [ ] Output encoding for user-supplied data in responses
+   - [ ] Rate limiting configured
+   - [ ] Request body size limits enforced
+   ```
+
+   Do NOT add the security checklist to stories that do not involve HTTP endpoints.
+
    **5.3: Write task checklists.** Each story issue body MUST include a `## Requirements` section with a task checklist. The format varies by tracker:
 
    **For GitHub, Gitea, GitLab, Jira, and Linear** — use markdown task checklists:
@@ -340,6 +366,9 @@ Follow the standard protocol from the plugin's `references/shared-patterns.md` �
 - `.claude-plugin-design.json` `projects.views`, `projects.columns`, `projects.iteration_weeks` are all optional with sensible defaults — do NOT overwrite existing keys when they are absent
 - Story issues MUST be consumable by `/design:work` and `/design:review` — they use the same `### Branch` and `### PR Convention` structural sections (Governing: SPEC-0010 REQ "Downstream Compatibility")
 - When `--scrum` is set, organize and enrich MUST run automatically after grooming — NEVER require the user to run `/design:organize` or `/design:enrich` separately (Governing: SPEC-0012 REQ "Automatic Organize and Enrich")
+- Stories that involve HTTP endpoints MUST include a `## Security Checklist` section with authentication, input validation, output encoding, rate limiting, and body size limit items (Governing: ADR-0018, SPEC-0016 REQ "Security Checklist in Issues")
+- The security checklist MUST NOT be added to stories that do not involve HTTP endpoints (DB migrations, background jobs, CLI commands, library refactoring, etc.) (Governing: SPEC-0016 REQ "Security Checklist in Issues")
+- The security checklist MUST be placed after `## Acceptance Criteria` and before `### Branch` / `### PR Convention` sections
 - Engineer B MUST provide a substantive objection for any story that has a weak requirement, vague scope, or missing spec reference — generic approval without review is not acceptable (Governing: SPEC-0012 REQ "Scrum Team Composition")
 - The sprint report MUST be emitted at the end of every `--scrum` run, even if all stories were deferred (Governing: SPEC-0012 REQ "Sprint Report")
 - `--scrum` and `--review` are mutually exclusive; if both are provided, `--scrum` takes precedence and `--review` is silently ignored

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -55,6 +55,97 @@ You are creating or updating an OpenSpec specification. Every spec is a **paired
 
 Follow the standard team handoff protocol from the plugin's `references/shared-patterns.md`. The drafter is the spec-writer; the reviewer is the architect who checks both spec.md and design.md against the Rules checklist below.
 
+## Web-Facing Detection and Security Injection
+
+<!-- Governing: ADR-0018 (Security-by-Default), SPEC-0016 REQ "Mandatory Security Section in Web Specs" -->
+
+Before writing the spec, determine whether the capability is **web-facing**. A spec is web-facing if ANY of the following are true:
+
+- It defines or modifies HTTP endpoints (REST API, GraphQL, gRPC-web, etc.)
+- It involves web server routes or middleware
+- It includes browser-rendered UI (HTML templates, HTMX, SPAs)
+- It describes an API consumed over HTTP/HTTPS
+- The capability name or description references: API, dashboard, webhook, web, HTTP, endpoint, route, server, frontend, UI, portal, gateway
+
+A spec is **NOT web-facing** if it exclusively involves: CLI tools, internal libraries, batch/cron jobs, data migrations, background workers, message queue consumers, or purely offline processing.
+
+### When the spec IS web-facing
+
+You MUST inject a **## Security Requirements** section into spec.md, placed after the functional `## Requirements` section. This section MUST cover all six topics below. Use the template in the "Security Requirements Section Template" below.
+
+You MUST also apply **auth-by-default**: when generating endpoint tables or lists, every endpoint MUST default to "Auth: Required". Any endpoint the spec author wants to be public MUST be listed as "Auth: Public" with an explicit justification (e.g., "Health check — required for load balancer probes"). Do NOT leave any endpoint without an auth designation.
+
+### When the spec is NOT web-facing
+
+Do NOT inject the Security Requirements section. Proceed with the standard spec template only.
+
+## Security Requirements Section Template
+
+When injecting the security section into a web-facing spec, use this template placed after the functional requirements:
+
+```markdown
+## Security Requirements
+
+<!-- Governing: ADR-0018 (Security-by-Default), SPEC-0016 REQ "Mandatory Security Section in Web Specs" -->
+
+### Authentication
+
+All endpoints MUST require authentication by default. Public (unauthenticated) endpoints MUST be explicitly listed with justification.
+
+| Endpoint | Auth | Justification |
+|----------|------|---------------|
+| {endpoint} | Required | — |
+| {public endpoint} | Public | {why auth is not required} |
+
+### Rate Limiting
+
+{Declare the rate limiting strategy for this capability. Specify limits per endpoint or globally. If rate limiting is deferred, state the justification.}
+
+### Security Headers
+
+All HTTP responses MUST include the following security headers:
+
+- `Content-Security-Policy`: {policy}
+- `X-Frame-Options`: DENY (or SAMEORIGIN with justification)
+- `X-Content-Type-Options`: nosniff
+- `Referrer-Policy`: strict-origin-when-cross-origin
+
+### Request Body Size Limits
+
+All endpoints that accept request bodies MUST enforce size limits. Request bodies MUST be bounded (e.g., `http.MaxBytesReader` in Go, `express.json({ limit })` in Node.js) to prevent unbounded memory allocation.
+
+Default limit: {size, e.g., 1MB} unless a specific endpoint requires a higher limit with justification.
+
+### CSRF Protection
+
+State-changing endpoints (POST, PUT, PATCH, DELETE) MUST implement CSRF protection. Strategy: {e.g., SameSite=Lax cookies, CSRF tokens, custom header validation}.
+
+### Redirect Validation
+
+Any endpoint that performs HTTP redirects with user-supplied URLs MUST validate the redirect target against an allowlist of permitted domains or paths. Open redirects MUST NOT be permitted.
+```
+
+## Auth-by-Default in Endpoint Tables
+
+<!-- Governing: ADR-0018 (Security-by-Default), SPEC-0016 REQ "Auth-by-Default" -->
+
+When a web-facing spec includes an endpoint table or endpoint list, you MUST apply auth-by-default:
+
+1. Every endpoint defaults to **"Auth: Required"**
+2. If the spec author identifies endpoints that should be public, mark them as **"Auth: Public"** and require a justification
+3. Justifications MUST be specific (e.g., "Health check — load balancer requires unauthenticated access"), not generic (e.g., "public endpoint")
+
+Example endpoint table with auth-by-default:
+
+```markdown
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | /api/items | Required | List items |
+| POST | /api/items | Required | Create item |
+| GET | /health | Public | Health check — required for load balancer probes |
+| GET | /login | Public | Login page — must be accessible to unauthenticated users |
+```
+
 ## spec.md Template
 
 ```markdown
@@ -89,6 +180,8 @@ Follow the standard team handoff protocol from the plugin's `references/shared-p
 - **WHEN** {precondition or trigger}
 - **THEN** {expected outcome}
 ```
+
+**Note:** For web-facing specs, append the Security Requirements section (from the template above) after the functional requirements.
 
 ## design.md Template
 
@@ -161,6 +254,11 @@ Follow the standard team handoff protocol from the plugin's `references/shared-p
   - Scenario format correctness (exactly `####` level headings with WHEN/THEN)
   - Completeness of both documents
   - Alignment between spec requirements and design decisions
+  - **Security section present for web-facing specs** (Governing: ADR-0018, SPEC-0016)
+  - **Auth-by-default applied to all endpoint tables** (Governing: ADR-0018, SPEC-0016)
 - If converting from an ADR, reference the ADR number in the spec's Overview section
 - design.md MUST include at least one Mermaid architecture diagram. Prefer C4 context/container diagrams for system-level, sequence diagrams for flows, and ERDs for data models.
 - When implementing code governed by this spec, agents SHOULD leave governing comments referencing the spec and requirement numbers: `// Governing: SPEC-XXXX REQ "Requirement Name", ADR-XXXX`
+- For web-facing specs: MUST inject the Security Requirements section covering authentication, rate limiting, security headers, body size limits, CSRF protection, and redirect validation (Governing: ADR-0018, SPEC-0016 REQ "Mandatory Security Section in Web Specs")
+- For web-facing specs: MUST apply auth-by-default — every endpoint defaults to "Auth: Required"; public endpoints need "Auth: Public" with explicit justification (Governing: ADR-0018, SPEC-0016 REQ "Auth-by-Default")
+- MUST NOT inject the Security Requirements section for non-web specs (CLI tools, libraries, batch jobs, data migrations, background workers)


### PR DESCRIPTION
## Summary
- **`/design:spec`**: Adds web-facing detection logic and injects a mandatory "Security Requirements" section covering authentication (auth-by-default), rate limiting, security headers, request body size limits, CSRF protection, and redirect validation. Non-web specs (CLI tools, libraries, batch jobs) are unaffected.
- **`/design:plan`**: Adds a security checklist (`## Security Checklist`) to issue bodies for stories that involve HTTP endpoints, covering authentication middleware, input validation, output encoding, rate limiting, and body size limits. Non-HTTP stories are unaffected.
- Auth-by-default: All endpoint tables default every endpoint to "Auth: Required"; public endpoints must be marked "Auth: Public" with explicit justification.

Closes #50
Part of #41
Implements SPEC-0016

## Test plan
- [ ] Run `/design:spec` for a web-facing capability (e.g., REST API) and verify the Security Requirements section is injected with all six topics
- [ ] Run `/design:spec` for a non-web capability (e.g., CLI tool) and verify no Security Requirements section is injected
- [ ] Verify endpoint tables in web specs default to "Auth: Required" with public endpoints requiring justification
- [ ] Run `/design:plan` on a web-facing spec and verify HTTP endpoint stories include the Security Checklist section
- [ ] Run `/design:plan` on a non-HTTP story and verify no Security Checklist is added
- [ ] Verify the security checklist appears after Acceptance Criteria and before Branch/PR Convention sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)