### PR TITLE
Story 4: /sdd:graph diagnostic verbs (orphans, cycles)

### DIFF
--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -87,11 +87,13 @@ Single contiguous bidirectional diagram: ancestors above (rendered as top-down c
 
 Surfaces three categories of orphan as flat markdown tables (default for flat results per SPEC-0018):
 
-1. **Source files without governing artifacts** — code nodes whose governing comment block referenced no resolvable artifact ID. Currently rare since unresolved IDs already fail validation as a hard error.
+1. **Source files without governing artifacts** — non-markdown source files in the project tree that contain no `Governing:` comment block. Discovered by a dedicated walk so these files do not become graph nodes (they remain invisible to traversal queries) but DO surface here. The walk uses the same exclusions as the graph builder (`.git`, `node_modules`, `vendor`, build/cache dirs, `docs/`, `skills/`, `references/`, etc.). Markdown files are skipped — they participate via frontmatter (ADRs, specs) or are out of scope for v1 (READMEs, ad-hoc docs).
 2. **Specs with no implementing code** — specs that no source file's governing comment references.
 3. **ADRs with no implementing spec** — ADRs that no spec declares `implements:` against.
 
 Optional `--scope <subtree>` restricts category 1 to source files under the given path. Categories 2 and 3 always cover the full graph.
+
+**Operator-facing framing.** A spec is flagged whenever no `Governing:` comment in source code references it; comment-less code is invisible by design (per SPEC-0018 § "Files without governing comments"). For repos that haven't yet attached governing comments to source code, expect every spec and ADR to be flagged. The output includes a one-line preamble explaining this so first-time readers know the verb is working as intended, not reporting a real catastrophe.
 
 ### `cycles`
 

--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -2,9 +2,9 @@
 
 ---
 name: graph
-description: Build and query the SDD artifact graph. Use when the user wants to validate frontmatter edges, find impact/ancestors/chain for an ADR or spec, detect orphans or cycles, or backfill edges from prose. Currently supports validate / impact / ancestors / chain; orphans/cycles/backfill land in later stories.
+description: Build and query the SDD artifact graph. Use when the user wants to validate frontmatter edges, find impact/ancestors/chain for an ADR or spec, detect orphans or cycles, or backfill edges from prose. Currently supports validate / impact / ancestors / chain / orphans / cycles; backfill lands in Story 7.
 allowed-tools: Bash, Read, Glob, Grep, Task
-argument-hint: <verb> [<artifact-id>]
+argument-hint: <verb> [<artifact-id>] [--scope <subtree>]
 ---
 
 # /sdd:graph — Artifact Graph Skill
@@ -83,9 +83,19 @@ The vertical-stack approximation of multi-parent fan-in (vs. a side-by-side merg
 
 Single contiguous bidirectional diagram: ancestors above (rendered as top-down chains with the target's title suppressed at the bottom of each), the queried artifact in the middle (rendered once as `<title> (queried)`), and impact below (rendered as a top-down indented tree). The two regions are visually joined by a single `│` continuation through the queried node — no markdown subheadings, no `▼` glyphs.
 
-### Diagnostic verbs (Story 4 — not yet implemented)
+### `orphans`
 
-`orphans` and `cycles` will be added in Story 4. Currently they return a "not yet implemented" error.
+Surfaces three categories of orphan as flat markdown tables (default for flat results per SPEC-0018):
+
+1. **Source files without governing artifacts** — code nodes whose governing comment block referenced no resolvable artifact ID. Currently rare since unresolved IDs already fail validation as a hard error.
+2. **Specs with no implementing code** — specs that no source file's governing comment references.
+3. **ADRs with no implementing spec** — ADRs that no spec declares `implements:` against.
+
+Optional `--scope <subtree>` restricts category 1 to source files under the given path. Categories 2 and 3 always cover the full graph.
+
+### `cycles`
+
+Lists any cycles detected during validation. Note: traversal/diagnostic verbs only run after validation passes (the hard-error gate in `main()`), so this verb's output in v1 is always "No cycles detected." The verb exists for tooling that wants to confirm cycle-freeness without running full validation.
 
 ### Backfill (Story 7 — not yet implemented)
 

--- a/skills/graph/lib/graph.py
+++ b/skills/graph/lib/graph.py
@@ -1066,15 +1066,171 @@ def cmd_traversal(graph: Graph, verb: str, target_id: str) -> tuple[str, int]:
 
 
 # ---------------------------------------------------------------------------
+# Diagnostic verbs (Story 4): orphans, cycles
+# ---------------------------------------------------------------------------
+
+
+def cmd_orphans(graph: Graph, scope: str | None = None) -> str:
+    """Render orphan diagnostic per SPEC-0018 REQ "Diagnostic Query Verbs".
+
+    Three orphan categories:
+      a. Source files with no governing comment block — represented by code
+         nodes already in the graph; we surface them when they have no
+         `governed-by` outgoing edges (which would mean their governing
+         comments referenced no resolvable artifacts). NOTE: Story 2's
+         walker only adds code nodes that already contain governing
+         comment blocks, so this category is currently always empty.
+         Truly comment-less files are invisible to the graph today; a
+         future story may walk the entire tree to surface them.
+      b. Specs with no implementing source files — specs that have no
+         derived `governed-by` inverse edges from any code node.
+      c. ADRs with no implementing spec — ADRs that have no derived
+         `implemented-by` inverse edges from any spec.
+
+    Output is a flat markdown table per SPEC-0018 (default for flat
+    results). Optional `scope` filter restricts category (a) to files
+    under the given subtree.
+    """
+    out: list[str] = ["# /sdd:graph orphans", ""]
+
+    code_orphans = _orphan_code(graph, scope)
+    spec_orphans = _orphan_specs(graph)
+    adr_orphans = _orphan_adrs(graph)
+
+    if not (code_orphans or spec_orphans or adr_orphans):
+        out.append("No orphans detected.")
+        out.append("")
+        return "\n".join(out)
+
+    if code_orphans:
+        out.append("## Source files without governing artifacts")
+        out.append("")
+        out.append("| File |")
+        out.append("|------|")
+        for path in code_orphans:
+            out.append(f"| `{path}` |")
+        out.append("")
+
+    if spec_orphans:
+        out.append("## Specs with no implementing code")
+        out.append("")
+        out.append("| Spec | Title |")
+        out.append("|------|-------|")
+        for spec_id in spec_orphans:
+            node = graph.nodes[spec_id]
+            title = _title_for(node).split(": ", 1)[1] if ": " in _title_for(node) else ""
+            out.append(f"| {spec_id} | {title} |")
+        out.append("")
+
+    if adr_orphans:
+        out.append("## ADRs with no implementing spec")
+        out.append("")
+        out.append("| ADR | Title |")
+        out.append("|-----|-------|")
+        for adr_id in adr_orphans:
+            node = graph.nodes[adr_id]
+            title = _title_for(node).split(": ", 1)[1] if ": " in _title_for(node) else ""
+            out.append(f"| {adr_id} | {title} |")
+        out.append("")
+
+    return "\n".join(out)
+
+
+def _orphan_code(graph: Graph, scope: str | None) -> list[str]:
+    """Source files in the graph whose governing comments resolve to nothing.
+
+    Code nodes are added by the walker only when they contain a governing
+    comment block, so the orphan candidates here are the small subset
+    where the comment exists but referenced no resolvable artifact ID.
+    """
+    orphans: list[str] = []
+    for node_id, node in sorted(graph.nodes.items()):
+        if node.kind != "code":
+            continue
+        if scope and not node_id.startswith(scope.rstrip("/") + "/") and node_id != scope:
+            continue
+        # A code node is an orphan if it has no outgoing governed-by edges
+        # (which would happen if all its comment-referenced IDs were
+        # unresolvable — already a hard error from validation).
+        outgoing = [e for e in graph.edges if e.source == node_id and not e.derived]
+        if not outgoing:
+            orphans.append(node_id)
+    return orphans
+
+
+def _orphan_specs(graph: Graph) -> list[str]:
+    """Specs that no code file governs (no derived governed-by from code)."""
+    orphans: list[str] = []
+    for node_id, node in sorted(graph.nodes.items()):
+        if node.kind != "spec":
+            continue
+        # An implementing edge would be a derived `governed-by` from a code
+        # node TO this spec; equivalently, an authored `governed-by` edge
+        # whose target is this spec from a code-kind source.
+        has_code_impl = any(
+            e.target == node_id
+            and e.type == "governed-by"
+            and graph.nodes.get(e.source) is not None
+            and graph.nodes[e.source].kind == "code"
+            for e in graph.edges
+        )
+        if not has_code_impl:
+            orphans.append(node_id)
+    return orphans
+
+
+def _orphan_adrs(graph: Graph) -> list[str]:
+    """ADRs that no spec implements (no authored implements TO this ADR)."""
+    orphans: list[str] = []
+    for node_id, node in sorted(graph.nodes.items()):
+        if node.kind != "adr":
+            continue
+        has_spec_impl = any(
+            e.target == node_id
+            and e.type == "implements"
+            and not e.derived
+            and graph.nodes.get(e.source) is not None
+            and graph.nodes[e.source].kind == "spec"
+            for e in graph.edges
+        )
+        if not has_spec_impl:
+            orphans.append(node_id)
+    return orphans
+
+
+def cmd_cycles(graph: Graph) -> str:
+    """List any cycles detected during validation.
+
+    Per SPEC-0018: "If validation passed, returns an empty result."
+    Note that this verb runs only after validation passes (the main()
+    hard-error gate). Therefore the output is always "No cycles detected."
+    in v1 — cycles would have already failed validation. The verb exists
+    primarily for tooling that wants to confirm cycle-freeness without
+    running full validation.
+    """
+    cycles = [d for d in graph.diagnostics if d.code == "cycle"]
+    out = ["# /sdd:graph cycles", ""]
+    if not cycles:
+        out.append("No cycles detected.")
+        out.append("")
+        return "\n".join(out)
+    out.append("| Cycle |")
+    out.append("|-------|")
+    for d in cycles:
+        out.append(f"| {d.message} |")
+    out.append("")
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
 
 _ALL_VERBS = ("validate", "impact", "ancestors", "chain", "orphans", "cycles", "backfill")
 _TRAVERSAL_VERBS = frozenset({"impact", "ancestors", "chain"})
+_DIAGNOSTIC_VERBS = frozenset({"orphans", "cycles"})
 _VERB_STORY = {
-    "orphans": 4,
-    "cycles": 4,
     "backfill": 7,
 }
 
@@ -1088,6 +1244,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--root", default=".", help="project root (default: cwd)")
     parser.add_argument("--adr-dir", help="ADR directory (default: <root>/docs/adrs)")
     parser.add_argument("--spec-dir", help="spec directory (default: <root>/docs/openspec/specs)")
+    parser.add_argument("--scope", help="restrict orphan code-file detection to a subtree")
     args = parser.parse_args(argv)
 
     if args.verb in _VERB_STORY:
@@ -1130,6 +1287,13 @@ def main(argv: list[str] | None = None) -> int:
         output, code = cmd_traversal(g, args.verb, args.id)
         print(output, end="")
         return code
+
+    if args.verb == "orphans":
+        print(cmd_orphans(g, scope=args.scope), end="")
+        return 0
+    if args.verb == "cycles":
+        print(cmd_cycles(g), end="")
+        return 0
 
     raise AssertionError(  # pragma: no cover — verbs/dispatch mismatch
         f"verb '{args.verb}' is in _ALL_VERBS but no dispatch path matches"

--- a/skills/graph/lib/graph.py
+++ b/skills/graph/lib/graph.py
@@ -306,9 +306,40 @@ def discover_code_edges(root: Path, excludes: frozenset[str] = _DEFAULT_CODE_EXC
     whose first 4096 bytes contain a governing-comment block. Markdown files
     are skipped — they participate via frontmatter, not governing comments.
     """
-    out: list[tuple[Path, list[str]]] = []
+    edges, _ = _walk_code_files(root, excludes)
+    return edges
+
+
+def discover_orphan_code(
+    root: Path, excludes: frozenset[str] = _DEFAULT_CODE_EXCLUDES
+) -> list[Path]:
+    """Walk `root` and return code files with NO governing-comment block.
+
+    Per SPEC-0018 § "Files without governing comments": these files MUST
+    NOT become graph nodes (so they remain invisible to traversal queries)
+    but MUST surface via the `orphans` verb. This walker uses the same
+    exclusions as `discover_code_edges` for consistency.
+
+    "Code files" excludes markdown (`.md`, `.markdown`) — markdown
+    participates via frontmatter, not governing comments. It also
+    excludes binary files (any file whose head doesn't decode as UTF-8).
+    """
+    _, orphans = _walk_code_files(root, excludes)
+    return orphans
+
+
+def _walk_code_files(
+    root: Path, excludes: frozenset[str]
+) -> tuple[list[tuple[Path, list[str]]], list[Path]]:
+    """Single tree walk that returns both governed-edge files and orphan files.
+
+    Returns (edges, orphans):
+      - edges: list of (path, ids) for files with governing comment blocks
+      - orphans: list of paths for files without governing comment blocks
+    """
+    edges: list[tuple[Path, list[str]]] = []
+    orphans: list[Path] = []
     for dirpath, dirnames, filenames in os.walk(root):
-        # Prune excluded and hidden directories in-place.
         dirnames[:] = sorted(
             d for d in dirnames if d not in excludes and not d.startswith(".")
         )
@@ -325,13 +356,36 @@ def discover_code_edges(root: Path, excludes: frozenset[str] = _DEFAULT_CODE_EXC
                 text = head.decode("utf-8", errors="ignore")
             except UnicodeDecodeError:
                 continue
-            m = _GOVERNING_RE.search(text)
-            if not m:
+            # Skip files that look binary (high non-printable ratio).
+            if _looks_binary(head):
                 continue
-            ids = sorted(set(_GOVERNING_ID_RE.findall(m.group(1))))
-            if ids:
-                out.append((path, ids))
-    return sorted(out, key=lambda t: str(t[0]))
+            m = _GOVERNING_RE.search(text)
+            if m:
+                ids = sorted(set(_GOVERNING_ID_RE.findall(m.group(1))))
+                if ids:
+                    edges.append((path, ids))
+                else:
+                    # Block exists but referenced no IDs — treat as comment-less
+                    # for orphan purposes.
+                    orphans.append(path)
+            else:
+                orphans.append(path)
+    return (
+        sorted(edges, key=lambda t: str(t[0])),
+        sorted(orphans),
+    )
+
+
+def _looks_binary(head: bytes) -> bool:
+    """Heuristic: a NUL byte or a high non-text ratio implies binary."""
+    if b"\x00" in head:
+        return True
+    if not head:
+        return False
+    # text characters: tab, LF, CR, form feed, printable ASCII, plus any UTF-8
+    # continuation bytes (0x80-0xff).
+    text_chars = sum(1 for b in head if b == 9 or b == 10 or b == 13 or 32 <= b < 127 or b >= 128)
+    return text_chars / len(head) < 0.85
 
 
 # ---------------------------------------------------------------------------
@@ -1070,22 +1124,23 @@ def cmd_traversal(graph: Graph, verb: str, target_id: str) -> tuple[str, int]:
 # ---------------------------------------------------------------------------
 
 
-def cmd_orphans(graph: Graph, scope: str | None = None) -> str:
+def cmd_orphans(graph: Graph, root: Path, scope: str | None = None) -> str:
     """Render orphan diagnostic per SPEC-0018 REQ "Diagnostic Query Verbs".
 
     Three orphan categories:
-      a. Source files with no governing comment block — represented by code
-         nodes already in the graph; we surface them when they have no
-         `governed-by` outgoing edges (which would mean their governing
-         comments referenced no resolvable artifacts). NOTE: Story 2's
-         walker only adds code nodes that already contain governing
-         comment blocks, so this category is currently always empty.
-         Truly comment-less files are invisible to the graph today; a
-         future story may walk the entire tree to surface them.
-      b. Specs with no implementing source files — specs that have no
-         derived `governed-by` inverse edges from any code node.
-      c. ADRs with no implementing spec — ADRs that have no derived
-         `implemented-by` inverse edges from any spec.
+      a. Source files with no governing comment block — found via a fresh
+         walk of `root` (using the same exclusions as the graph builder).
+         These files are NOT graph nodes, per SPEC-0018: they remain
+         invisible to traversal queries and surface only here.
+      b. Specs with no implementing source files — specs that no code
+         file's governing comment references.
+      c. ADRs with no implementing spec — ADRs that no spec declares
+         `implements:` against.
+
+    A spec-or-ADR is flagged whenever no `Governing:` comment in source
+    code references it; comment-less code is invisible by design (per
+    the spec scenario). For repos that don't yet attach governing
+    comments to source code, expect every spec and ADR to be flagged.
 
     Output is a flat markdown table per SPEC-0018 (default for flat
     results). Optional `scope` filter restricts category (a) to files
@@ -1093,7 +1148,7 @@ def cmd_orphans(graph: Graph, scope: str | None = None) -> str:
     """
     out: list[str] = ["# /sdd:graph orphans", ""]
 
-    code_orphans = _orphan_code(graph, scope)
+    code_orphans = _orphan_code(graph, root, scope)
     spec_orphans = _orphan_specs(graph)
     adr_orphans = _orphan_adrs(graph)
 
@@ -1102,13 +1157,21 @@ def cmd_orphans(graph: Graph, scope: str | None = None) -> str:
         out.append("")
         return "\n".join(out)
 
+    out.append(
+        "Orphans surface artifacts that have no traceability link to code: a spec is "
+        "flagged whenever no `Governing:` comment in source code references it, "
+        "and an ADR is flagged whenever no spec declares `implements:` against it. "
+        "Source files without governing comments are listed separately."
+    )
+    out.append("")
+
     if code_orphans:
         out.append("## Source files without governing artifacts")
         out.append("")
         out.append("| File |")
         out.append("|------|")
         for path in code_orphans:
-            out.append(f"| `{path}` |")
+            out.append(f"| `{_md_escape(path)}` |")
         out.append("")
 
     if spec_orphans:
@@ -1118,8 +1181,7 @@ def cmd_orphans(graph: Graph, scope: str | None = None) -> str:
         out.append("|------|-------|")
         for spec_id in spec_orphans:
             node = graph.nodes[spec_id]
-            title = _title_for(node).split(": ", 1)[1] if ": " in _title_for(node) else ""
-            out.append(f"| {spec_id} | {title} |")
+            out.append(f"| {spec_id} | {_md_escape(_node_title_only(node))} |")
         out.append("")
 
     if adr_orphans:
@@ -1129,33 +1191,45 @@ def cmd_orphans(graph: Graph, scope: str | None = None) -> str:
         out.append("|-----|-------|")
         for adr_id in adr_orphans:
             node = graph.nodes[adr_id]
-            title = _title_for(node).split(": ", 1)[1] if ": " in _title_for(node) else ""
-            out.append(f"| {adr_id} | {title} |")
+            out.append(f"| {adr_id} | {_md_escape(_node_title_only(node))} |")
         out.append("")
 
     return "\n".join(out)
 
 
-def _orphan_code(graph: Graph, scope: str | None) -> list[str]:
-    """Source files in the graph whose governing comments resolve to nothing.
+def _node_title_only(node: Node) -> str:
+    """Return the truncated normalized title without the leading ID prefix."""
+    full = _title_for(node)
+    if ": " in full:
+        return full.split(": ", 1)[1]
+    return ""
 
-    Code nodes are added by the walker only when they contain a governing
-    comment block, so the orphan candidates here are the small subset
-    where the comment exists but referenced no resolvable artifact ID.
+
+def _md_escape(s: str) -> str:
+    """Escape `|` and backslash for safe inclusion in markdown table cells."""
+    return s.replace("\\", "\\\\").replace("|", "\\|")
+
+
+def _orphan_code(graph: Graph, root: Path, scope: str | None) -> list[str]:
+    """Code files without a governing comment block, per SPEC-0018.
+
+    These files are NOT graph nodes (the builder skips files with no
+    `Governing:` block to keep traversal queries clean). The walk runs
+    fresh here so the verb can surface comment-less files independent of
+    what's already in the graph.
+
+    `scope` filters results to a subtree. Empty / `.` / `./` / leading
+    `./` are all normalized to "include everything."
     """
-    orphans: list[str] = []
-    for node_id, node in sorted(graph.nodes.items()):
-        if node.kind != "code":
+    paths = discover_orphan_code(root)
+    scope_clean = (scope or "").lstrip("./").rstrip("/")
+    rel_paths: list[str] = []
+    for p in paths:
+        rel = str(p.relative_to(root)) if p.is_relative_to(root) else str(p)
+        if scope_clean and not (rel == scope_clean or rel.startswith(scope_clean + "/")):
             continue
-        if scope and not node_id.startswith(scope.rstrip("/") + "/") and node_id != scope:
-            continue
-        # A code node is an orphan if it has no outgoing governed-by edges
-        # (which would happen if all its comment-referenced IDs were
-        # unresolvable — already a hard error from validation).
-        outgoing = [e for e in graph.edges if e.source == node_id and not e.derived]
-        if not outgoing:
-            orphans.append(node_id)
-    return orphans
+        rel_paths.append(rel)
+    return rel_paths
 
 
 def _orphan_specs(graph: Graph) -> list[str]:
@@ -1229,7 +1303,6 @@ def cmd_cycles(graph: Graph) -> str:
 
 _ALL_VERBS = ("validate", "impact", "ancestors", "chain", "orphans", "cycles", "backfill")
 _TRAVERSAL_VERBS = frozenset({"impact", "ancestors", "chain"})
-_DIAGNOSTIC_VERBS = frozenset({"orphans", "cycles"})
 _VERB_STORY = {
     "backfill": 7,
 }
@@ -1289,7 +1362,7 @@ def main(argv: list[str] | None = None) -> int:
         return code
 
     if args.verb == "orphans":
-        print(cmd_orphans(g, scope=args.scope), end="")
+        print(cmd_orphans(g, root=root, scope=args.scope), end="")
         return 0
     if args.verb == "cycles":
         print(cmd_cycles(g), end="")


### PR DESCRIPTION
## Summary
Implements SPEC-0018 REQ "Diagnostic Query Verbs". Two flat-result verbs that operate over the entire graph (or a subtree via `--scope`).

## What lands

**`orphans`** — surfaces three orphan categories as markdown tables (default for flat results per SPEC-0018):
1. **Source files without governing artifacts** — code nodes whose governing comment block referenced no resolvable artifact ID
2. **Specs with no implementing code** — specs that no source file's governing comment references
3. **ADRs with no implementing spec** — ADRs that no spec declares `implements:` against

Optional `--scope <subtree>` restricts category 1 to source files under the given path.

**`cycles`** — lists cycle diagnostics from validation. Always empty in v1 since traversal/diagnostic verbs only run after the hard-error gate. Documented as a tooling hook for cycle-freeness confirmation.

## Sample output (this repo)

\`\`\`
$ python3 skills/graph/lib/graph.py orphans
# /sdd:graph orphans

## Specs with no implementing code

| Spec | Title |
|------|-------|
| SPEC-0001 | Drift Introspection Skills |
| SPEC-0002 | Initialization and Context Priming |
... (18 specs)

## ADRs with no implementing spec

| ADR | Title |
|-----|-------|
| ADR-0001 | Add Drift and Introspection Skills for Design Artifact Vali… |
... (22 ADRs — every ADR except 0023, since SPEC-0018 is the only spec
     currently carrying an `implements:` declaration)
\`\`\`

The 18 specs and 22 ADRs in the orphan output will be reduced to 0 (or near-zero) once Story 8 runs `/sdd:graph backfill` and lands the proposed `implements:` / `governs:` / `requires:` declarations across the existing artifacts.

\`\`\`
$ python3 skills/graph/lib/graph.py cycles
# /sdd:graph cycles

No cycles detected.
\`\`\`

## Test plan
- [x] `orphans` lists 18 specs + 22 ADRs as orphans (matches expected pre-backfill state)
- [x] `cycles` returns "No cycles detected." after validation passes
- [x] `validate` still passes clean (regression check)
- [x] Byte-identical reproducibility confirmed across consecutive runs
- [x] `--scope` flag accepted; manual scope filter test (no code orphans in this repo so the filter is a no-op)
- [x] Markdown table output uses fenced default (no `--table` needed; that's Story 6's flag)

## Stack position
Independent of Story 3 (#80, merged) — both branched off main after Story 2. Story 5 (workspace mode) and Story 6 (output formats) extend this. Story 7 (backfill) is independent.

## What this PR does NOT do
- **JSON / Mermaid / `--table` output formats**: Story 6 (orphans is markdown-table by default; only flat-result default is implemented here)
- **Workspace-mode `[module]` prefixing**: Story 5 (orphans output currently has no module column)
- **`backfill`**: Story 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)