### PR TITLE
Story 2: /sdd:graph skill core (parse + build + validate)

### DIFF
--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -1,0 +1,115 @@
+<!-- Governing: ADR-0023 (Frontmatter DAG and /sdd:graph Skill), SPEC-0018 REQ "Graph Construction", SPEC-0018 REQ "Graph Validation" -->
+
+---
+name: graph
+description: Build and query the SDD artifact graph. Use when the user wants to validate frontmatter edges, find impact/ancestors/chain for an ADR or spec, detect orphans or cycles, or backfill edges from prose. Story 2 ships the `validate` verb; traversal verbs land in subsequent stories.
+allowed-tools: Bash, Read, Glob, Grep, Task
+argument-hint: validate [--module <name>]
+---
+
+# /sdd:graph — Artifact Graph Skill
+
+You are running `/sdd:graph`. This skill builds an in-memory directed graph of the project's ADRs, specs, and governed source files, then answers queries against it.
+
+This skill differs from other SDD skills: instead of orchestrating Claude through markdown instructions, it delegates the deterministic build/validate/traverse work to a Python helper at `lib/graph.py` in this skill's directory. The output of the helper is the contract — JSON output (Story 6) is the stable shape any future MCP would consume. Markdown is reserved for orchestration and review UX (e.g., the `backfill` mode's accept/edit/reject in Story 7).
+
+## Process
+
+<!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
+
+0. **Resolve artifact paths**: Follow the **Artifact Path Resolution** pattern from `references/shared-patterns.md` to determine the ADR and spec directories. The resolved ADR directory is `{adr-dir}` and spec directory is `{spec-dir}`.
+
+   In Story 2 the helper accepts a single root and a single ADR/spec dir per invocation. Workspace-mode aggregation (multiple modules, `[module]/ID` prefixes) lands in Story 5.
+
+1. **Parse the verb and flags from `$ARGUMENTS`**.
+
+   Currently supported: `validate`. Other verbs (`impact`, `ancestors`, `chain`, `orphans`, `cycles`, `backfill`) are added in Stories 3-7 and will return a "not implemented yet" error if invoked now.
+
+2. **Locate the helper script**.
+
+   The helper lives at `{skill-dir}/lib/graph.py`, where `{skill-dir}` is the absolute path to this skill's directory (the `Base directory for this skill` line in the skill invocation header). The helper is invoked via `python3` and reads from the project root passed via `--root`.
+
+3. **Invoke the helper**.
+
+   For `validate`:
+
+   ```bash
+   python3 {skill-dir}/lib/graph.py validate --root {project-root} --adr-dir {adr-dir} --spec-dir {spec-dir}
+   ```
+
+   - `{project-root}` is the working directory (typically `.`).
+   - `{adr-dir}` and `{spec-dir}` are passed only if Step 0 resolved a non-default location (e.g., a workspace module). For a single-module project, omit them and the helper defaults to `docs/adrs/` and `docs/openspec/specs/` under the root.
+
+4. **Present the helper's stdout to the user verbatim**.
+
+   The helper emits markdown directly. Do not reformat or summarize unless the user asks.
+
+5. **Surface the helper's exit code**.
+
+   - Exit `0`: graph validates clean (no hard errors). Warnings, if any, are visible in the output.
+   - Exit `1`: hard errors. The graph is not queryable until they are fixed. Do not proceed to other verbs.
+   - Exit `2`: invocation error (bad arguments, missing root). This is a skill bug — surface it as such.
+
+## What `validate` reports
+
+Per SPEC-0018 REQ "Graph Validation", three classes of finding:
+
+| Finding | Severity | Trigger |
+|---------|----------|---------|
+| Unresolved ID | error | An edge references an artifact ID that has no node in the graph |
+| Cycle | error | A cycle exists in any acyclic edge type (`supersedes`, `extends`, `enables`, `governs`, `implements`, `requires`) |
+| Status inconsistency | warning | An ADR/spec is `supersedes`-targeted but the target's status is not `superseded` (ADR) or `deprecated` (ADR/spec) |
+
+The helper also reports authoring-time mistakes that are not in the canonical spec but are useful in practice:
+
+| Finding | Severity | Trigger |
+|---------|----------|---------|
+| Authored derived field | warning | Frontmatter declares a derived field (`governed-by`, `implemented-by`, etc.) that should be computed, not authored |
+| Schema misuse | warning | A spec declares an ADR-only field, or an ADR declares a spec-only field |
+| Malformed edge list | error | An edge field is not a list, or contains a non-string entry |
+| Duplicate ID | error | Two files declare the same ADR-XXXX or SPEC-XXXX |
+
+## Architecture
+
+```
++---------------------+      +---------------------+
+| docs/adrs/*.md      |      | docs/openspec/...   |
+| (frontmatter edges) |      |    /spec.md         |
++----------+----------+      +----------+----------+
+           |                            |
+           +----------+    +------------+
+                      |    |
+                      v    v
+          +-----------------------------+
+          | lib/graph.py                |
+          |  - parse frontmatter (YAML  |
+          |    subset; stdlib only)     |
+          |  - parse governing comments |
+          |  - build directed graph     |
+          |  - validate (3 checks)      |
+          |  - derive inverse edges     |
+          +--------------+--------------+
+                         |
+              +----------+----------+
+              | stdout (markdown    |
+              | by default)         |
+              +---------------------+
+```
+
+The helper is stdlib-only — no PyYAML dependency. The frontmatter parser is intentionally narrow: it handles scalars and inline-bracket lists, which is all the SPEC-0018 schema declares. Extending it to nested mappings or block-list YAML is future work that should not be undertaken speculatively.
+
+## Cross-references
+
+- **Schema**: `references/shared-patterns.md` § "Graph Edge Resolution"
+- **Author surfaces**: `skills/adr/SKILL.md` § "Graph Edge Frontmatter", `skills/spec/SKILL.md` § "Graph Edge Frontmatter"
+- **Code-edge format**: `references/shared-patterns.md` § "Governing Comment Format"
+- **Canonical spec**: `docs/openspec/specs/artifact-graph/spec.md` (SPEC-0018)
+- **Canonical decision**: `docs/adrs/ADR-0023-frontmatter-dag-and-graph-skill.md`
+
+## Rules
+
+- Verb output is the helper's stdout — do not paraphrase it.
+- Hard errors (exit 1) MUST be surfaced before any other action. Do not run other verbs against a graph that failed validation.
+- The helper is the source of truth. If the helper output disagrees with this SKILL.md, fix the SKILL.md or the helper, not the user's expectations.
+- Do not bypass the helper to "do graph work in markdown." Determinism and byte-identity require the script.
+- When extending the helper (Stories 3-7), preserve the existing Python module structure: discovery → parsing → models → construction → validation. New verbs add new entry points but do not rewrite the core.

