### PR TITLE
Story 3: /sdd:graph traversal verbs (impact, ancestors, chain)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ docs-site/node_modules/
 docs-site/build/
 docs-site/.docusaurus/
 templates/docs-generated/
+__pycache__/
+*.pyc

--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -75,13 +75,13 @@ Renders a top-down ASCII DAG: queried artifact at the top, dependents flowing be
 
 ### `ancestors <id>`
 
-Renders ancestor chains with the queried artifact at the **bottom** of each chain (per SPEC-0018 § Layout rules). Each leaf-to-target path is shown as its own vertical chain — the queried artifact name appears at the bottom of each. The vertical connector uses a dashed glyph `┆` since the visual flow is the inverse of the authored relationship; edge labels reflect the derived inverse type with the `(derived)` annotation.
+Renders ancestor paths in a single contiguous diagram with the queried artifact at the bottom (per SPEC-0018 § Layout rules). Each enumerated leaf-to-target path is rendered as a top-down chain (most-distant ancestor first, edge labels and `┆` continuation glyphs flowing down), separated by a blank line from the next path, with the queried artifact appearing exactly once at the bottom. The vertical connector uses the dashed glyph `┆` because the visual flow is the inverse of the authored relationship; edge labels reflect the derived inverse type with the `(derived)` annotation.
 
-This rendering is intentionally redundant for shared targets — splitting paths into independent chains keeps the ASCII byte-identical and avoids the merging-diagram complexity that an indented tree cannot represent cleanly.
+The vertical-stack approximation of multi-parent fan-in (vs. a side-by-side merging Y) is a tractable ASCII-only rendering — multi-parent inputs read as a sequence of independent ancestor paths feeding into the shared queried node.
 
 ### `chain <id>`
 
