### PR TITLE
Artifact Path Resolution and Module Scoping

### DIFF
--- a/references/shared-patterns.md
+++ b/references/shared-patterns.md
@@ -4,13 +4,81 @@
 
 Patterns used across multiple design plugin skills. Skills reference specific sections by heading instead of duplicating the content.
 
+## Artifact Path Resolution
+
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+Canonical algorithm for resolving the paths to ADR and spec directories. All skills that access ADRs or specs MUST use this pattern instead of hardcoding `docs/adrs/` or `docs/openspec/specs/`.
+
+### Step 1: Determine the Module Root
+
+- If a `--module <name>` flag is provided, locate the module root. Read the project-root `CLAUDE.md` for a `### Modules` section listing module names and their root directories. If the module name is not found, error: "Unknown module `{name}`. Available modules: {list of names from CLAUDE.md}."
+- If `--module` is NOT provided and the project has a `### Modules` section in the root `CLAUDE.md`, the skill is operating in **aggregate mode** — it should iterate over all modules (and the project root, if it has its own artifacts).
+- If no `### Modules` section exists, the project is a **single-module project** — the module root is the project root.
+
+### Step 2: Read Artifact Location Declarations
+
+Read the module's `CLAUDE.md` (or the root `CLAUDE.md` for single-module projects) and look for artifact location declarations in the `## Architecture Context` section:
+
+- `- Architecture Decision Records are in {path}` → use `{path}` as the ADR directory
+- `- Specifications are in {path}` → use `{path}` as the spec directory
+
+Paths are relative to the module root (or project root for single-module projects).
+
+### Step 3: Apply Defaults
+
+If the `CLAUDE.md` does not declare a path for ADRs or specs, fall back to these defaults:
+
+- **ADR directory**: `docs/adrs/`
+- **Spec directory**: `docs/openspec/specs/`
+
+### Step 4: Resolve Absolute Paths
+
+Resolve the artifact paths relative to the module root:
+
+- Single-module or `--module` provided: `{module-root}/{artifact-path}`
+- Aggregate mode (no `--module`, workspace with modules): resolve paths per-module and combine results
+
+### CLAUDE.md Modules Section Format
+
+Projects that use workspace mode declare modules in the root `CLAUDE.md`:
+
+```markdown
+### Modules
+
+| Module | Root | Description |
+|--------|------|-------------|
+| api | services/api | REST API service |
+| web | services/web | Web frontend |
+| shared | packages/shared | Shared library |
+```
+
+Each module MAY have its own `CLAUDE.md` at its root with an `## Architecture Context` section declaring module-specific artifact paths. Module-level paths override root-level defaults.
+
+### Examples
+
+**Single-module project** (no `### Modules` section):
+- ADR path: `docs/adrs/` (from CLAUDE.md or default)
+- Spec path: `docs/openspec/specs/` (from CLAUDE.md or default)
+
+**Workspace with `--module api`**:
+- Module root: `services/api/` (from `### Modules` table)
+- Read `services/api/CLAUDE.md` for declarations
+- ADR path: `services/api/docs/adrs/` (or module-declared path)
+- Spec path: `services/api/docs/openspec/specs/` (or module-declared path)
+
+**Workspace aggregate mode** (no `--module`):
+- Iterate each module from `### Modules` table
+- Resolve paths per-module
+- Combine all ADRs and specs across modules, prefixing output with module name for disambiguation
+
 ## Spec Resolution
 
-Resolve a spec identifier to a file path:
+Resolve a spec identifier to a file path. Use the resolved spec directory from the **Artifact Path Resolution** pattern above (referred to as `{spec-dir}` below).
 
-- If a SPEC number is provided (e.g., `SPEC-0003`), find the matching spec directory by scanning `docs/openspec/specs/*/spec.md` for the SPEC number in the title.
-- If a capability directory name is provided (e.g., `web-dashboard`), look for `docs/openspec/specs/{name}/spec.md`.
-- If no spec identifier is provided (ignoring flags), list available specs by globbing `docs/openspec/specs/*/spec.md`, read the title from each, and use `AskUserQuestion` to ask which spec to use.
+- If a SPEC number is provided (e.g., `SPEC-0003`), find the matching spec directory by scanning `{spec-dir}/*/spec.md` for the SPEC number in the title.
+- If a capability directory name is provided (e.g., `web-dashboard`), look for `{spec-dir}/{name}/spec.md`.
+- If no spec identifier is provided (ignoring flags), list available specs by globbing `{spec-dir}/*/spec.md`, read the title from each, and use `AskUserQuestion` to ask which spec to use.
 - If the spec doesn't exist, tell the user and suggest `/design:spec` to create one.
 
 ## Config Resolution

--- a/skills/adr/SKILL.md
+++ b/skills/adr/SKILL.md
@@ -2,7 +2,7 @@
 name: adr
 description: Create a new Architecture Decision Record (ADR) using MADR format. Use when the user wants to document an architectural decision, says "create an ADR", "we need an ADR for", or discusses a decision that should be recorded.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, WebFetch, WebSearch, TeamCreate, TeamDelete, TaskCreate, TaskUpdate, TaskList, TaskGet, SendMessage, AskUserQuestion
-argument-hint: [short description of the decision] [--review]
+argument-hint: [short description of the decision] [--review] [--module <name>]
 ---
 
 # Create an Architecture Decision Record (ADR)