--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -4,7 +4,7 @@
 name: graph
 description: Build and query the SDD artifact graph. Use when the user wants to validate frontmatter edges, find impact/ancestors/chain for an ADR or spec, detect orphans or cycles, or backfill edges from prose. Story 2 ships the `validate` verb; traversal verbs land in subsequent stories.
 allowed-tools: Bash, Read, Glob, Grep, Task
-argument-hint: validate [--module <name>]
+argument-hint: validate
 ---
 
 # /sdd:graph — Artifact Graph Skill
@@ -23,7 +23,9 @@ This skill differs from other SDD skills: instead of orchestrating Claude throug
 
 1. **Parse the verb and flags from `$ARGUMENTS`**.
 
-   Currently supported: `validate`. Other verbs (`impact`, `ancestors`, `chain`, `orphans`, `cycles`, `backfill`) are added in Stories 3-7 and will return a "not implemented yet" error if invoked now.
+   Currently supported: `validate`. Other v1 verbs (`impact`, `ancestors`, `chain`, `orphans`, `cycles`, `backfill`) are recognized at the argparse layer and return a clear "not yet implemented (planned for Story N)" message with exit code 2 if invoked now. They land in Stories 3-7.
+
+   The `--module <name>` flag for workspace-mode aggregation is not yet wired through the helper — it lands in Story 5 along with cross-module ID prefixing. Until then, the helper operates on a single `--root`. If the user passes `--module`, surface that this flag is Story 5 work and proceed without it.
 
 2. **Locate the helper script**.
 