-Bidirectional view: ancestors above (rendered as vertical chains with the target's name suppressed at the bottom of each chain — the trailing `▼` flows into the middle section), the queried artifact in the middle (rendered as a `## Heading` with the artifact's title), and impact below (rendered as a top-down tree).
+Single contiguous bidirectional diagram: ancestors above (rendered as top-down chains with the target's title suppressed at the bottom of each), the queried artifact in the middle (rendered once as `<title> (queried)`), and impact below (rendered as a top-down indented tree). The two regions are visually joined by a single `│` continuation through the queried node — no markdown subheadings, no `▼` glyphs.
 
 ### Diagnostic verbs (Story 4 — not yet implemented)
 

--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -2,9 +2,9 @@
 
 ---
 name: graph
-description: Build and query the SDD artifact graph. Use when the user wants to validate frontmatter edges, find impact/ancestors/chain for an ADR or spec, detect orphans or cycles, or backfill edges from prose. Story 2 ships the `validate` verb; traversal verbs land in subsequent stories.
+description: Build and query the SDD artifact graph. Use when the user wants to validate frontmatter edges, find impact/ancestors/chain for an ADR or spec, detect orphans or cycles, or backfill edges from prose. Currently supports validate / impact / ancestors / chain; orphans/cycles/backfill land in later stories.
 allowed-tools: Bash, Read, Glob, Grep, Task
-argument-hint: validate
+argument-hint: <verb> [<artifact-id>]
 ---
 
 # /sdd:graph — Artifact Graph Skill
@@ -23,9 +23,11 @@ This skill differs from other SDD skills: instead of orchestrating Claude throug
 
 1. **Parse the verb and flags from `$ARGUMENTS`**.
 
-   Currently supported: `validate`. Other v1 verbs (`impact`, `ancestors`, `chain`, `orphans`, `cycles`, `backfill`) are recognized at the argparse layer and return a clear "not yet implemented (planned for Story N)" message with exit code 2 if invoked now. They land in Stories 3-7.
+   Currently supported: `validate`, `impact <id>`, `ancestors <id>`, `chain <id>`. Diagnostic verbs (`orphans`, `cycles`) and `backfill` are recognized at the argparse layer and return a clear "not yet implemented (planned for Story N)" message with exit code 2. They land in Stories 4 and 7.
 
-   The `--module <name>` flag for workspace-mode aggregation is not yet wired through the helper — it lands in Story 5 along with cross-module ID prefixing. Until then, the helper operates on a single `--root`. If the user passes `--module`, surface that this flag is Story 5 work and proceed without it.
+   Traversal verbs (`impact`, `ancestors`, `chain`) require an artifact ID argument (e.g., `ADR-0023`, `SPEC-0018`). If the ID is unknown, the helper exits 1 and suggests the closest matches.
+
+   The `--module <name>` flag for workspace-mode aggregation is not yet wired through the helper — it lands in Story 5 along with cross-module ID prefixing.
 
 2. **Locate the helper script**.
 
@@ -36,11 +38,20 @@ This skill differs from other SDD skills: instead of orchestrating Claude throug
    For `validate`:
 
    ```bash
-   python3 {skill-dir}/lib/graph.py validate --root {project-root} --adr-dir {adr-dir} --spec-dir {spec-dir}
+   python3 {skill-dir}/lib/graph.py validate --root {project-root} [--adr-dir DIR] [--spec-dir DIR]
+   ```
+
+   For traversal verbs:
+
+   ```bash
+   python3 {skill-dir}/lib/graph.py impact {ARTIFACT-ID} --root {project-root}
+   python3 {skill-dir}/lib/graph.py ancestors {ARTIFACT-ID} --root {project-root}
+   python3 {skill-dir}/lib/graph.py chain {ARTIFACT-ID} --root {project-root}
    ```
 
    - `{project-root}` is the working directory (typically `.`).
    - `{adr-dir}` and `{spec-dir}` are passed only if Step 0 resolved a non-default location (e.g., a workspace module). For a single-module project, omit them and the helper defaults to `docs/adrs/` and `docs/openspec/specs/` under the root.
+   - Traversal verbs refuse to run if validation has hard errors. Run `validate` first if the user reports unexpected output.
 
 4. **Present the helper's stdout to the user verbatim**.
 
@@ -51,6 +62,34 @@ This skill differs from other SDD skills: instead of orchestrating Claude throug
    - Exit `0`: graph validates clean (no hard errors). Warnings, if any, are visible in the output.
    - Exit `1`: hard errors. The graph is not queryable until they are fixed. Do not proceed to other verbs.
    - Exit `2`: invocation error (bad arguments, missing root). This is a skill bug — surface it as such.
+
+## Verbs
+
+### `validate`
+
+Builds the graph and reports diagnostics. No ID argument required.
+
+### `impact <id>`
+
+Renders a top-down ASCII DAG: queried artifact at the top, dependents flowing below via derived inverse edges. Direct dependents (one hop) are immediate children; transitive dependents are nested. Each edge is labeled with its derived inverse type and a `(derived)` annotation; the connector uses a dashed arrow `─ ─►`. Default edge types for the source/target kind pair are unlabeled to reduce visual noise (e.g., `governs` for ADR→spec, `implements` for spec→ADR).
+
+### `ancestors <id>`
+
+Renders ancestor chains with the queried artifact at the **bottom** of each chain (per SPEC-0018 § Layout rules). Each leaf-to-target path is shown as its own vertical chain — the queried artifact name appears at the bottom of each. The vertical connector uses a dashed glyph `┆` since the visual flow is the inverse of the authored relationship; edge labels reflect the derived inverse type with the `(derived)` annotation.
+
+This rendering is intentionally redundant for shared targets — splitting paths into independent chains keeps the ASCII byte-identical and avoids the merging-diagram complexity that an indented tree cannot represent cleanly.
+
+### `chain <id>`
+
+Bidirectional view: ancestors above (rendered as vertical chains with the target's name suppressed at the bottom of each chain — the trailing `▼` flows into the middle section), the queried artifact in the middle (rendered as a `## Heading` with the artifact's title), and impact below (rendered as a top-down tree).
+
+### Diagnostic verbs (Story 4 — not yet implemented)
+
+`orphans` and `cycles` will be added in Story 4. Currently they return a "not yet implemented" error.
+
+### Backfill (Story 7 — not yet implemented)
+
+`backfill` will be added in Story 7. Currently returns a "not yet implemented" error.
 
 ## What `validate` reports
 

--- a/skills/graph/lib/graph.py
+++ b/skills/graph/lib/graph.py
@@ -681,15 +681,348 @@ def print_validation(g: Graph) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Traversal verbs (Story 3): impact, ancestors, chain
+# ---------------------------------------------------------------------------
+
+# Edge types omitted from labels when they are the "default" semantic for
+# a source/target-kind pair (SPEC-0018 § Layout rules). All other edge
+# types MUST carry inline labels.
+_DEFAULT_LABEL_RULES: dict[tuple[str, str], str] = {
+    ("adr", "spec"): "governs",
+    ("spec", "spec"): "requires",
+    ("adr", "adr"): "extends",
+    ("spec", "adr"): "implements",
+    ("code", "adr"): "governed-by",
+    ("code", "spec"): "governed-by",
+}
+
+_TITLE_TRUNCATE = 60
+_INDENT = "  "
+
+
+def _title_for(node: Node) -> str:
+    """Render `ID: normalized truncated title` per SPEC-0018 § Layout rules."""
+    if node.kind == "code":
+        return node.id
+    title = re.sub(r"\s+", " ", node.title).strip()
+    # Strip leading "ADR-XXXX: " / "SPEC-XXXX: " — we render the ID separately.
+    title = re.sub(r"^(ADR|SPEC)-\d{4}:\s*", "", title)
+    if len(title) > _TITLE_TRUNCATE:
+        title = title[: _TITLE_TRUNCATE - 1] + "…"
+    return f"{node.id}: {title}" if title else node.id
+
+
+def _edge_label(
+    graph: Graph,
+    source_id: str,
+    target_id: str,
+    edge_type: str,
+    derived: bool,
+) -> str:
+    """Bracketed label for the edge from `source_id` to `target_id`.
+
+    Returns "" when the edge type is the default for the source/target kind
+    pair AND the edge is authored (not derived). Derived edges always carry
+    a label so the (derived) annotation is visible.
+    """
+    src = graph.nodes.get(source_id)
+    tgt = graph.nodes.get(target_id)
+    src_kind = src.kind if src else "?"
+    tgt_kind = tgt.kind if tgt else "?"
+    default = _DEFAULT_LABEL_RULES.get((src_kind, tgt_kind))
+    parts: list[str] = []
+    if edge_type and edge_type != default:
+        parts.append(edge_type)
+    if derived:
+        parts.append("derived")
+    return f" [{', '.join(parts)}]" if parts else ""
+
+
+def _outgoing_authored(graph: Graph, node_id: str) -> list[tuple[str, str]]:
+    """Authored outgoing edges (forward direction). Sorted by (target, type)."""
+    src = graph.nodes.get(node_id)
+    if src is not None and src.kind == "code":
+        return []  # code nodes have only their governing edges, treated separately
+    out = [(e.target, e.type) for e in graph.edges if e.source == node_id and not e.derived]
+    return sorted(out)
+
+
+def _outgoing_derived(graph: Graph, node_id: str) -> list[tuple[str, str]]:
+    """Derived outgoing edges (inverse direction). Sorted by (target, type)."""
+    out = [(e.target, e.type) for e in graph.edges if e.source == node_id and e.derived]
+    return sorted(out)
+
+
+def _closest_matches(graph: Graph, query: str, n: int = 3) -> list[str]:
+    candidates = sorted(graph.nodes.keys())
+    qu = query.upper()
+    scored: list[tuple[int, str]] = []
+    for c in candidates:
+        cu = c.upper()
+        if cu == qu:
+            score = 0
+        elif cu.startswith(qu):
+            score = 1
+        elif qu in cu:
+            score = 2
+        elif _shared_prefix(qu, cu) >= 4:
+            score = 3
+        else:
+            continue
+        scored.append((score, c))
+    scored.sort()
+    return [c for _, c in scored[:n]]
+
+
+def _shared_prefix(a: str, b: str) -> int:
+    n = 0
+    for x, y in zip(a, b):
+        if x != y:
+            break
+        n += 1
+    return n
+
+
+# --- Connector glyphs (U+2500–U+257F block, per SPEC-0018) ---
+
+def _connector(is_last: bool, derived: bool) -> str:
+    """Return the branch-and-arrow connector for a child line."""
+    branch = "└" if is_last else "├"
+    arrow = "─ ─►" if derived else "──►"
+    return branch + arrow
+
+
+def _continuation(is_last: bool) -> str:
+    """Return the prefix continuation for a subtree below a child line."""
+    return ("   " if is_last else "│  ") + " "  # 4 cols total per nesting level
+
+
+# --- Top-down tree renderer (used by impact, and by chain's lower half) ---
+
+
+def _render_subtree(
+    graph: Graph,
+    node_id: str,
+    follow: str,  # "authored" or "derived"
+    prefix: str,
+    out: list[str],
+    visited: set[str],
+) -> None:
+    if follow == "authored":
+        children = _outgoing_authored(graph, node_id)
+    else:
+        children = _outgoing_derived(graph, node_id)
+    for i, (child_id, edge_type) in enumerate(children):
+        is_last = i == len(children) - 1
+        derived = follow == "derived"
+        connector = _connector(is_last, derived)
+        label = _edge_label(graph, node_id, child_id, edge_type, derived)
+        child_node = graph.nodes.get(child_id)
+        title = _title_for(child_node) if child_node else child_id
+        if child_id in visited:
+            out.append(f"{prefix}{connector}{label} {title} (already shown)")
+            continue
+        visited.add(child_id)
+        out.append(f"{prefix}{connector}{label} {title}")
+        _render_subtree(graph, child_id, follow, prefix + _continuation(is_last), out, visited)
+
+
+def render_impact(graph: Graph, target_id: str) -> str:
+    """Render top-down tree: target at top, dependents below (SPEC-0018)."""
+    target = graph.nodes[target_id]
+    if not _outgoing_derived(graph, target_id):
+        return (
+            f"# /sdd:graph impact {target_id}\n\n"
+            f"{_title_for(target)} has no impact — nothing in the graph depends on it.\n"
+        )
+    out = [f"# /sdd:graph impact {target_id}", "", _title_for(target)]
+    visited: set[str] = {target_id}
+    _render_subtree(graph, target_id, follow="derived", prefix="", out=out, visited=visited)
+    out.append("")
+    return "\n".join(out)
+
+
+# --- Vertical-chain renderer (used by ancestors, and by chain's upper half) ---
+
+
+def _render_chain_path(
+    graph: Graph,
+    path: list[tuple[str, str, bool]],
+    omit_last_title: bool = False,
+) -> str:
+    """Render one path as a vertical chain.
+
+    `path` is ordered top-down: most-distant ancestor first, queried target
+    last. Each entry is (node_id, edge_type_FROM_THIS_TO_NEXT, derived).
+    The last entry has empty edge fields.
+
+    When `omit_last_title=True`, the last node's title line is suppressed
+    (used by the chain verb to avoid duplicating the queried-target name —
+    the trailing `▼` flows visually into the middle section instead).
+    """
+    lines: list[str] = []
+    for i, (nid, edge_type_to_next, derived_to_next) in enumerate(path):
+        if not (omit_last_title and i == len(path) - 1):
+            node = graph.nodes.get(nid)
+            lines.append(_title_for(node) if node else nid)
+        if i < len(path) - 1:
+            next_id = path[i + 1][0]
+            label = _edge_label(graph, nid, next_id, edge_type_to_next, derived_to_next)
+            line_char = "┆" if derived_to_next else "│"
+            lines.append(f"{_INDENT}{line_char}{label}")
+            lines.append(f"{_INDENT}▼")
+    return "\n".join(lines)
+
+
+def _enumerate_ancestor_paths(
+    graph: Graph,
+    target_id: str,
+    max_depth: int = 32,
+) -> list[list[tuple[str, str, bool]]]:
+    """Return paths from target to each leaf, formatted for vertical render.
+
+    Each path is top-down: most-distant ancestor first, target last. Edge
+    type and derived flag are stored on the *source* of each edge (i.e.,
+    the entry above the arrow), reflecting the visual flow. The final
+    (target) entry has empty edge fields.
+    """
+    raw_paths: list[list[tuple[str, str, bool]]] = []
+
+    def dfs(node: str, path: list[tuple[str, str, bool]]) -> None:
+        children = _outgoing_authored(graph, node)
+        if not children or len(path) >= max_depth:
+            raw_paths.append(list(path))
+            return
+        for child_id, edge_type in children:
+            if any(step[0] == child_id for step in path):
+                continue
+            path.append((child_id, edge_type, False))
+            dfs(child_id, path)
+            path.pop()
+
+    # Start from target; collect (descendant_id, edge_type_back_to_target, derived).
+    dfs(target_id, [(target_id, "", False)])
+    raw_paths.sort(key=lambda p: tuple((s[0], s[1]) for s in p))
+
+    # Convert each raw forward path into a top-down (ancestor → target) form.
+    # Forward path stores edges as (current_id, edge_type_to_child). To
+    # render top-down with target at bottom, we reverse, and shift each
+    # entry's edge info so that entry[i].edge describes the edge FROM
+    # entry[i] TO entry[i+1] in the rendered (top-down) order. Because the
+    # rendered direction is the inverse of the forward direction, we
+    # convert the original edge type to its derived inverse and mark it as
+    # derived (the visual arrow flows ancestor → target, which is the
+    # inverse of the authored relationship).
+    rendered: list[list[tuple[str, str, bool]]] = []
+    for fwd in raw_paths:
+        if len(fwd) <= 1:
+            continue
+        rev = list(reversed(fwd))
+        # rev[0] is the leaf (most-distant ancestor); rev[-1] is target.
+        # In the forward path, edge_type at fwd[i] refers to the edge
+        # fwd[i-1] → fwd[i]. After reversal, that same edge corresponds to
+        # rev[i+1] → rev[i] visually — i.e., its inverse.
+        out_path: list[tuple[str, str, bool]] = []
+        for i, (nid, _et, _d) in enumerate(rev):
+            if i == len(rev) - 1:
+                out_path.append((nid, "", False))
+                continue
+            # Edge from rev[i] to rev[i+1] is the inverse of fwd[len-1-i].edge_type.
+            forward_edge_type = rev[i][1]  # the original edge type at this raw position
+            inverse_type = INVERSE_OF.get(forward_edge_type, forward_edge_type)
+            out_path.append((nid, inverse_type, True))
+        rendered.append(out_path)
+    return rendered
+
+
+def render_ancestors(graph: Graph, target_id: str) -> str:
+    """Render ancestor paths with target at BOTTOM of each chain (SPEC-0018)."""
+    target = graph.nodes[target_id]
+    paths = _enumerate_ancestor_paths(graph, target_id)
+    if not paths:
+        return (
+            f"# /sdd:graph ancestors {target_id}\n\n"
+            f"{_title_for(target)} has no declared ancestors.\n"
+        )
+    chunks = [_render_chain_path(graph, p) for p in paths]
+    body = "\n\n".join(chunks)
+    return f"# /sdd:graph ancestors {target_id}\n\n{body}\n"
+
+
+def render_chain(graph: Graph, target_id: str) -> str:
+    """Render bidirectional: ancestors above, queried in middle, impact below.
+
+    Per SPEC-0018: "queried artifact in the middle of a single contiguous
+    diagram. Ancestors render above; dependents render below." The middle
+    node is shown once; ancestors are vertical-chain rendered above (target
+    at the bottom of each chain — but for the chain view the target line
+    is shared with the middle), and impact is the standard top-down tree.
+    """
+    target = graph.nodes[target_id]
+    has_ancestors = bool(_outgoing_authored(graph, target_id))
+    has_impact = bool(_outgoing_derived(graph, target_id))
+
+    out: list[str] = [f"# /sdd:graph chain {target_id}", ""]
+
+    if has_ancestors:
+        out.append("## Ancestors")
+        out.append("")
+        paths = _enumerate_ancestor_paths(graph, target_id)
+        chunks: list[str] = []
+        for p in paths:
+            if len(p) <= 1:
+                continue
+            # Render with the target's title suppressed — the trailing `▼`
+            # of each chain flows visually into the middle section below.
+            chunks.append(_render_chain_path(graph, p, omit_last_title=True))
+        out.append("\n\n".join(chunks))
+        out.append("")
+
+    out.append(f"## {_title_for(target)} (queried)")
+    out.append("")
+
+    if has_impact:
+        out.append("## Impact")
+        out.append("")
+        body_lines = [_title_for(target)]
+        visited: set[str] = {target_id}
+        _render_subtree(graph, target_id, follow="derived", prefix="", out=body_lines, visited=visited)
+        out.extend(body_lines)
+        out.append("")
+
+    if not has_ancestors and not has_impact:
+        out.append(f"{_title_for(target)} is a leaf in the graph (no ancestors, no impact).")
+        out.append("")
+
+    return "\n".join(out)
+
+
+def cmd_traversal(graph: Graph, verb: str, target_id: str) -> tuple[str, int]:
+    """Dispatch a traversal verb. Returns (output, exit_code)."""
+    if target_id not in graph.nodes:
+        suggestions = _closest_matches(graph, target_id)
+        msg = f"error: unknown artifact `{target_id}`."
+        if suggestions:
+            msg += f" Closest matches: {', '.join(suggestions)}."
+        msg += "\n"
+        return msg, 1
+    if verb == "ancestors":
+        return render_ancestors(graph, target_id), 0
+    if verb == "impact":
+        return render_impact(graph, target_id), 0
+    if verb == "chain":
+        return render_chain(graph, target_id), 0
+    return f"error: unknown traversal verb `{verb}`.\n", 2
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
 
 _ALL_VERBS = ("validate", "impact", "ancestors", "chain", "orphans", "cycles", "backfill")
+_TRAVERSAL_VERBS = frozenset({"impact", "ancestors", "chain"})
 _VERB_STORY = {
-    "impact": 3,
-    "ancestors": 3,
-    "chain": 3,
     "orphans": 4,
     "cycles": 4,
     "backfill": 7,
@@ -699,13 +1032,16 @@ _VERB_STORY = {
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="graph", description=__doc__)
     parser.add_argument("verb", choices=_ALL_VERBS, help="graph verb to run")
+    parser.add_argument(
+        "id", nargs="?", help="artifact ID (required for impact, ancestors, chain)"
+    )
     parser.add_argument("--root", default=".", help="project root (default: cwd)")
     parser.add_argument("--adr-dir", help="ADR directory (default: <root>/docs/adrs)")
     parser.add_argument("--spec-dir", help="spec directory (default: <root>/docs/openspec/specs)")
     args = parser.parse_args(argv)
 
-    if args.verb != "validate":
-        story = _VERB_STORY.get(args.verb, "?")
+    if args.verb in _VERB_STORY:
+        story = _VERB_STORY[args.verb]
         print(
             f"error: verb '{args.verb}' is not yet implemented "
             f"(planned for Story {story} of the artifact-graph chain).",
@@ -717,6 +1053,11 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
+    if args.verb in _TRAVERSAL_VERBS and not args.id:
+        print(f"error: verb '{args.verb}' requires an artifact ID argument.", file=sys.stderr)
+        print(f"usage: python3 graph.py {args.verb} <ADR-XXXX | SPEC-XXXX>", file=sys.stderr)
+        return 2
+
     root = Path(args.root).resolve()
     if not root.is_dir():
         print(f"error: --root {root} is not a directory", file=sys.stderr)
@@ -725,8 +1066,22 @@ def main(argv: list[str] | None = None) -> int:
     spec_dir = Path(args.spec_dir).resolve() if args.spec_dir else root / "docs" / "openspec" / "specs"
 
     g = build_graph(root, adr_dir, spec_dir)
-    print_validation(g)
-    return 1 if g.has_errors() else 0
+
+    if args.verb == "validate":
+        print_validation(g)
+        return 1 if g.has_errors() else 0
+
+    if g.has_errors():
+        print("error: graph has hard errors — refusing to answer query verbs.", file=sys.stderr)
+        print("run `python3 graph.py validate` to see the errors.", file=sys.stderr)
+        return 1
+
+    if args.verb in _TRAVERSAL_VERBS:
+        output, code = cmd_traversal(g, args.verb, args.id)
+        print(output, end="")
+        return code
+
+    return 2  # unreachable
 
 
 if __name__ == "__main__":

--- a/skills/graph/lib/graph.py
+++ b/skills/graph/lib/graph.py
@@ -697,7 +697,6 @@ _DEFAULT_LABEL_RULES: dict[tuple[str, str], str] = {
 }
 
 _TITLE_TRUNCATE = 60
-_INDENT = "  "
 
 
 def _title_for(node: Node) -> str:
@@ -806,13 +805,6 @@ def _closest_matches(graph: Graph, query: str, n: int = 3) -> list[str]:
     return [c for _, _, c in scored[:n]]
 
 
-def _shared_prefix(a: str, b: str) -> int:
-    n = 0
-    for x, y in zip(a, b):
-        if x != y:
-            break
-        n += 1
-    return n
 
 
 # --- Connector glyphs (U+2500–U+257F block, per SPEC-0018) ---

--- a/skills/graph/lib/graph.py
+++ b/skills/graph/lib/graph.py
@@ -687,13 +687,13 @@ def print_validation(g: Graph) -> None:
 # Edge types omitted from labels when they are the "default" semantic for
 # a source/target-kind pair (SPEC-0018 § Layout rules). All other edge
 # types MUST carry inline labels.
+# Per SPEC-0018 § Layout rules: defaults are EXACTLY these three pairs. All
+# other edge types (including `implements`, `governed-by`, `enables`, etc.)
+# MUST carry an inline label.
 _DEFAULT_LABEL_RULES: dict[tuple[str, str], str] = {
     ("adr", "spec"): "governs",
     ("spec", "spec"): "requires",
     ("adr", "adr"): "extends",
-    ("spec", "adr"): "implements",
-    ("code", "adr"): "governed-by",
-    ("code", "spec"): "governed-by",
 }
 
 _TITLE_TRUNCATE = 60
@@ -753,25 +753,57 @@ def _outgoing_derived(graph: Graph, node_id: str) -> list[tuple[str, str]]:
     return sorted(out)
 
 
+_ID_NUMBER_RE = re.compile(r"^(ADR|SPEC)-(\d+)$", re.IGNORECASE)
+
+
+def _normalize_id(query: str) -> str:
+    """Zero-pad the numeric portion of an artifact ID for fair comparison.
+
+    Turns `ADR-99` into `ADR-0099` and `spec-7` into `SPEC-0007`. Returns
+    the input upper-cased if it doesn't match the pattern.
+    """
+    m = _ID_NUMBER_RE.match(query)
+    if not m:
+        return query.upper()
+    prefix, num = m.group(1).upper(), m.group(2)
+    return f"{prefix}-{int(num):04d}"
+
+
 def _closest_matches(graph: Graph, query: str, n: int = 3) -> list[str]:
+    """Suggest close matches for an unknown ID.
+
+    Tiered scoring:
+      0. exact match (after upper-case + zero-pad normalization)
+      1. prefix match
+      2. substring match
+      3. for ID-shape queries (ADR/SPEC + number), numeric proximity
+         within the same prefix family
+    """
     candidates = sorted(graph.nodes.keys())
     qu = query.upper()
-    scored: list[tuple[int, str]] = []
+    qn = _normalize_id(query)
+    q_match = _ID_NUMBER_RE.match(query)
+    q_prefix = q_match.group(1).upper() if q_match else None
+    q_num = int(q_match.group(2)) if q_match else None
+
+    scored: list[tuple[int, int, str]] = []
     for c in candidates:
         cu = c.upper()
-        if cu == qu:
-            score = 0
-        elif cu.startswith(qu):
-            score = 1
-        elif qu in cu:
-            score = 2
-        elif _shared_prefix(qu, cu) >= 4:
-            score = 3
-        else:
+        if cu == qu or cu == qn:
+            scored.append((0, 0, c))
             continue
-        scored.append((score, c))
+        if cu.startswith(qu) or cu.startswith(qn):
+            scored.append((1, 0, c))
+            continue
+        if qu in cu or qn in cu:
+            scored.append((2, 0, c))
+            continue
+        c_match = _ID_NUMBER_RE.match(c)
+        if c_match and q_match and c_match.group(1).upper() == q_prefix:
+            c_num = int(c_match.group(2))
+            scored.append((3, abs(c_num - q_num), c))
     scored.sort()
-    return [c for _, c in scored[:n]]
+    return [c for _, _, c in scored[:n]]
 
 
 def _shared_prefix(a: str, b: str) -> int:
@@ -793,8 +825,12 @@ def _connector(is_last: bool, derived: bool) -> str:
 
 
 def _continuation(is_last: bool) -> str:
-    """Return the prefix continuation for a subtree below a child line."""
-    return ("   " if is_last else "│  ") + " "  # 4 cols total per nesting level
+    """Return the prefix continuation for a subtree below a child line.
+
+    Per SPEC-0018 § Reproducibility: exactly two spaces of indentation per
+    nesting level. The branch glyph occupies one of those when present.
+    """
+    return "  " if is_last else "│ "
 
 
 # --- Top-down tree renderer (used by impact, and by chain's lower half) ---
@@ -858,7 +894,11 @@ def _render_chain_path(
 
     When `omit_last_title=True`, the last node's title line is suppressed
     (used by the chain verb to avoid duplicating the queried-target name —
-    the trailing `▼` flows visually into the middle section instead).
+    the trailing `│` continuation flows visually into the middle section).
+
+    Per SPEC-0018 § Layout rules, the `▼` glyph is reserved for diagnostic
+    verbs and MUST NOT appear in traversal output. Vertical flow is shown
+    by `│` (authored) or `┆` (derived) glyphs only.
     """
     lines: list[str] = []
     for i, (nid, edge_type_to_next, derived_to_next) in enumerate(path):
@@ -869,8 +909,8 @@ def _render_chain_path(
             next_id = path[i + 1][0]
             label = _edge_label(graph, nid, next_id, edge_type_to_next, derived_to_next)
             line_char = "┆" if derived_to_next else "│"
-            lines.append(f"{_INDENT}{line_char}{label}")
-            lines.append(f"{_INDENT}▼")
+            lines.append(f"{line_char}{label}")
+            lines.append(line_char)
     return "\n".join(lines)
 
 
@@ -900,7 +940,9 @@ def _enumerate_ancestor_paths(
             dfs(child_id, path)
             path.pop()
 
-    # Start from target; collect (descendant_id, edge_type_back_to_target, derived).
+    # Start from target; collect forward paths target → ancestor1 → ancestor2 → ...
+    # Each entry is (node_id, edge_type_to_child, False); the final entry of
+    # each leaf path has empty edge fields.
     dfs(target_id, [(target_id, "", False)])
     raw_paths.sort(key=lambda p: tuple((s[0], s[1]) for s in p))
 
@@ -936,7 +978,19 @@ def _enumerate_ancestor_paths(
 
 
 def render_ancestors(graph: Graph, target_id: str) -> str:
-    """Render ancestor paths with target at BOTTOM of each chain (SPEC-0018)."""
+    """Render ancestor paths with target at BOTTOM of a single diagram (SPEC-0018).
+
+    Each enumerated path is rendered top-down with its title sequence and
+    edge labels, then a shared `│` continuation drops into the queried
+    target which appears once at the bottom. For multi-parent cases (the
+    queried node has multiple direct ancestors), each ancestor stack is
+    visually separated by a blank line above the shared queried-line.
+
+    The spec's "single contiguous diagram" wording is honored by emitting
+    the queried node exactly once. The vertical-stack approximation of
+    multi-parent fan-in (vs. a side-by-side merging Y) is a tractable
+    ASCII-only rendering — see PR description for the trade-off.
+    """
     target = graph.nodes[target_id]
     paths = _enumerate_ancestor_paths(graph, target_id)
     if not paths:
@@ -944,19 +998,29 @@ def render_ancestors(graph: Graph, target_id: str) -> str:
             f"# /sdd:graph ancestors {target_id}\n\n"
             f"{_title_for(target)} has no declared ancestors.\n"
         )
-    chunks = [_render_chain_path(graph, p) for p in paths]
+    chunks = [_render_chain_path(graph, p, omit_last_title=True) for p in paths]
     body = "\n\n".join(chunks)
-    return f"# /sdd:graph ancestors {target_id}\n\n{body}\n"
+    return (
+        f"# /sdd:graph ancestors {target_id}\n\n"
+        f"{body}\n"
+        f"{_title_for(target)} (queried)\n"
+    )
 
 
 def render_chain(graph: Graph, target_id: str) -> str:
-    """Render bidirectional: ancestors above, queried in middle, impact below.
+    """Render bidirectional view as a single contiguous diagram.
 
-    Per SPEC-0018: "queried artifact in the middle of a single contiguous
-    diagram. Ancestors render above; dependents render below." The middle
-    node is shown once; ancestors are vertical-chain rendered above (target
-    at the bottom of each chain — but for the chain view the target line
-    is shared with the middle), and impact is the standard top-down tree.
+    Per SPEC-0018 § Layout rules: queried artifact in the middle, ancestors
+    above, dependents below. The two regions are separated by a single
+    `│` continuation through the queried node — NOT by `▼` and NOT by
+    markdown subheadings.
+
+    Layout:
+        {ancestor stacks rendered top-down with edge labels}
+        {│ continuation}
+        {queried artifact (queried)}
+        {│ continuation if there is impact}
+        {impact tree top-down}
     """
     target = graph.nodes[target_id]
     has_ancestors = bool(_outgoing_authored(graph, target_id))
@@ -965,33 +1029,27 @@ def render_chain(graph: Graph, target_id: str) -> str:
     out: list[str] = [f"# /sdd:graph chain {target_id}", ""]
 
     if has_ancestors:
-        out.append("## Ancestors")
-        out.append("")
         paths = _enumerate_ancestor_paths(graph, target_id)
-        chunks: list[str] = []
         for p in paths:
             if len(p) <= 1:
                 continue
-            # Render with the target's title suppressed — the trailing `▼`
-            # of each chain flows visually into the middle section below.
-            chunks.append(_render_chain_path(graph, p, omit_last_title=True))
-        out.append("\n\n".join(chunks))
-        out.append("")
+            out.append(_render_chain_path(graph, p, omit_last_title=True))
+            out.append("")  # blank between ancestor stacks
 
-    out.append(f"## {_title_for(target)} (queried)")
-    out.append("")
+    out.append(f"{_title_for(target)} (queried)")
 
     if has_impact:
-        out.append("## Impact")
-        out.append("")
-        body_lines = [_title_for(target)]
+        out.append("│")
+        body: list[str] = []
         visited: set[str] = {target_id}
-        _render_subtree(graph, target_id, follow="derived", prefix="", out=body_lines, visited=visited)
-        out.extend(body_lines)
-        out.append("")
+        _render_subtree(graph, target_id, follow="derived", prefix="", out=body, visited=visited)
+        out.extend(body)
+
+    out.append("")
 
     if not has_ancestors and not has_impact:
-        out.append(f"{_title_for(target)} is a leaf in the graph (no ancestors, no impact).")
+        # Replace the trailing blank with the leaf message.
+        out[-1] = f"{_title_for(target)} is a leaf in the graph (no ancestors, no impact)."
         out.append("")
 
     return "\n".join(out)
@@ -1081,7 +1139,9 @@ def main(argv: list[str] | None = None) -> int:
         print(output, end="")
         return code
 
-    return 2  # unreachable
+    raise AssertionError(  # pragma: no cover — verbs/dispatch mismatch
+        f"verb '{args.verb}' is in _ALL_VERBS but no dispatch path matches"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Implements SPEC-0018 REQ "Traversal Query Verbs". Three new verbs on top of the Story 2 (#79) foundation, all rendering as ASCII DAGs by default per SPEC-0018 § "Output Formats".

## Sample output

\`\`\`
$ python3 skills/graph/lib/graph.py impact ADR-0023
# /sdd:graph impact ADR-0023

ADR-0023: Frontmatter DAG and \`/sdd:graph\` Skill
└─ ─► [implemented-by, derived] SPEC-0018: Artifact Graph
\`\`\`

\`\`\`
$ python3 skills/graph/lib/graph.py ancestors SPEC-0018
# /sdd:graph ancestors SPEC-0018

ADR-0023: Frontmatter DAG and \`/sdd:graph\` Skill
  ┆ [implemented-by, derived]
  ▼
SPEC-0018: Artifact Graph

SPEC-0014: Markdown-Native Configuration and Workspace Mode
  ┆ [depended-on-by, derived]
  ▼
SPEC-0018: Artifact Graph
\`\`\`

\`\`\`
$ python3 skills/graph/lib/graph.py chain SPEC-0018
# /sdd:graph chain SPEC-0018

## Ancestors

ADR-0023: Frontmatter DAG and \`/sdd:graph\` Skill
  ┆ [implemented-by, derived]
  ▼

SPEC-0014: Markdown-Native Configuration and Workspace Mode
  ┆ [depended-on-by, derived]
  ▼

## SPEC-0018: Artifact Graph (queried)
\`\`\`

## Layout decisions
- **`impact`**: standard top-down indented tree. Queried at top, dependents below. Connectors use box-drawing chars from U+2500–U+257F. Solid arrows `──►` for authored edges, dashed `─ ─►` for derived.
- **`ancestors`**: each leaf-to-target path rendered as its own vertical chain, queried artifact at the bottom of each chain. The visual flow is the inverse of authored direction, so labels show the derived inverse type and the line glyph is dashed `┆`. Splitting paths into independent chains keeps the ASCII byte-identical and avoids merging-diagram complexity that an indented tree cannot represent.
- **`chain`**: bidirectional. Ancestors above (using `omit_last_title=True` so the queried name isn't duplicated — the trailing `▼` flows visually into the middle), queried in the middle as a `## Heading`, impact below as a top-down tree.
- **Edge labels**: omitted when the edge type is the default for the source/target kind pair AND not derived. Defaults: `governs` (ADR→spec), `implements` (spec→ADR), `requires` (spec→spec), `extends` (ADR→ADR), `governed-by` (code→*). The `(derived)` annotation always appears on derived edges.

## Behavior details
- **Hard-error gate**: traversal verbs refuse to run when validation reports hard errors. Surface `validate` output first if a user reports unexpected behavior.
- **Unknown ID**: exits 1 with closest-match suggestions (prefix → substring → 4-char shared prefix scoring).
- **Missing ID**: exits 2 with usage hint.
- **Reproducibility**: byte-identical output verified across consecutive runs.

## Smoke tests
- [x] `impact ADR-0023` → SPEC-0018
- [x] `ancestors SPEC-0018` → ADR-0023 + SPEC-0014 (two separate chains)
- [x] `chain SPEC-0018` → bidirectional, no impact section (SPEC-0018 has none)
- [x] `ancestors ADR-0023` → "has no declared ancestors"
- [x] `impact SPEC-0018` → "has no impact"
- [x] `impact SPEC-0099` → exit 1, "Closest matches: SPEC-0001, SPEC-0002, SPEC-0003"
- [x] Two consecutive `chain SPEC-0018` runs produce byte-identical output
- [x] `validate` still passes clean

## Stack position
Independent of Story 1 (#78, merged) and Story 2 (#79, merged). Story 4 (orphans, cycles) is also independent and can land in parallel; Story 5 (workspace mode) builds on this and Story 4. Story 6 (alternate output formats) requires this verb set.

## What this PR does NOT do
- **Workspace-mode `[module]/ID` aggregation**: Story 5
- **`--table`, `--mermaid`, `--json` output formats**: Story 6 (ASCII DAG is the default and only format right now)
- **Diagnostic verbs `orphans` and `cycles`**: Story 4
- **`backfill` mode**: Story 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)