@@ -11,7 +11,11 @@ You are creating a new ADR using the MADR (Markdown Architectural Decision Recor
 
 ## Process
 
-1. **Determine the next ADR number**: Scan `docs/adrs/` for existing `ADR-XXXX-*.md` files and increment to the next number. Start at ADR-0001 if none exist. Create `docs/adrs/` if it does not exist. If `$ARGUMENTS` is empty (ignoring flags like `--review`), use `AskUserQuestion` to ask the user what decision they want to document.
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+0. **Resolve artifact paths**: Follow the **Artifact Path Resolution** pattern from `references/shared-patterns.md` to determine the ADR directory. If `$ARGUMENTS` contains `--module <name>`, resolve paths relative to that module. The resolved ADR directory is referred to as `{adr-dir}` below.
+
+1. **Determine the next ADR number**: Scan `{adr-dir}` for existing `ADR-XXXX-*.md` files and increment to the next number. Start at ADR-0001 if none exist. Create `{adr-dir}` if it does not exist. If `$ARGUMENTS` is empty (ignoring flags like `--review` and `--module`), use `AskUserQuestion` to ask the user what decision they want to document.
 
 2. **Choose drafting mode**: Check if `$ARGUMENTS` contains `--review`.
 
@@ -26,7 +30,7 @@ You are creating a new ADR using the MADR (Markdown Architectural Decision Recor
      - The drafter should research the codebase (read relevant files, understand the current architecture) before writing
      - If `TeamCreate` fails, fall back to single-agent mode: draft the ADR directly, then self-review against the architect's checklist in the Rules section before writing.
 
-3. **Write the ADR** to `docs/adrs/ADR-XXXX-short-title.md`
+3. **Write the ADR** to `{adr-dir}/ADR-XXXX-short-title.md`
 
 4. **Clean up** the team when done (if `--review` was used).
 
@@ -36,11 +40,11 @@ You are creating a new ADR using the MADR (Markdown Architectural Decision Recor
    - "To formalize requirements from this decision, run: `/design:spec {suggested capability name}`"
    - "The spec skill can also break requirements into trackable issues (Beads, GitHub, or Gitea) for sprint planning."
 
-7. **CLAUDE.md integration**: Check if this is the first ADR (i.e., `docs/adrs/` was just created or contains only this new file). If so:
-   - Check if a `CLAUDE.md` exists in the project root
-   - If it exists, check if it already references `docs/adrs/`
+7. **CLAUDE.md integration**: Check if this is the first ADR (i.e., `{adr-dir}` was just created or contains only this new file). If so:
+   - Check if a `CLAUDE.md` exists at the module root (or project root for single-module projects)
+   - If it exists, check if it already references the ADR directory
    - If no reference exists, ask the user: "I can add an Architecture Context section to your CLAUDE.md so future sessions know about your decisions. Shall I?"
-   - If the user says yes, append an `## Architecture Context` section with `- Architecture Decision Records are in docs/adrs/`
+   - If the user says yes, append an `## Architecture Context` section with `- Architecture Decision Records are in {adr-dir}`
    - If `CLAUDE.md` doesn't exist, suggest creating one
 
 ### Team Handoff Protocol (only for `--review` mode)

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -2,7 +2,7 @@
 name: audit
 description: Comprehensive audit of design artifact alignment across the project. Use when the user says "audit the architecture", "full drift report", or wants a thorough review of spec compliance and ADR adherence.
 allowed-tools: Read, Glob, Grep, Task, TeamCreate, TeamDelete, TaskCreate, TaskUpdate, TaskList, TaskGet, SendMessage, AskUserQuestion
-argument-hint: [scope] [--review] [--scrum]
+argument-hint: [scope] [--review] [--scrum] [--module <name>]
 ---
 
 # Comprehensive Design Audit
@@ -11,14 +11,18 @@ You are performing a deep, comprehensive audit of design artifact alignment acro
 
 ## Process
 
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+0. **Resolve artifact paths**: Follow the **Artifact Path Resolution** pattern from `references/shared-patterns.md` to determine the ADR and spec directories. If `$ARGUMENTS` contains `--module <name>`, resolve paths relative to that module; otherwise, in a workspace, aggregate across all modules. The resolved ADR directory is `{adr-dir}` and spec directory is `{spec-dir}`.
+
 1. **Parse arguments**: Extract the scope and flags from `$ARGUMENTS`.
    - Scope can be a topic keyword (`security`, `api`, `database`), a directory path (`src/`), or omitted for a full project audit.
    - Check for the `--review` flag.
    - If scope matches nothing, report: "No design artifacts or source files matched the scope \"{scope}\". Try a broader scope, or run `/design:audit` without a scope for a full project audit."
 
 2. **Locate design artifacts**:
-   - Scan `docs/adrs/` for ADR files. If the directory does not exist, report: "The docs/adrs/ directory does not exist. Run `/design:adr [description]` to create your first ADR."
-   - Scan `docs/openspec/specs/` for spec files. If the directory does not exist, report: "The docs/openspec/specs/ directory does not exist. Run `/design:spec [capability]` to create your first spec."
+   - Scan `{adr-dir}` for ADR files. If the directory does not exist, report: "The `{adr-dir}` directory does not exist. Run `/design:adr [description]` to create your first ADR."
+   - Scan `{spec-dir}` for spec files. If the directory does not exist, report: "The `{spec-dir}` directory does not exist. Run `/design:spec [capability]` to create your first spec."
    - If neither ADRs nor specs exist, report: "No design artifacts found. Create an ADR with `/design:adr` or a spec with `/design:spec` first."
    - It is valid for only ADRs or only specs to exist -- proceed with whatever is available and note which categories cannot be checked.
 
@@ -38,7 +42,7 @@ You are performing a deep, comprehensive audit of design artifact alignment acro
 
    **With `--scrum`**: Scrum triage mode — see the **Scrum Triage Ceremony** section below. When `--scrum` is set, complete the standard audit analysis (steps 4–6) first, then enter the ceremony. Do NOT run `--review` mode when `--scrum` is set.
 
-4. **Validate spec artifact pairing**: For each spec directory found under `docs/openspec/specs/`, check that both `spec.md` and `design.md` exist. If a `spec.md` exists without a corresponding `design.md` (or vice versa), report as `[WARNING]` under "Stale Artifacts" with finding: "Unpaired spec artifact: {path} exists but {missing-file} is missing. Per ADR-0003, spec.md and design.md are a paired unit." (Governing: ADR-0003, SPEC-0003)
+4. **Validate spec artifact pairing**: For each spec directory found under `{spec-dir}`, check that both `spec.md` and `design.md` exist. If a `spec.md` exists without a corresponding `design.md` (or vice versa), report as `[WARNING]` under "Stale Artifacts" with finding: "Unpaired spec artifact: {path} exists but {missing-file} is missing. Per ADR-0003, spec.md and design.md are a paired unit." (Governing: ADR-0003, SPEC-0003)
 
 5. **Analyze across all six categories**:
 
@@ -120,7 +124,7 @@ You are performing a deep, comprehensive audit of design artifact alignment acro
 
    | Severity | Finding | Source | Location |
    |----------|---------|--------|----------|
-   | [INFO] | {description} | SPEC-XXXX | docs/openspec/specs/path/spec.md |
+   | [INFO] | {description} | SPEC-XXXX | {spec-dir}/path/spec.md |
 
    ---
 

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -2,7 +2,7 @@
 name: check
 description: Quick-check code against ADRs and specs for drift. Use when the user says "check for drift", "does this match the spec", or wants a fast alignment check on a specific file or directory.
 allowed-tools: Read, Glob, Grep
-argument-hint: [target]
+argument-hint: [target] [--module <name>]
 ---
 
 # Quick Drift Check
@@ -10,6 +10,10 @@ argument-hint: [target]
 You are performing a fast, focused drift check on a specific target. This skill detects whether code aligns with its governing ADRs and specs.
 
 ## Process
+
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+0. **Resolve artifact paths**: Follow the **Artifact Path Resolution** pattern from `references/shared-patterns.md` to determine the ADR and spec directories. If `$ARGUMENTS` contains `--module <name>`, resolve paths relative to that module; otherwise, in a workspace, aggregate across all modules. The resolved ADR directory is `{adr-dir}` and spec directory is `{spec-dir}`.
 
 1. **Parse the target**: Extract the target from `$ARGUMENTS`.
    - A file path: `src/auth/login.ts`
@@ -20,12 +24,12 @@ You are performing a fast, focused drift check on a specific target. This skill 
 
 2. **Validate the target exists**:
    - For file/directory targets: verify the path exists. If not, report: "Target not found: `{target}`. Provide a valid file path, directory, ADR reference (ADR-XXXX), or SPEC reference (SPEC-XXXX)."
-   - For ADR references: glob `docs/adrs/ADR-{number}-*.md`. If not found, report: "ADR-{XXXX} not found in docs/adrs/. Run `/design:list adr` to see available ADRs."
-   - For SPEC references: glob `docs/openspec/specs/*/spec.md` and search for the matching SPEC number. If not found, report: "SPEC-{XXXX} not found in docs/openspec/specs/. Run `/design:list spec` to see available specs."
+   - For ADR references: glob `{adr-dir}/ADR-{number}-*.md`. If not found, report: "ADR-{XXXX} not found in `{adr-dir}`. Run `/design:list adr` to see available ADRs."
+   - For SPEC references: glob `{spec-dir}/*/spec.md` and search for the matching SPEC number. If not found, report: "SPEC-{XXXX} not found in `{spec-dir}`. Run `/design:list spec` to see available specs."
 
 3. **Locate design artifacts**:
-   - Scan `docs/adrs/` for ADR files. If the directory does not exist, report: "The docs/adrs/ directory does not exist. Run `/design:adr [description]` to create your first ADR."
-   - Scan `docs/openspec/specs/` for spec files. If the directory does not exist, report: "The docs/openspec/specs/ directory does not exist. Run `/design:spec [capability]` to create your first spec."
+   - Scan `{adr-dir}` for ADR files. If the directory does not exist, report: "The `{adr-dir}` directory does not exist. Run `/design:adr [description]` to create your first ADR."
+   - Scan `{spec-dir}` for spec files. If the directory does not exist, report: "The `{spec-dir}` directory does not exist. Run `/design:spec [capability]` to create your first spec."
    - If neither ADRs nor specs exist, report: "No design artifacts found. Create an ADR with `/design:adr` or a spec with `/design:spec` first."
    - It is valid for only ADRs or only specs to exist -- proceed with whatever is available.
 
@@ -34,7 +38,7 @@ You are performing a fast, focused drift check on a specific target. This skill 
    - If the target is an ADR: read the ADR, find related specs and code files that should implement the decision.
    - If the target is a SPEC: read the spec, find related ADRs and code files that should implement the requirements.
 
-5. **Validate spec artifact pairing**: For each spec directory found under `docs/openspec/specs/`, check that both `spec.md` and `design.md` exist. If a `spec.md` exists without a corresponding `design.md` (or vice versa), report as `[WARNING]` under "Code vs. Spec" with finding: "Unpaired spec artifact: {path} exists but {missing-file} is missing. Per ADR-0003, spec.md and design.md are a paired unit." (Governing: ADR-0003, SPEC-0003)
+5. **Validate spec artifact pairing**: For each spec directory found under `{spec-dir}`, check that both `spec.md` and `design.md` exist. If a `spec.md` exists without a corresponding `design.md` (or vice versa), report as `[WARNING]` under "Code vs. Spec" with finding: "Unpaired spec artifact: {path} exists but {missing-file} is missing. Per ADR-0003, spec.md and design.md are a paired unit." (Governing: ADR-0003, SPEC-0003)
 
 6. **Analyze for drift** across three categories:
 

--- a/skills/discover/SKILL.md
+++ b/skills/discover/SKILL.md
@@ -2,7 +2,7 @@
 name: discover
 description: Discover implicit architectural decisions and spec-worthy subsystems in an existing codebase. Use when the user says "discover architecture", "what decisions exist in this code", "bootstrap ADRs", or wants to reverse-engineer design artifacts from code.
 allowed-tools: Read, Glob, Grep, Task, AskUserQuestion
-argument-hint: [scope]
+argument-hint: [scope] [--module <name>]
 ---
 
 # Discover Implicit Architecture
@@ -11,17 +11,21 @@ Explore an existing codebase to discover implicit architectural decisions and sp
 
 ## Process
 
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+0. **Resolve artifact paths**: Follow the **Artifact Path Resolution** pattern from `references/shared-patterns.md` to determine the ADR and spec directories. If `$ARGUMENTS` contains `--module <name>`, resolve paths relative to that module; otherwise, in a workspace, aggregate across all modules. The resolved ADR directory is `{adr-dir}` and spec directory is `{spec-dir}`.
+
 1. **Parse the scope**: Extract the optional scope from `$ARGUMENTS`.
    - A directory path: `src/auth/` -- limit analysis to that subtree
    - A domain keyword: `auth`, `api`, `data` -- limit by semantic relevance
-   - If `$ARGUMENTS` is empty, analyze the entire project
+   - If `$ARGUMENTS` is empty, analyze the entire project (or module if `--module` is set)
 
 2. **Validate the scope** (if provided):
    - For directory paths: verify the path exists. If not, report: "Scope not found: `{scope}`. Provide a valid directory path or omit the scope to analyze the entire project."
 
 3. **Load existing design artifacts**:
-   - Glob `docs/adrs/ADR-*.md` and read each file's title, context, and decision outcome
-   - Glob `docs/openspec/specs/*/spec.md` and read each file's title and overview
+   - Glob `{adr-dir}/ADR-*.md` and read each file's title, context, and decision outcome
+   - Glob `{spec-dir}/*/spec.md` and read each file's title and overview
    - Build an exclusion list of already-documented decisions and subsystems
    - If neither directory exists, note that no existing artifacts were found (this is expected for first-time discovery)
 

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -2,13 +2,13 @@
 name: docs
 description: Generate a documentation site from your ADRs and specs. Use when the user says "generate docs", "create a docs site", or wants to publish their architecture decisions.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, AskUserQuestion
-argument-hint: [project name or options]
+argument-hint: [project name or options] [--module <name>]
 context: fork
 ---
 
 # Generate Docusaurus Documentation Site
 
-Transform ADRs from `docs/adrs/` and OpenSpec specs from `docs/openspec/specs/` into a polished documentation website with:
+Transform ADRs and OpenSpec specs (located via the **Artifact Path Resolution** pattern from `references/shared-patterns.md`) into a polished documentation website with:
 
 - RFC 2119 keyword highlighting (MUST, SHALL, MAY, etc.)
 - ADR cross-reference linking (ADR-0001 becomes a clickable link)
@@ -25,11 +25,17 @@ Supports two modes:
 
 ## Process
 
+### Step 0: Resolve Artifact Paths
+
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+Follow the **Artifact Path Resolution** pattern from `references/shared-patterns.md` to determine the ADR and spec directories. If `$ARGUMENTS` contains `--module <name>`, resolve paths relative to that module; otherwise, in a workspace, aggregate across all modules. The resolved ADR directory is `{adr-dir}` and spec directory is `{spec-dir}`.
+
 ### Step 1: Pre-flight Checks
 
 - Check if Node.js is installed. If not, tell the user: "Node.js is required to run the docs site. Please install it from https://nodejs.org/ and re-run this command." and stop.
-- Check if `docs/adrs/` has any ADR `.md` files
-- Check if `docs/openspec/specs/` has any spec directories (containing `spec.md`)
+- Check if `{adr-dir}` has any ADR `.md` files
+- Check if `{spec-dir}` has any spec directories (containing `spec.md`)
 - If NEITHER has content, tell the user: "No ADRs or specs found. Create some first with `/design:adr` or `/design:spec`, then re-run `/design:docs`." and stop.
 - If only one has content, proceed but note which is empty (e.g., "No specs found yet -- the docs site will only include ADRs for now.")
 

--- a/skills/enrich/SKILL.md
+++ b/skills/enrich/SKILL.md
@@ -2,7 +2,7 @@
 name: enrich
 description: Retroactively add branch naming and PR convention sections to existing issue bodies. Use when the user says "add branch names to issues", "enrich issues", or wants to add developer workflow conventions to existing issues.
 allowed-tools: Read, Glob, Grep, Bash, Write, Edit, ToolSearch, AskUserQuestion
-argument-hint: [SPEC-XXXX or spec-name] [--branch-prefix <prefix>] [--dry-run]
+argument-hint: [SPEC-XXXX or spec-name] [--branch-prefix <prefix>] [--dry-run] [--module <name>]
 ---
 
 <!-- Governing: ADR-0015 (Markdown-Native Configuration), SPEC-0014 REQ "Config Resolution Pattern" -->
@@ -13,16 +13,20 @@ You are retroactively adding `### Branch` and `### PR Convention` sections to ex
 
 ## Process
 
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+0. **Resolve artifact paths**: Follow the **Artifact Path Resolution** pattern from `references/shared-patterns.md` to determine the spec directory. If `$ARGUMENTS` contains `--module <name>`, resolve paths relative to that module. The resolved spec directory is `{spec-dir}`.
+
 1. **Parse arguments**: Extract from `$ARGUMENTS`:
    - Spec identifier: a SPEC number (e.g., `SPEC-0007`) or capability directory name
    - `--branch-prefix <prefix>`: Custom branch prefix instead of the default `feature`/`epic` prefixes
    - `--dry-run`: Preview what would be added without modifying any issues
 
-   If no spec identifier is provided, list available specs by globbing `docs/openspec/specs/*/spec.md`, read the title from each, and use `AskUserQuestion` to ask which spec to enrich.
+   If no spec identifier is provided, list available specs by globbing `{spec-dir}/*/spec.md`, read the title from each, and use `AskUserQuestion` to ask which spec to enrich.
 
-2. **Resolve spec**: Follow the plugin's `references/shared-patterns.md` § "Spec Resolution".
+2. **Resolve spec**: Follow the plugin's `references/shared-patterns.md` § "Spec Resolution" (which uses `{spec-dir}` from the Artifact Path Resolution pattern).
 
-3. **Read spec**: Read `docs/openspec/specs/{capability-name}/spec.md` to get the spec number and understand the requirements.
+3. **Read spec**: Read `{spec-dir}/{capability-name}/spec.md` to get the spec number and understand the requirements.
 
 4. **Detect tracker**: Follow the "Tracker Detection" flow in the plugin's `references/shared-patterns.md`. If no tracker is found, error — enrichment requires a tracker.
 

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -2,7 +2,7 @@
 name: init
 description: Set up CLAUDE.md with design plugin references for architecture-aware sessions. Use when the user installs the plugin, says "initialize design", or wants to configure CLAUDE.md for the design plugin.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion
-argument-hint:
+argument-hint: [--module <name>]
 ---
 
 <!-- Governing: ADR-0015 (Markdown-Native Configuration), SPEC-0014 REQ "Migration from JSON to CLAUDE.md" -->
@@ -12,6 +12,10 @@ argument-hint:
 Set up the project's `CLAUDE.md` with architecture context so Claude sessions are design-aware.
 
 ## Process
+
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+**Module support**: If `$ARGUMENTS` contains `--module <name>`, resolve the module root by reading the `### Modules` section from the project-root `CLAUDE.md`. All CLAUDE.md reads and writes in the steps below target the module's `CLAUDE.md` at the module root instead of the project root. If the project has no `### Modules` section and `--module` is provided, error: "No modules defined in CLAUDE.md. Run `/design:init` without `--module` first, then add a `### Modules` section."
 
 0. **Check for `.claude-plugin-design.json` migration** (Governing: SPEC-0014 REQ "Migration from JSON to CLAUDE.md"):
 

--- a/skills/list/SKILL.md
+++ b/skills/list/SKILL.md
@@ -2,7 +2,7 @@
 name: list
 description: List all architecture decisions and specs with their status. Use when the user asks "what decisions have we made", "list ADRs", "show specs", or wants an overview.
 allowed-tools: Read, Glob, Grep
-argument-hint: [filter: adr|spec|all]
+argument-hint: [filter: adr|spec|all] [--module <name>]
 disable-model-invocation: true
 ---
 
@@ -12,19 +12,23 @@ List all ADRs and specs in the project with their status, date, and title.
 
 ## Process
 
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+0. **Resolve artifact paths**: Follow the **Artifact Path Resolution** pattern from `references/shared-patterns.md` to determine the ADR and spec directories. If `$ARGUMENTS` contains `--module <name>`, resolve paths relative to that module; otherwise, in a workspace, aggregate across all modules. The resolved ADR directory is `{adr-dir}` and spec directory is `{spec-dir}`.
+
 1. **Parse filter**: Check `$ARGUMENTS` for a filter keyword:
    - `adr` -- only show ADRs
    - `spec` -- only show specs
    - `all` or empty -- show both (default)
 
 2. **Scan for ADRs** (unless filter is `spec`):
-   - Glob for `docs/adrs/ADR-*.md` files
+   - Glob for `{adr-dir}/ADR-*.md` files (in aggregate mode, glob per-module and prefix results with module name)
    - For each file, read the YAML frontmatter to extract `status` and `date`
    - Extract the title from the first `# ` heading
    - Sort by ADR number
 
 3. **Scan for specs** (unless filter is `adr`):
-   - Glob for `docs/openspec/specs/*/spec.md` files
+   - Glob for `{spec-dir}/*/spec.md` files (in aggregate mode, glob per-module and prefix results with module name)
    - For each file, read the YAML frontmatter to extract `status` and `date`
    - Extract the title from the first `# ` heading (e.g., `SPEC-0001: Web Dashboard`)
    - Sort by SPEC number

--- a/skills/organize/SKILL.md
+++ b/skills/organize/SKILL.md
@@ -2,7 +2,7 @@
 name: organize
 description: Retroactively group existing issues into tracker-native projects. Use when the user says "organize issues", "group issues into projects", or wants to create project boards for existing sprint issues.
 allowed-tools: Read, Glob, Grep, Bash, Write, Edit, ToolSearch, AskUserQuestion
-argument-hint: [SPEC-XXXX or spec-name] [--project <name>] [--dry-run]
+argument-hint: [SPEC-XXXX or spec-name] [--project <name>] [--dry-run] [--module <name>]
 ---
 
 <!-- Governing: ADR-0015 (Markdown-Native Configuration), SPEC-0014 REQ "Config Resolution Pattern" -->
@@ -13,16 +13,20 @@ You are retroactively grouping existing tracker issues into tracker-native proje
 
 ## Process
 
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+0. **Resolve artifact paths**: Follow the **Artifact Path Resolution** pattern from `references/shared-patterns.md` to determine the spec directory. If `$ARGUMENTS` contains `--module <name>`, resolve paths relative to that module. The resolved spec directory is `{spec-dir}`.
+
 1. **Parse arguments**: Extract from `$ARGUMENTS`:
    - Spec identifier: a SPEC number (e.g., `SPEC-0007`) or capability directory name
    - `--project <name>`: Use a single combined project with this name for all issues
    - `--dry-run`: Preview what would be created without making changes
 
-   If no spec identifier is provided, list available specs by globbing `docs/openspec/specs/*/spec.md`, read the title from each, and use `AskUserQuestion` to ask which spec to organize.
+   If no spec identifier is provided, list available specs by globbing `{spec-dir}/*/spec.md`, read the title from each, and use `AskUserQuestion` to ask which spec to organize.
 
-2. **Resolve spec**: Follow the plugin's `references/shared-patterns.md` § "Spec Resolution".
+2. **Resolve spec**: Follow the plugin's `references/shared-patterns.md` § "Spec Resolution" (which uses `{spec-dir}` from the Artifact Path Resolution pattern).
 
-3. **Read spec**: Read `docs/openspec/specs/{capability-name}/spec.md` and `design.md` to understand the spec number, requirement names, and architecture.
+3. **Read spec**: Read `{spec-dir}/{capability-name}/spec.md` and `design.md` to understand the spec number, requirement names, and architecture.
 
 4. **Detect tracker**: Follow the "Config Resolution" and "Tracker Detection" flows in the plugin's `references/shared-patterns.md`. Also read `Projects` settings from the `### Design Plugin Configuration` section in CLAUDE.md for cached project IDs and enrichment config (Views, Columns, Iteration Weeks). If no tracker is found, error — projects require a tracker.
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -4,7 +4,7 @@
 name: plan
 description: Break an existing spec into trackable issues in your issue tracker. Use when the user says "plan a sprint", "create issues from spec", "break down the spec", or wants to turn requirements into tasks.
 allowed-tools: Read, Glob, Grep, Bash, Write, Edit, Task, AskUserQuestion, TeamCreate, TeamDelete, TaskCreate, TaskUpdate, TaskList, TaskGet, SendMessage, ToolSearch
-argument-hint: [spec-name or SPEC-XXXX] [--review] [--scrum] [--project <name>] [--no-projects] [--branch-prefix <prefix>] [--no-branches]
+argument-hint: [spec-name or SPEC-XXXX] [--review] [--scrum] [--project <name>] [--no-projects] [--branch-prefix <prefix>] [--no-branches] [--module <name>]
 ---
 
 <!-- Governing: ADR-0015 (Markdown-Native Configuration), SPEC-0014 REQ "Config Resolution Pattern" -->
@@ -15,9 +15,13 @@ You are breaking down an existing specification into trackable work items (epics
 
 ## Process
 
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+0. **Resolve artifact paths**: Follow the **Artifact Path Resolution** pattern from `references/shared-patterns.md` to determine the ADR and spec directories. If `$ARGUMENTS` contains `--module <name>`, resolve paths relative to that module. The resolved ADR directory is `{adr-dir}` and spec directory is `{spec-dir}`.
+
 1. **Identify the target spec and parse flags**: Parse `$ARGUMENTS`.
 
-   **Spec resolution:** Follow the standard flow in the plugin's `references/shared-patterns.md` § "Spec Resolution".
+   **Spec resolution:** Follow the standard flow in the plugin's `references/shared-patterns.md` § "Spec Resolution" (which uses `{spec-dir}` from the Artifact Path Resolution pattern).
 
    **Flag parsing:**
    - `--scrum`: Enable scrum ceremony mode (see Scrum Mode section below). When set, the skill runs a full team-groomed planning ceremony: spec completeness audit → issue decomposition → multi-agent grooming → organize → enrich → sprint report. Mutually exclusive with `--review`; if both are set, `--scrum` takes precedence.
@@ -26,12 +30,13 @@ You are breaking down an existing specification into trackable work items (epics
    - `--no-projects`: Skip project creation entirely. Mutually exclusive with `--project`.
    - `--branch-prefix <prefix>`: Custom branch prefix instead of the default `feature`/`epic` prefixes.
    - `--no-branches`: Omit `### Branch` and `### PR Convention` sections from issue bodies.
+   - `--module <name>`: Resolve artifact paths relative to the named module (see step 0).
 
    If both `--project` and `--no-projects` are provided, warn the user and use `--no-projects`.
 
    **If `--scrum` is set, skip to the Scrum Mode section after completing step 1. Do not proceed through steps 2–8 in sequence — scrum mode orchestrates them internally.**
 
-2. **Read the spec**: Read both `docs/openspec/specs/{capability-name}/spec.md` and `docs/openspec/specs/{capability-name}/design.md` to understand the full scope of requirements, scenarios, and architecture.
+2. **Read the spec**: Read both `{spec-dir}/{capability-name}/spec.md` and `{spec-dir}/{capability-name}/design.md` to understand the full scope of requirements, scenarios, and architecture.
 
 3. **Choose drafting mode**: Check if `$ARGUMENTS` contains `--review`.
 
@@ -63,9 +68,9 @@ Tell the user: "Starting scrum ceremony. This will audit spec completeness, deco
 
 Before spawning the grooming team, audit every spec referenced by any in-scope issue:
 
-1. For each referenced spec, check if `docs/openspec/specs/{name}/design.md` exists alongside `spec.md`.
+1. For each referenced spec, check if `{spec-dir}/{name}/design.md` exists alongside `spec.md`.
 2. If `design.md` is **missing**, generate a draft `design.md` co-located with `spec.md`. Use the design.md template from `/design:spec`. Set frontmatter `status: draft`. Log: "Generated draft design.md for {spec-name}."
-3. If a tracker issue has **no backing spec**, generate both `docs/openspec/specs/{issue-slug}/spec.md` and `design.md` as drafts (status: draft), deriving the capability name from the issue title. Log: "Generated draft spec proposal for issue #{n}: {title}."
+3. If a tracker issue has **no backing spec**, generate both `{spec-dir}/{issue-slug}/spec.md` and `design.md` as drafts (status: draft), deriving the capability name from the issue title. Log: "Generated draft spec proposal for issue #{n}: {title}."
 4. After all drafts are generated, report the audit results: pass count, missing design.md count, unspec'd issue count, and file paths of generated drafts.
 
 ### Phase 3: Issue Decomposition
@@ -311,8 +316,8 @@ Ordered for implementation (dependencies respected):
       ```markdown
       # {Capability Title}
       ## Spec
-      - [spec.md](docs/openspec/specs/{name}/spec.md)
-      - [design.md](docs/openspec/specs/{name}/design.md)
+      - [spec.md]({spec-dir}/{name}/spec.md)
+      - [design.md]({spec-dir}/{name}/design.md)
       ## Governing ADRs
       - ADR-XXXX: {title}
       ## Key Files
@@ -338,7 +343,7 @@ Ordered for implementation (dependencies respected):
 
 6. **Fallback: Generate `tasks.md`** (when no tracker is available). Governing: SPEC-0006, ADR-0007.
 
-   Write `docs/openspec/specs/{capability-name}/tasks.md` co-located with spec.md and design.md. MUST NOT generate `tasks.md` when a tracker is available — tasks live in the tracker OR in `tasks.md`, never both.
+   Write `{spec-dir}/{capability-name}/tasks.md` co-located with spec.md and design.md. MUST NOT generate `tasks.md` when a tracker is available — tasks live in the tracker OR in `tasks.md`, never both.
 
    **Template format:**
    ```markdown

--- a/skills/prime/SKILL.md
+++ b/skills/prime/SKILL.md
@@ -2,7 +2,7 @@
 name: prime
 description: Load ADR and spec context into the session for architecture-aware responses. Use when the user says "prime context", "load architecture", starts a new session, or wants Claude to know about existing decisions.
 allowed-tools: Read, Glob, Grep
-argument-hint: [topic]
+argument-hint: [topic] [--module <name>]
 ---
 
 # Prime Architecture Context
@@ -11,7 +11,11 @@ Load existing ADRs and specs into the session so Claude can give architecture-aw
 
 ## Process
 
-1. **Check if init has been run**: Read `CLAUDE.md` at the project root and check if it contains references to `docs/adrs/` or `docs/openspec/specs/`. If CLAUDE.md does not exist or lacks design plugin references, output:
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+0. **Resolve artifact paths**: Follow the **Artifact Path Resolution** pattern from `references/shared-patterns.md` to determine the ADR and spec directories. If `$ARGUMENTS` contains `--module <name>`, resolve paths relative to that module; otherwise, in a workspace, aggregate across all modules. The resolved ADR directory is `{adr-dir}` and spec directory is `{spec-dir}`.
+
+1. **Check if init has been run**: Read `CLAUDE.md` at the project root (or module root if `--module` is set) and check if it contains references to an ADR or spec directory. If CLAUDE.md does not exist or lacks design plugin references, output:
 
    ```
    CLAUDE.md does not have design plugin references. Run `/design:init` first to set up your project, then re-run `/design:prime`.
@@ -19,14 +23,14 @@ Load existing ADRs and specs into the session so Claude can give architecture-aw
 
    Then stop. Do NOT proceed with scanning.
 
-2. **Scan for ADRs**: Glob for `docs/adrs/ADR-*.md` files. For each file:
+2. **Scan for ADRs**: Glob for `{adr-dir}/ADR-*.md` files (in aggregate mode, glob per-module). For each file:
    - Read the YAML frontmatter to extract `status` and `date`
    - Extract the title from the first `# ` heading
    - Read the `## Context and Problem Statement` section
    - Read the `## Decision Outcome` section to extract the key decision
    - Sort by ADR number
 
-3. **Scan for specs**: Glob for `docs/openspec/specs/*/spec.md` files. For each file:
+3. **Scan for specs**: Glob for `{spec-dir}/*/spec.md` files (in aggregate mode, glob per-module). For each file:
    - Read the YAML frontmatter to extract `status`
    - Extract the title from the first `# ` heading (e.g., `SPEC-0001: Web Dashboard`)
    - Read the `## Overview` section
@@ -46,8 +50,8 @@ Load existing ADRs and specs into the session so Claude can give architecture-aw
      ```
 
 5. **Handle edge cases**:
-   - If `docs/adrs/` does not exist: "The docs/adrs/ directory does not exist. Run `/design:adr [description]` to create your first ADR."
-   - If `docs/openspec/specs/` does not exist: "The docs/openspec/specs/ directory does not exist. Run `/design:spec [capability]` to create your first spec."
+   - If `{adr-dir}` does not exist: "The `{adr-dir}` directory does not exist. Run `/design:adr [description]` to create your first ADR."
+   - If `{spec-dir}` does not exist: "The `{spec-dir}` directory does not exist. Run `/design:spec [capability]` to create your first spec."
    - If neither directory has any artifacts: "No design artifacts found. Create an ADR with `/design:adr` or a spec with `/design:spec` first."
    - If ADRs exist but no specs (or vice versa), present whichever exists and note the other is empty
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -2,7 +2,7 @@
 name: review
 description: Review and merge PRs produced by /design:work using reviewer-responder agent pairs. Use when the user says "review PRs", "review the spec PRs", or wants automated spec-aware code review.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, WebFetch, WebSearch, TeamCreate, TeamDelete, TaskCreate, TaskUpdate, TaskList, TaskGet, SendMessage, AskUserQuestion, ToolSearch
-argument-hint: [SPEC-XXXX or PR numbers] [--pairs N] [--no-merge] [--dry-run]
+argument-hint: [SPEC-XXXX or PR numbers] [--pairs N] [--no-merge] [--dry-run] [--module <name>]
 ---
 
 <!-- Governing: ADR-0015 (Markdown-Native Configuration), SPEC-0014 REQ "Config Resolution Pattern" -->
@@ -13,12 +13,16 @@ You are reviewing PRs produced by `/design:work` using reviewer-responder agent 
 
 ## Process
 
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+0. **Resolve artifact paths**: Follow the **Artifact Path Resolution** pattern from `references/shared-patterns.md` to determine the spec directory. If `$ARGUMENTS` contains `--module <name>`, resolve paths relative to that module. The resolved spec directory is `{spec-dir}`.
+
 1. **Parse arguments**: Parse `$ARGUMENTS`.
 
    **Target resolution:**
    - If a SPEC number is provided (e.g., `SPEC-0003`), find all open PRs whose branch names match the spec's issue branch patterns or whose bodies reference the spec number.
    - If PR numbers are provided (e.g., `101 102 105`), fetch exactly those PRs.
-   - If `$ARGUMENTS` is empty (ignoring flags), list available specs by globbing `docs/openspec/specs/*/spec.md`, read the title from each, and use `AskUserQuestion` to ask which spec's PRs to review.
+   - If `$ARGUMENTS` is empty (ignoring flags), list available specs by globbing `{spec-dir}/*/spec.md`, read the title from each, and use `AskUserQuestion` to ask which spec's PRs to review.
 
    **Flag parsing:**
    - `--pairs N`: Number of reviewer-responder pairs (default 2). Read CLAUDE.md `Review > Max Pairs` as fallback default.

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -2,7 +2,7 @@
 name: spec
 description: Create a specification with requirements, scenarios, and design rationale. Use when the user wants to write a spec, formalize requirements, convert an ADR to a specification, or says "create a spec".
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, WebFetch, WebSearch, TeamCreate, TeamDelete, TaskCreate, TaskUpdate, TaskList, TaskGet, SendMessage, AskUserQuestion
-argument-hint: [capability name or ADR reference] [--review]
+argument-hint: [capability name or ADR reference] [--review] [--module <name>]
 ---
 
 # Create an OpenSpec Specification
@@ -15,11 +15,15 @@ You are creating or updating an OpenSpec specification. Every spec is a **paired
 
 ## Process
 
-1. **Determine the capability name**: Use kebab-case (e.g., `web-dashboard`, `webhook-trigger`). If converting from an ADR, derive from the ADR title. If `$ARGUMENTS` is empty (ignoring flags like `--review`), use `AskUserQuestion` to ask the user what capability they want to specify.
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
 
-2. **Check for existing directory**: If `docs/openspec/specs/{capability-name}/` already exists, use `AskUserQuestion` to ask whether to update the existing spec or choose a different name. If updating: read both the existing `spec.md` and `design.md` before making changes, then update both files maintaining alignment between them.
+0. **Resolve artifact paths**: Follow the **Artifact Path Resolution** pattern from `references/shared-patterns.md` to determine the spec directory. If `$ARGUMENTS` contains `--module <name>`, resolve paths relative to that module. The resolved spec directory is referred to as `{spec-dir}` below.
 
-3. **Determine the next SPEC number**: Scan `docs/openspec/specs/` for existing spec.md files, find the highest SPEC number used, and increment. SPEC numbers are formatted as `SPEC-XXXX` (e.g., SPEC-0001). Start at SPEC-0001 if none exist. **IMPORTANT**: The prefix is `SPEC-`, NOT `RFC-`. Do not confuse spec numbering with RFC 2119 (which is a language standard for requirements keywords).
+1. **Determine the capability name**: Use kebab-case (e.g., `web-dashboard`, `webhook-trigger`). If converting from an ADR, derive from the ADR title. If `$ARGUMENTS` is empty (ignoring flags like `--review` and `--module`), use `AskUserQuestion` to ask the user what capability they want to specify.
+
+2. **Check for existing directory**: If `{spec-dir}/{capability-name}/` already exists, use `AskUserQuestion` to ask whether to update the existing spec or choose a different name. If updating: read both the existing `spec.md` and `design.md` before making changes, then update both files maintaining alignment between them.
+
+3. **Determine the next SPEC number**: Scan `{spec-dir}` for existing spec.md files, find the highest SPEC number used, and increment. SPEC numbers are formatted as `SPEC-XXXX` (e.g., SPEC-0001). Start at SPEC-0001 if none exist. **IMPORTANT**: The prefix is `SPEC-`, NOT `RFC-`. Do not confuse spec numbering with RFC 2119 (which is a language standard for requirements keywords).
 
 4. **Choose drafting mode**: Check if `$ARGUMENTS` contains `--review`.
 
@@ -35,8 +39,8 @@ You are creating or updating an OpenSpec specification. Every spec is a **paired
      - If `TeamCreate` fails, fall back to single-agent mode: draft both files directly, then self-review against the architect's checklist in the Rules section before writing.
 
 5. **Write both files**:
-   - `docs/openspec/specs/{capability-name}/spec.md`
-   - `docs/openspec/specs/{capability-name}/design.md`
+   - `{spec-dir}/{capability-name}/spec.md`
+   - `{spec-dir}/{capability-name}/design.md`
 
 6. **Clean up** the team when done (if `--review` was used).
 
@@ -44,11 +48,11 @@ You are creating or updating an OpenSpec specification. Every spec is a **paired
 
 8. **Suggest sprint planning**: After the spec is written, suggest: "To break this spec into trackable issues, run `/design:plan SPEC-XXXX`."
 
-9. **CLAUDE.md integration**: Check if this is the first spec (i.e., `docs/openspec/specs/` was just created or contains only this new directory). If so:
-   - Check if a `CLAUDE.md` exists in the project root
-   - If it exists, check if it already references `docs/openspec/specs/`
+9. **CLAUDE.md integration**: Check if this is the first spec (i.e., `{spec-dir}` was just created or contains only this new directory). If so:
+   - Check if a `CLAUDE.md` exists at the module root (or project root for single-module projects)
+   - If it exists, check if it already references the spec directory
    - If no reference exists, ask the user: "I can add an Architecture Context section to your CLAUDE.md so future sessions know about your specs. Shall I?"
-   - If the user says yes, append an `## Architecture Context` section with `- Specifications are in docs/openspec/specs/`
+   - If the user says yes, append an `## Architecture Context` section with `- Specifications are in {spec-dir}`
    - If `CLAUDE.md` doesn't exist, suggest creating one
 
 ### Team Handoff Protocol (only for `--review` mode)

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -2,7 +2,7 @@
 name: status
 description: Change the status of an ADR or spec (e.g., proposed to accepted, draft to review). Use when the user says "accept ADR", "approve the spec", "mark as accepted", or wants to update decision status.
 allowed-tools: Read, Write, Edit, Glob, Grep, AskUserQuestion
-argument-hint: [ADR-XXXX or SPEC-XXXX] [new status]
+argument-hint: [ADR-XXXX or SPEC-XXXX] [new status] [--module <name>]
 disable-model-invocation: true
 ---
 
@@ -12,19 +12,23 @@ Update the status field in the YAML frontmatter of an ADR or spec file.
 
 ## Process
 
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+0. **Resolve artifact paths**: Follow the **Artifact Path Resolution** pattern from `references/shared-patterns.md` to determine the ADR and spec directories. If `$ARGUMENTS` contains `--module <name>`, resolve paths relative to that module; otherwise, in a workspace, aggregate across all modules. The resolved ADR directory is `{adr-dir}` and spec directory is `{spec-dir}`.
+
 1. **Parse arguments**: Extract the identifier and new status from `$ARGUMENTS`.
    - Identifier: `ADR-XXXX` or `SPEC-XXXX` (or a capability name for specs)
    - Status: the new status value
 
-2. **If identifier is missing**: Scan for available ADRs and specs, present a list with current statuses, and use `AskUserQuestion` to ask which to update.
+2. **If identifier is missing**: Scan for available ADRs and specs (using `{adr-dir}` and `{spec-dir}`), present a list with current statuses, and use `AskUserQuestion` to ask which to update.
 
 3. **If status is missing**: Show the current status and use `AskUserQuestion` to ask what to change it to. Show valid options:
    - ADR statuses: `proposed`, `accepted`, `deprecated`, `superseded`
    - Spec statuses: `draft`, `review`, `approved`, `implemented`, `deprecated`
 
 4. **Locate the file**:
-   - For ADRs: Glob `docs/adrs/ADR-{number}-*.md` to find the matching file
-   - For SPECs: Glob `docs/openspec/specs/*/spec.md` and search for the matching SPEC number in the heading
+   - For ADRs: Glob `{adr-dir}/ADR-{number}-*.md` to find the matching file
+   - For SPECs: Glob `{spec-dir}/*/spec.md` and search for the matching SPEC number in the heading
 
 5. **Update the frontmatter**: Edit the `status:` field in the YAML frontmatter to the new value. If no frontmatter exists, add one with the status field.
 

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -4,7 +4,7 @@
 name: work
 description: Pick up tracker issues and implement them in parallel using git worktrees. Use when the user says "work on issues", "implement the spec", "start coding", or wants agents to build from planned issues.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, WebFetch, WebSearch, TeamCreate, TeamDelete, TaskCreate, TaskUpdate, TaskList, TaskGet, SendMessage, AskUserQuestion, ToolSearch, EnterWorktree
-argument-hint: [SPEC-XXXX | issue numbers | (empty = propose from backlog)] [--max-agents N] [--draft] [--dry-run] [--no-tests]
+argument-hint: [SPEC-XXXX | issue numbers | (empty = propose from backlog)] [--max-agents N] [--draft] [--dry-run] [--no-tests] [--module <name>]
 ---
 
 <!-- Governing: ADR-0015 (Markdown-Native Configuration), SPEC-0014 REQ "Config Resolution Pattern" -->
@@ -14,6 +14,10 @@ argument-hint: [SPEC-XXXX | issue numbers | (empty = propose from backlog)] [--m
 You are picking up tracker issues and implementing them in parallel using git worktrees. Each issue gets its own worktree and worker agent.
 
 ## Process
+
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+0. **Resolve artifact paths**: Follow the **Artifact Path Resolution** pattern from `references/shared-patterns.md` to determine the ADR and spec directories. If `$ARGUMENTS` contains `--module <name>`, resolve paths relative to that module. The resolved spec directory is `{spec-dir}`.
 
 1. **Parse arguments**: Parse `$ARGUMENTS`.
 


### PR DESCRIPTION
## Summary
- Add Artifact Path Resolution pattern to `shared-patterns.md` with 4-step algorithm
- Add `--module <name>` flag to all 15 skills via argument-hint and new step 0
- Replace all hardcoded `docs/adrs/` and `docs/openspec/specs/` with `{adr-dir}` and `{spec-dir}`
- Update Spec Resolution to use resolved paths

## Changed Files (16)
- `references/shared-patterns.md` — new Artifact Path Resolution pattern
- All 15 `skills/*/SKILL.md` — `--module` flag, step 0, path variables

Closes #43
Part of #39
Implements SPEC-0014

🤖 Generated with [Claude Code](https://claude.com/claude-code)