@@ -97,6 +99,8 @@ The helper also reports authoring-time mistakes that are not in the canonical sp
 ```
 
 The helper is stdlib-only — no PyYAML dependency. The frontmatter parser is intentionally narrow: it handles scalars and inline-bracket lists, which is all the SPEC-0018 schema declares. Extending it to nested mappings or block-list YAML is future work that should not be undertaken speculatively.
+
+**Python version.** Requires Python 3.10+ (uses PEP 604 union syntax `str | None` and `Path.is_relative_to`).
 
 ## Cross-references
 

--- a/skills/graph/lib/graph.py
+++ b/skills/graph/lib/graph.py
@@ -1,0 +1,686 @@
+#!/usr/bin/env python3
+# Governing: ADR-0023 (Frontmatter DAG and /sdd:graph Skill), SPEC-0018 REQ "Graph Construction", SPEC-0018 REQ "Graph Validation", SPEC-0018 REQ "Inverse Edge Derivation"
+"""sdd graph — artifact graph builder.
+
+Story 2 scope: file discovery, frontmatter parsing, governing-comment parsing,
+graph construction, inverse-edge derivation, validation. Verbs (impact,
+ancestors, chain, orphans, cycles, backfill) are added in Stories 3-7.
+
+Invoke: python3 graph.py <verb> [--root PATH] [--module NAME]
+
+Currently supported verbs:
+    validate    Build the graph and report validation diagnostics. Exits
+                non-zero if any hard error is detected.
+
+Exit codes:
+    0  success, no hard errors (warnings may be present)
+    1  hard error in graph (unresolved ID, cycle, malformed input)
+    2  invocation error (bad arguments, missing root)
+
+This file uses stdlib only — no PyYAML dependency. The frontmatter parser is
+intentionally narrow: it handles scalars and inline-bracket lists, which is
+all the edge schema declares. A user who wants nested YAML in frontmatter
+will need to extend it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Edge schema constants (mirror SPEC-0018 REQ "Frontmatter Edge Schema")
+# ---------------------------------------------------------------------------
+
+ADR_EDGE_FIELDS: tuple[str, ...] = ("supersedes", "extends", "enables", "governs", "related")
+SPEC_EDGE_FIELDS: tuple[str, ...] = ("implements", "requires", "extends", "supersedes")
+ALL_EDGE_FIELDS: frozenset[str] = frozenset(ADR_EDGE_FIELDS) | frozenset(SPEC_EDGE_FIELDS)
+
+# Forward → derived inverse (SPEC-0018 REQ "Inverse Edge Derivation").
+INVERSE_OF: dict[str, str] = {
+    "supersedes": "superseded-by",
+    "extends": "extended-by",
+    "enables": "enabled-by",
+    "governs": "governed-by",
+    "implements": "implemented-by",
+    "requires": "depended-on-by",
+    "related": "related",  # symmetric
+}
+
+# Reverse-direction fields that MUST NOT appear in authored frontmatter.
+DERIVED_FIELDS: frozenset[str] = frozenset(INVERSE_OF.values()) - frozenset({"related"})
+
+# Edge types that must form a DAG (per SPEC-0018 REQ "Graph Validation").
+# `related` is symmetric and exempt.
+ACYCLIC_EDGE_TYPES: frozenset[str] = frozenset(
+    {"supersedes", "extends", "enables", "governs", "implements", "requires"}
+)
+
+ADR_STATUSES = frozenset({"proposed", "accepted", "deprecated", "superseded"})
+SPEC_STATUSES = frozenset({"draft", "review", "approved", "implemented", "deprecated"})
+
+# ---------------------------------------------------------------------------
+# Frontmatter parser (stdlib only, narrow by design)
+# ---------------------------------------------------------------------------
+
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*(?:\n|\Z)", re.DOTALL)
+
+
+def parse_frontmatter(text: str) -> dict[str, object]:
+    """Extract YAML-ish frontmatter from `text`.
+
+    Returns a dict mapping field names to either strings (scalars) or
+    lists of strings (bracket lists). Returns an empty dict if no
+    frontmatter block is present.
+
+    The parser handles:
+      key: value
+      key: [item1, item2]
+      key: ["[module]/SPEC-XXXX", ADR-0001]   (quoted scalars in lists)
+      # comment lines (skipped)
+      blank lines (skipped)
+
+    The parser does NOT handle:
+      - block lists (- item form)
+      - nested mappings
+      - multi-line scalars
+    The schema does not need any of those, so this is intentional.
+    """
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return {}
+    body = m.group(1)
+    result: dict[str, object] = {}
+    for raw_line in body.splitlines():
+        line = raw_line.rstrip()
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip()
+        # Strip inline comments only when outside quotes.
+        value = _strip_inline_comment(value)
+        if value.startswith("[") and value.endswith("]"):
+            inner = value[1:-1].strip()
+            result[key] = [_unquote(item.strip()) for item in _split_csv(inner) if item.strip()]
+        else:
+            result[key] = _unquote(value)
+    return result
+
+
+def _strip_inline_comment(value: str) -> str:
+    """Strip a trailing  # comment outside of quotes."""
+    in_quote: str | None = None
+    for i, ch in enumerate(value):
+        if in_quote:
+            if ch == in_quote:
+                in_quote = None
+            continue
+        if ch in ('"', "'"):
+            in_quote = ch
+            continue
+        if ch == "#" and (i == 0 or value[i - 1].isspace()):
+            return value[:i].rstrip()
+    return value
+
+
+def _split_csv(value: str) -> list[str]:
+    """Split on commas that are not inside quotes or square-bracket nests."""
+    out: list[str] = []
+    buf: list[str] = []
+    in_quote: str | None = None
+    depth = 0
+    for ch in value:
+        if in_quote:
+            buf.append(ch)
+            if ch == in_quote:
+                in_quote = None
+        elif ch in ('"', "'"):
+            in_quote = ch
+            buf.append(ch)
+        elif ch == "[":
+            depth += 1
+            buf.append(ch)
+        elif ch == "]":
+            depth -= 1
+            buf.append(ch)
+        elif ch == "," and depth == 0:
+            out.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    if buf:
+        out.append("".join(buf))
+    return out
+
+
+def _unquote(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+        return value[1:-1]
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Node:
+    id: str  # canonical ID (ADR-0001, SPEC-0001) or relative file path for code nodes
+    kind: str  # "adr" | "spec" | "code"
+    path: str  # absolute filesystem path
+    status: str | None = None
+    date: str | None = None
+    title: str = ""
+    module: str | None = None  # workspace mode — set by Story 5
+
+
+@dataclass
+class Edge:
+    source: str
+    target: str
+    type: str
+    derived: bool
+
+
+@dataclass
+class Diagnostic:
+    severity: str  # "error" or "warning"
+    code: str
+    message: str
+    source_id: str | None = None
+    field: str | None = None
+    target_id: str | None = None
+
+
+@dataclass
+class Graph:
+    nodes: dict[str, Node] = field(default_factory=dict)
+    edges: list[Edge] = field(default_factory=list)
+    diagnostics: list[Diagnostic] = field(default_factory=list)
+
+    def has_errors(self) -> bool:
+        return any(d.severity == "error" for d in self.diagnostics)
+
+    def add_diagnostic(self, **kwargs: object) -> None:
+        self.diagnostics.append(Diagnostic(**kwargs))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# File discovery
+# ---------------------------------------------------------------------------
+
+_TITLE_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+_ID_FROM_TITLE_RE = re.compile(r"^(ADR|SPEC)-(\d{4})\b")
+_ADR_FILE_RE = re.compile(r"^ADR-(\d{4})-")
+
+
+def discover_adrs(adr_dir: Path) -> list[tuple[str, Path, dict]]:
+    """Return (id, path, frontmatter) tuples for every ADR found."""
+    out: list[tuple[str, Path, dict]] = []
+    if not adr_dir.is_dir():
+        return out
+    for path in sorted(adr_dir.glob("ADR-*.md")):
+        m = _ADR_FILE_RE.match(path.name)
+        if not m:
+            continue
+        adr_id = f"ADR-{m.group(1)}"
+        text = _read_text(path)
+        out.append((adr_id, path, parse_frontmatter(text)))
+    return out
+
+
+def discover_specs(spec_dir: Path) -> list[tuple[str, Path, dict]]:
+    """Return (id, path, frontmatter) tuples for every spec.md found.
+
+    Spec ID is read from the first `# SPEC-XXXX:` heading; spec.md files
+    that lack such a heading are skipped with no error (consumers should
+    surface them via /sdd:list, not here).
+    """
+    out: list[tuple[str, Path, dict]] = []
+    if not spec_dir.is_dir():
+        return out
+    for path in sorted(spec_dir.glob("*/spec.md")):
+        text = _read_text(path)
+        spec_id = _extract_spec_id(text)
+        if spec_id is None:
+            continue
+        out.append((spec_id, path, parse_frontmatter(text)))
+    return sorted(out, key=lambda t: t[0])
+
+
+def _extract_spec_id(text: str) -> str | None:
+    for m in _TITLE_RE.finditer(text):
+        title = m.group(1)
+        id_m = _ID_FROM_TITLE_RE.match(title)
+        if id_m:
+            return f"SPEC-{id_m.group(2)}"
+    return None
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+# Governing comment block per ADR-0020 / SPEC-0016 REQ "Governing Comment Format".
+# File-level only — first comment line that starts with `Governing:`.
+_GOVERNING_RE = re.compile(
+    r"""
+    ^[ \t]*                       # optional leading indent
+    (?://|\#|<!--)                # comment opener: //, #, <!--
+    [ \t]*Governing:[ \t]*        # marker
+    (.+?)                         # body of governing line (non-greedy)
+    [ \t]*(?:-->)?[ \t]*$         # optional --> closer for HTML comments
+    """,
+    re.IGNORECASE | re.VERBOSE | re.MULTILINE,
+)
+_GOVERNING_ID_RE = re.compile(r"\b(ADR-\d{4}|SPEC-\d{4})\b")
+
+_DEFAULT_CODE_EXCLUDES = frozenset(
+    {".git", "node_modules", "vendor", ".venv", "venv", "__pycache__",
+     "dist", "build", "target", ".next", ".cache",
+     "docs", "skills", "references", "evals", "templates",
+     "docs-generated", "docs-site"}
+)
+
+
+def discover_code_edges(root: Path, excludes: frozenset[str] = _DEFAULT_CODE_EXCLUDES) -> list[tuple[Path, list[str]]]:
+    """Walk `root` and return (path, [referenced_artifact_ids]) for every file
+    whose first 4096 bytes contain a governing-comment block. Markdown files
+    are skipped — they participate via frontmatter, not governing comments.
+    """
+    out: list[tuple[Path, list[str]]] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Prune excluded and hidden directories in-place.
+        dirnames[:] = sorted(
+            d for d in dirnames if d not in excludes and not d.startswith(".")
+        )
+        for name in sorted(filenames):
+            if name.endswith((".md", ".markdown")):
+                continue
+            path = Path(dirpath) / name
+            try:
+                with open(path, "rb") as f:
+                    head = f.read(4096)
+            except OSError:
+                continue
+            try:
+                text = head.decode("utf-8", errors="ignore")
+            except UnicodeDecodeError:
+                continue
+            m = _GOVERNING_RE.search(text)
+            if not m:
+                continue
+            ids = sorted(set(_GOVERNING_ID_RE.findall(m.group(1))))
+            if ids:
+                out.append((path, ids))
+    return sorted(out, key=lambda t: str(t[0]))
+
+
+# ---------------------------------------------------------------------------
+# Graph construction
+# ---------------------------------------------------------------------------
+
+
+def build_graph(root: Path, adr_dir: Path, spec_dir: Path) -> Graph:
+    """Build the graph for a single module rooted at `root`.
+
+    Discovers ADRs, specs, and governed code files; constructs nodes; reads
+    forward edges from frontmatter; derives inverse edges; runs validation.
+    """
+    g = Graph()
+
+    # 1. ADR nodes + forward edges.
+    for adr_id, path, fm in discover_adrs(adr_dir):
+        if adr_id in g.nodes:
+            g.add_diagnostic(
+                severity="error",
+                code="duplicate-id",
+                message=f"{adr_id} declared by multiple files",
+                source_id=adr_id,
+            )
+            continue
+        g.nodes[adr_id] = Node(
+            id=adr_id,
+            kind="adr",
+            path=str(path),
+            status=_str_or_none(fm.get("status")),
+            date=_str_or_none(fm.get("date")),
+            title=_extract_title(_read_text(path)) or adr_id,
+        )
+        _ingest_edges(g, adr_id, fm, ADR_EDGE_FIELDS)
+
+    # 2. Spec nodes + forward edges.
+    for spec_id, path, fm in discover_specs(spec_dir):
+        if spec_id in g.nodes:
+            g.add_diagnostic(
+                severity="error",
+                code="duplicate-id",
+                message=f"{spec_id} declared by multiple files",
+                source_id=spec_id,
+            )
+            continue
+        g.nodes[spec_id] = Node(
+            id=spec_id,
+            kind="spec",
+            path=str(path),
+            status=_str_or_none(fm.get("status")),
+            date=_str_or_none(fm.get("date")),
+            title=_extract_title(_read_text(path)) or spec_id,
+        )
+        _ingest_edges(g, spec_id, fm, SPEC_EDGE_FIELDS)
+
+    # 3. Code nodes + governance edges (from governing comment blocks).
+    for path, ids in discover_code_edges(root):
+        rel = str(path.relative_to(root)) if path.is_relative_to(root) else str(path)
+        node_id = rel
+        if node_id not in g.nodes:
+            g.nodes[node_id] = Node(id=node_id, kind="code", path=str(path))
+        for target in ids:
+            g.edges.append(Edge(source=node_id, target=target, type="governed-by", derived=False))
+
+    # 4. Validate.
+    _validate(g)
+
+    # 5. Derive inverse edges. (Done after validation so cycle detection
+    #    operates on authored edges only.)
+    _derive_inverses(g)
+
+    return g
+
+
+def _str_or_none(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value or None
+    return str(value)
+
+
+def _extract_title(text: str) -> str:
+    m = _TITLE_RE.search(text)
+    return m.group(1) if m else ""
+
+
+def _ingest_edges(g: Graph, source_id: str, fm: dict, allowed: tuple[str, ...]) -> None:
+    for field_name, raw in fm.items():
+        if field_name in DERIVED_FIELDS:
+            g.add_diagnostic(
+                severity="warning",
+                code="authored-derived-edge",
+                message=(
+                    f"{source_id} declares derived field `{field_name}`; "
+                    "derived edges MUST NOT be authored — value ignored"
+                ),
+                source_id=source_id,
+                field=field_name,
+            )
+            continue
+        if field_name not in ALL_EDGE_FIELDS:
+            continue
+        if field_name not in allowed:
+            g.add_diagnostic(
+                severity="warning",
+                code="schema-misuse",
+                message=(
+                    f"{source_id} declares `{field_name}`, which is not a valid "
+                    f"edge field for this artifact type"
+                ),
+                source_id=source_id,
+                field=field_name,
+            )
+            continue
+        if not isinstance(raw, list):
+            g.add_diagnostic(
+                severity="error",
+                code="malformed-edge-list",
+                message=f"{source_id}.{field_name} must be a list (e.g., [ADR-0001])",
+                source_id=source_id,
+                field=field_name,
+            )
+            continue
+        for target in raw:
+            if not isinstance(target, str) or not target.strip():
+                g.add_diagnostic(
+                    severity="error",
+                    code="malformed-edge-target",
+                    message=f"{source_id}.{field_name} contains a non-string or empty target",
+                    source_id=source_id,
+                    field=field_name,
+                )
+                continue
+            g.edges.append(
+                Edge(source=source_id, target=target.strip(), type=field_name, derived=False)
+            )
+
+
+# ---------------------------------------------------------------------------
+# Validation (SPEC-0018 REQ "Graph Validation")
+# ---------------------------------------------------------------------------
+
+
+def _validate(g: Graph) -> None:
+    _validate_id_resolution(g)
+    _validate_no_cycles(g)
+    _validate_status_consistency(g)
+
+
+def _validate_id_resolution(g: Graph) -> None:
+    """Every artifact ID in a frontmatter edge MUST exist as a node."""
+    for edge in g.edges:
+        if edge.derived:
+            continue
+        # Code-edge targets reference artifacts; their IDs must resolve.
+        # Frontmatter-edge targets must also resolve.
+        if edge.target not in g.nodes:
+            # Cross-module IDs ([module]/SPEC-XXXX) are deferred to Story 5;
+            # in single-module mode we treat them as unresolved.
+            g.add_diagnostic(
+                severity="error",
+                code="unresolved-id",
+                message=(
+                    f"{edge.source} {edge.type} unknown artifact {edge.target}"
+                ),
+                source_id=edge.source,
+                field=edge.type,
+                target_id=edge.target,
+            )
+
+
+def _validate_no_cycles(g: Graph) -> None:
+    """Detect cycles in DAG-required edge types via Tarjan-style DFS."""
+    # Build adjacency for acyclic-required edges only (ignores `related`).
+    adj: dict[str, list[tuple[str, str]]] = {}
+    for edge in g.edges:
+        if edge.derived or edge.type not in ACYCLIC_EDGE_TYPES:
+            continue
+        if edge.target not in g.nodes:
+            continue  # already reported by id-resolution
+        adj.setdefault(edge.source, []).append((edge.target, edge.type))
+
+    color: dict[str, int] = {}  # 0=white, 1=gray, 2=black
+    parent: dict[str, tuple[str, str] | None] = {}
+
+    def dfs(start: str) -> None:
+        stack: list[tuple[str, int]] = [(start, 0)]
+        while stack:
+            node, idx = stack[-1]
+            if color.get(node, 0) == 0:
+                color[node] = 1
+            children = adj.get(node, [])
+            if idx == len(children):
+                color[node] = 2
+                stack.pop()
+                continue
+            stack[-1] = (node, idx + 1)
+            child, edge_type = children[idx]
+            c = color.get(child, 0)
+            if c == 0:
+                parent[child] = (node, edge_type)
+                stack.append((child, 0))
+            elif c == 1:
+                cycle = _reconstruct_cycle(child, node, parent, edge_type)
+                g.add_diagnostic(
+                    severity="error",
+                    code="cycle",
+                    message=f"cycle detected: {' -> '.join(cycle)}",
+                )
+
+    for node_id in sorted(g.nodes):
+        if color.get(node_id, 0) == 0:
+            dfs(node_id)
+
+
+def _reconstruct_cycle(
+    cycle_start: str,
+    cur: str,
+    parent: dict[str, tuple[str, str] | None],
+    closing_edge_type: str,
+) -> list[str]:
+    """Walk parent chain from `cur` back to `cycle_start` to materialize the cycle."""
+    chain = [cur]
+    while cur != cycle_start and cur in parent and parent[cur] is not None:
+        cur = parent[cur][0]  # type: ignore[index]
+        chain.append(cur)
+    chain.reverse()
+    chain.append(f"{chain[-1]} --[{closing_edge_type}]--> {cycle_start}")
+    return chain
+
+
+def _validate_status_consistency(g: Graph) -> None:
+    """When A `supersedes` B, B's status MUST be `superseded` (ADR) or
+    `deprecated` (spec or ADR). Mismatch is a warning, not a hard error.
+    """
+    for edge in g.edges:
+        if edge.derived or edge.type != "supersedes":
+            continue
+        target = g.nodes.get(edge.target)
+        if target is None or target.kind == "code":
+            continue
+        expected = ("superseded", "deprecated") if target.kind == "adr" else ("deprecated",)
+        if target.status is None or target.status not in expected:
+            actual = target.status or "<unset>"
+            g.add_diagnostic(
+                severity="warning",
+                code="status-inconsistent",
+                message=(
+                    f"{edge.source} supersedes {edge.target}, but "
+                    f"{edge.target} status is `{actual}` (expected one of "
+                    f"{', '.join(expected)})"
+                ),
+                source_id=edge.source,
+                field="supersedes",
+                target_id=edge.target,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Inverse derivation (SPEC-0018 REQ "Inverse Edge Derivation")
+# ---------------------------------------------------------------------------
+
+
+def _derive_inverses(g: Graph) -> None:
+    """For every authored forward edge, add a derived inverse edge.
+
+    For symmetric `related`, add a derived edge in the opposite direction
+    only if it is not already present as authored.
+    """
+    authored_pairs: set[tuple[str, str, str]] = {
+        (e.source, e.target, e.type) for e in g.edges if not e.derived
+    }
+    new_edges: list[Edge] = []
+    for edge in list(g.edges):
+        if edge.derived:
+            continue
+        if edge.type not in INVERSE_OF:
+            continue
+        if edge.target not in g.nodes:
+            continue  # don't derive from broken targets
+        inverse_type = INVERSE_OF[edge.type]
+        if edge.type == "related":
+            # Skip if the symmetric authored edge already exists in reverse.
+            if (edge.target, edge.source, "related") in authored_pairs:
+                continue
+        new_edges.append(
+            Edge(source=edge.target, target=edge.source, type=inverse_type, derived=True)
+        )
+    g.edges.extend(new_edges)
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def print_validation(g: Graph) -> None:
+    n_nodes = len(g.nodes)
+    n_edges_authored = sum(1 for e in g.edges if not e.derived)
+    n_edges_derived = sum(1 for e in g.edges if e.derived)
+    errors = [d for d in g.diagnostics if d.severity == "error"]
+    warnings = [d for d in g.diagnostics if d.severity == "warning"]
+
+    print(f"# /sdd:graph validate")
+    print()
+    print(f"- Nodes: {n_nodes} (ADRs + specs + governed code files)")
+    print(f"- Authored edges: {n_edges_authored}")
+    print(f"- Derived edges: {n_edges_derived}")
+    print(f"- Errors: {len(errors)}")
+    print(f"- Warnings: {len(warnings)}")
+    print()
+
+    if errors:
+        print("## Errors")
+        print()
+        for d in errors:
+            print(f"- **{d.code}** — {d.message}")
+        print()
+
+    if warnings:
+        print("## Warnings")
+        print()
+        for d in warnings:
+            print(f"- **{d.code}** — {d.message}")
+        print()
+
+    if not errors and not warnings:
+        print("Graph validates clean.")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="graph", description=__doc__)
+    parser.add_argument("verb", choices=["validate"], help="graph verb to run")
+    parser.add_argument("--root", default=".", help="project root (default: cwd)")
+    parser.add_argument("--adr-dir", help="ADR directory (default: <root>/docs/adrs)")
+    parser.add_argument("--spec-dir", help="spec directory (default: <root>/docs/openspec/specs)")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    if not root.is_dir():
+        print(f"error: --root {root} is not a directory", file=sys.stderr)
+        return 2
+    adr_dir = Path(args.adr_dir).resolve() if args.adr_dir else root / "docs" / "adrs"
+    spec_dir = Path(args.spec_dir).resolve() if args.spec_dir else root / "docs" / "openspec" / "specs"
+
+    g = build_graph(root, adr_dir, spec_dir)
+    print_validation(g)
+    return 1 if g.has_errors() else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/graph/lib/graph.py
+++ b/skills/graph/lib/graph.py
@@ -6,16 +6,22 @@ Story 2 scope: file discovery, frontmatter parsing, governing-comment parsing,
 graph construction, inverse-edge derivation, validation. Verbs (impact,
 ancestors, chain, orphans, cycles, backfill) are added in Stories 3-7.
 
-Invoke: python3 graph.py <verb> [--root PATH] [--module NAME]
+Invoke: python3 graph.py <verb> [--root PATH]
 
 Currently supported verbs:
     validate    Build the graph and report validation diagnostics. Exits
                 non-zero if any hard error is detected.
 
+Other v1 verbs (impact, ancestors, chain, orphans, cycles, backfill) are
+accepted at the argparse layer and return a clear "not yet implemented"
+message rather than an opaque argparse error. They land in Stories 3-7.
+
 Exit codes:
     0  success, no hard errors (warnings may be present)
     1  hard error in graph (unresolved ID, cycle, malformed input)
-    2  invocation error (bad arguments, missing root)
+    2  invocation error (bad arguments, missing root, unimplemented verb)
+
+Requires Python 3.10+ (uses `str | None` syntax and other PEP 604 unions).
 
 This file uses stdlib only — no PyYAML dependency. The frontmatter parser is
 intentionally narrow: it handles scalars and inline-bracket lists, which is
@@ -382,6 +388,11 @@ def build_graph(root: Path, adr_dir: Path, spec_dir: Path) -> Graph:
         _ingest_edges(g, spec_id, fm, SPEC_EDGE_FIELDS)
 
     # 3. Code nodes + governance edges (from governing comment blocks).
+    # Note: code-edge type is `governed-by` — same name as the inverse derived
+    # from `governs:` frontmatter, but with `derived=False` because it's
+    # authored in code (per ADR-0020). Downstream verbs that distinguish
+    # provenance can read the source-node `kind` (code vs adr/spec) along
+    # with the `derived` flag.
     for path, ids in discover_code_edges(root):
         rel = str(path.relative_to(root)) if path.is_relative_to(root) else str(path)
         node_id = rel
@@ -477,15 +488,22 @@ def _validate(g: Graph) -> None:
 
 
 def _validate_id_resolution(g: Graph) -> None:
-    """Every artifact ID in a frontmatter edge MUST exist as a node."""
+    """Every artifact ID in a frontmatter edge MUST exist as a node.
+
+    TODO(Story 5): When workspace mode lands, this check must understand
+    `[module]/SPEC-XXXX` cross-module references. Today the parser
+    coerces both quoted (`["[shared-lib]/SPEC-0001"]`) and unquoted
+    (`[[shared-lib]/SPEC-0001]`) forms into the same string target, so
+    the unquoted-YAML case from SPEC-0018 REQ "Workspace Mode
+    Aggregation" Scenario "Cross-module edge with unquoted YAML rejected"
+    falls out as a generic `unresolved-id` rather than the specified
+    hard error about YAML nested-list parsing. Detect-and-distinguish in
+    Story 5.
+    """
     for edge in g.edges:
         if edge.derived:
             continue
-        # Code-edge targets reference artifacts; their IDs must resolve.
-        # Frontmatter-edge targets must also resolve.
         if edge.target not in g.nodes:
-            # Cross-module IDs ([module]/SPEC-XXXX) are deferred to Story 5;
-            # in single-module mode we treat them as unresolved.
             g.add_diagnostic(
                 severity="error",
                 code="unresolved-id",
@@ -530,11 +548,11 @@ def _validate_no_cycles(g: Graph) -> None:
                 parent[child] = (node, edge_type)
                 stack.append((child, 0))
             elif c == 1:
-                cycle = _reconstruct_cycle(child, node, parent, edge_type)
+                cycle = _reconstruct_cycle(child, node, parent)
                 g.add_diagnostic(
                     severity="error",
                     code="cycle",
-                    message=f"cycle detected: {' -> '.join(cycle)}",
+                    message=f"cycle detected ({edge_type}): {' -> '.join(cycle)}",
                 )
 
     for node_id in sorted(g.nodes):
@@ -546,15 +564,20 @@ def _reconstruct_cycle(
     cycle_start: str,
     cur: str,
     parent: dict[str, tuple[str, str] | None],
-    closing_edge_type: str,
 ) -> list[str]:
-    """Walk parent chain from `cur` back to `cycle_start` to materialize the cycle."""
+    """Walk parent chain from `cur` back to `cycle_start` to materialize the cycle.
+
+    The returned list closes the cycle by repeating `cycle_start` at the end —
+    e.g., for A→B→A the result is ["A", "B", "A"], which renders as
+    "A -> B -> A" when joined. The closing edge type is reported in the
+    diagnostic message separately by the caller.
+    """
     chain = [cur]
     while cur != cycle_start and cur in parent and parent[cur] is not None:
         cur = parent[cur][0]  # type: ignore[index]
         chain.append(cur)
     chain.reverse()
-    chain.append(f"{chain[-1]} --[{closing_edge_type}]--> {cycle_start}")
+    chain.append(cycle_start)
     return chain
 
 
@@ -662,13 +685,37 @@ def print_validation(g: Graph) -> None:
 # ---------------------------------------------------------------------------
 
 
+_ALL_VERBS = ("validate", "impact", "ancestors", "chain", "orphans", "cycles", "backfill")
+_VERB_STORY = {
+    "impact": 3,
+    "ancestors": 3,
+    "chain": 3,
+    "orphans": 4,
+    "cycles": 4,
+    "backfill": 7,
+}
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="graph", description=__doc__)
-    parser.add_argument("verb", choices=["validate"], help="graph verb to run")
+    parser.add_argument("verb", choices=_ALL_VERBS, help="graph verb to run")
     parser.add_argument("--root", default=".", help="project root (default: cwd)")
     parser.add_argument("--adr-dir", help="ADR directory (default: <root>/docs/adrs)")
     parser.add_argument("--spec-dir", help="spec directory (default: <root>/docs/openspec/specs)")
     args = parser.parse_args(argv)
+
+    if args.verb != "validate":
+        story = _VERB_STORY.get(args.verb, "?")
+        print(
+            f"error: verb '{args.verb}' is not yet implemented "
+            f"(planned for Story {story} of the artifact-graph chain).",
+            file=sys.stderr,
+        )
+        print(
+            "see docs/adrs/ADR-0023-frontmatter-dag-and-graph-skill.md for the roadmap.",
+            file=sys.stderr,
+        )
+        return 2
 
     root = Path(args.root).resolve()
     if not root.is_dir():


### PR DESCRIPTION
## Summary
- Ships the keystone of the artifact graph chain: `skills/graph/SKILL.md` + `skills/graph/lib/graph.py` implementing SPEC-0018 REQ "Graph Construction" and REQ "Graph Validation".
- No traversal verbs yet (Stories 3-7 add those). Currently supported: `validate`. Future verbs (`impact`, `ancestors`, `chain`, `orphans`, `cycles`, `backfill`) build on this foundation.
- Per the agreed Pattern-B precedent, the deterministic core is a Python helper invoked via Bash. The SKILL.md orchestrates calling it; the helper's stdout is the contract that Story 6's `--json` will formalize.

## What lands

**`skills/graph/lib/graph.py` (stdlib-only, 686 LOC)**
- Narrow frontmatter parser handling scalars + inline-bracket lists + quoted scalars (the `["[module]/ID"]` cross-module form).
- File discovery for ADRs (`docs/adrs/ADR-*.md`), specs (`docs/openspec/specs/*/spec.md`), and governed code files via recursive walk with the usual exclusions.
- Graph model: Node, Edge (with `derived: bool`), Diagnostic, Graph dataclasses.
- Three canonical validations per SPEC-0018: ID resolution (error), cycle detection in acyclic edge types (error), status consistency on `supersedes` (warning).
- Four authoring-time validations: duplicate IDs, malformed edge lists, authored derived fields, schema misuse.
- Full forward→derived inverse derivation per SPEC-0018 REQ "Inverse Edge Derivation", with symmetric `related` handled correctly.

**`skills/graph/SKILL.md`**
- Standard skill manifest, governing comment, orchestration prose, validation-findings table, architecture diagram, cross-references, rules.

## Smoke test against this repo
```
# /sdd:graph validate

- Nodes: 41 (ADRs + specs + governed code files)
- Authored edges: 2
- Derived edges: 2
- Errors: 0
- Warnings: 0

Graph validates clean.
```
The two authored edges are SPEC-0018's own `implements: [ADR-0023]` and `requires: [SPEC-0014]`; the two derived edges are their inverses (`implemented-by` and `depended-on-by`). Story 8 will add edges to the other 22 ADRs and 17 specs via `/sdd:graph backfill`.

## Story-size disclosure
801 LOC (686 Python + 115 markdown) exceeds ADR-0011's 200-500 target. Splitting the parser, models, builder, three validators, and inverse derivation would force unnatural seams (e.g., a builder that can't validate, validators with no builder). All subsequent verb stories sit cleanly within the LOC target on top of this foundation.

## Test plan
- [x] `python3 skills/graph/lib/graph.py validate` against this repo: 0 errors, 0 warnings
- [x] `python3 skills/graph/lib/graph.py validate --root /tmp` exits non-zero (no artifacts → unresolved IDs from any /tmp files)
- [x] Frontmatter parser handles SPEC-0018's actual frontmatter including the bracket-list form
- [x] Inverse derivation produces 2 derived edges from 2 authored edges
- [x] No PyYAML dependency
- [x] Helper exits 0 clean / 1 hard errors / 2 invocation errors

## Stack position
This PR is **independent** of Story 1 (#78, already merged) but logically follows it: the schema docs in Story 1 are the contract; this PR implements the contract's reader. Subsequent verb stories (3-7) will branch off this PR's branch where dependencies require it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)