### PR TITLE
Story 8: Run /sdd:graph backfill on the SDD repo (+ traversal hygiene)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs-site/.docusaurus/
 templates/docs-generated/
 __pycache__/
 *.pyc
+.sdd-graph-backfill-skip

--- a/docs/adrs/ADR-0002-init-and-context-priming-skill.md
+++ b/docs/adrs/ADR-0002-init-and-context-priming-skill.md
@@ -2,6 +2,7 @@
 status: accepted
 date: 2026-02-14
 decision-makers: Plugin maintainers
+related: [ADR-0001]
 ---
 
 # ADR-0002: Add Initialization and Context-Priming Skills to the SDD Plugin

--- a/docs/adrs/ADR-0003-foundational-skills-and-artifact-formats.md
+++ b/docs/adrs/ADR-0003-foundational-skills-and-artifact-formats.md
@@ -2,6 +2,7 @@
 status: accepted
 date: 2026-02-14
 decision-makers: Plugin maintainers
+related: [ADR-0001, ADR-0002]
 ---
 
 # ADR-0003: Foundational Design Artifact Formats and Core Skills

--- a/docs/adrs/ADR-0005-codebase-discovery-skill.md
+++ b/docs/adrs/ADR-0005-codebase-discovery-skill.md
@@ -2,6 +2,7 @@
 status: accepted
 date: 2026-02-14
 decision-makers: Joe Stump, Plugin maintainers
+related: [ADR-0001, ADR-0003]
 ---
 
 # ADR-0005: Add a Codebase Discovery Skill for Reverse-Engineering Design Artifacts

--- a/docs/adrs/ADR-0007-tasks-md-fallback-for-trackerless-projects.md
+++ b/docs/adrs/ADR-0007-tasks-md-fallback-for-trackerless-projects.md
@@ -2,6 +2,8 @@
 status: accepted
 date: 2026-02-20
 decision-makers: joestump
+governs: [SPEC-0006]
+related: [ADR-0003]
 ---
 
 # ADR-0007: Generate tasks.md as openspec artifact when no issue tracker is available

--- a/docs/adrs/ADR-0008-standalone-sprint-planning-skill.md
+++ b/docs/adrs/ADR-0008-standalone-sprint-planning-skill.md
@@ -2,6 +2,8 @@
 status: accepted
 date: 2026-02-20
 decision-makers: joestump
+governs: [SPEC-0007]
+related: [ADR-0003, ADR-0007]
 ---
 
 # ADR-0008: Standalone Sprint Planning Skill

--- a/docs/adrs/ADR-0009-project-grouping-and-developer-workflow-conventions.md
+++ b/docs/adrs/ADR-0009-project-grouping-and-developer-workflow-conventions.md
@@ -2,6 +2,9 @@
 status: accepted
 date: 2026-02-20
 decision-makers: joestump
+extends: [ADR-0008]
+governs: [SPEC-0007]
+related: [ADR-0003]
 ---
 
 # ADR-0009: Project Grouping and Developer Workflow Conventions

--- a/docs/adrs/ADR-0010-parallel-pr-review-and-response-skill.md
+++ b/docs/adrs/ADR-0010-parallel-pr-review-and-response-skill.md
@@ -2,6 +2,8 @@
 status: accepted
 date: 2026-02-20
 decision-makers: joestump
+extends: [ADR-0009]
+related: [ADR-0008]
 ---
 
 # ADR-0010: Parallel PR Review and Response Skill

--- a/docs/adrs/ADR-0011-story-sized-issue-granularity.md
+++ b/docs/adrs/ADR-0011-story-sized-issue-granularity.md
@@ -2,6 +2,8 @@
 status: accepted
 date: 2026-02-21
 decision-makers: joestump
+extends: [ADR-0008, ADR-0009]
+governs: [SPEC-0007]
 ---
 
 # ADR-0011: Story-Sized Issue Granularity

--- a/docs/adrs/ADR-0012-project-workspace-enrichment.md
+++ b/docs/adrs/ADR-0012-project-workspace-enrichment.md
@@ -2,6 +2,8 @@
 status: accepted
 date: 2026-02-21
 decision-makers: joestump
+extends: [ADR-0009, ADR-0011]
+related: [ADR-0008]
 ---
 
 # ADR-0012: Project Workspace Enrichment

--- a/docs/adrs/ADR-0013-scrum-mode-for-plan.md
+++ b/docs/adrs/ADR-0013-scrum-mode-for-plan.md
@@ -2,6 +2,9 @@
 status: accepted
 date: 2026-02-28
 decision-makers: joestump
+extends: [ADR-0008, ADR-0009]
+governs: [SPEC-0012]
+related: [ADR-0011, ADR-0012]
 ---
 
 # ADR-0013: Scrum Mode for `/sdd:plan` — Team-Groomed Sprint Planning

--- a/docs/adrs/ADR-0014-scrum-mode-for-audit.md
+++ b/docs/adrs/ADR-0014-scrum-mode-for-audit.md
@@ -2,6 +2,8 @@
 status: accepted
 date: 2026-03-01
 decision-makers: joestump
+governs: [SPEC-0001, SPEC-0013]
+related: [ADR-0001, ADR-0013]
 ---
 
 # ADR-0014: Scrum Mode for `/sdd:audit` — Team-Triaged Drift Remediation

--- a/docs/adrs/ADR-0015-markdown-native-configuration.md
+++ b/docs/adrs/ADR-0015-markdown-native-configuration.md
@@ -2,6 +2,8 @@
 status: proposed
 date: 2026-03-27
 decision-makers: joestump
+enables: [ADR-0016]
+governs: [SPEC-0014]
 ---
 
 # ADR-0015: Markdown-Native Configuration — Eliminate `.claude-plugin-design.json`

--- a/docs/adrs/ADR-0016-workspace-mode-multi-module-projects.md
+++ b/docs/adrs/ADR-0016-workspace-mode-multi-module-projects.md
@@ -2,6 +2,8 @@
 status: proposed
 date: 2026-03-27
 decision-makers: joestump
+governs: [SPEC-0014]
+related: [ADR-0015]
 ---
 
 # ADR-0016: Workspace Mode for Multi-Module Projects

--- a/docs/adrs/ADR-0017-parallel-agent-coordination-pr-stacking.md
+++ b/docs/adrs/ADR-0017-parallel-agent-coordination-pr-stacking.md
@@ -2,6 +2,8 @@
 status: proposed
 date: 2026-03-27
 decision-makers: joestump
+governs: [SPEC-0015]
+related: [ADR-0008, ADR-0009, ADR-0010, ADR-0015]
 ---
 
 # ADR-0017: Parallel Agent Coordination and PR Stacking

--- a/docs/adrs/ADR-0018-security-by-default-web-specs.md
+++ b/docs/adrs/ADR-0018-security-by-default-web-specs.md
@@ -2,6 +2,8 @@
 status: proposed
 date: 2026-03-27
 decision-makers: joestump
+governs: [SPEC-0016]
+related: [ADR-0001, ADR-0019]
 ---
 
 # ADR-0018: Security-by-Default for Web Specifications

--- a/docs/adrs/ADR-0019-frontend-quality-standards.md
+++ b/docs/adrs/ADR-0019-frontend-quality-standards.md
@@ -2,6 +2,8 @@
 status: proposed
 date: 2026-03-27
 decision-makers: joestump
+governs: [SPEC-0016]
+related: [ADR-0001, ADR-0017, ADR-0018]
 ---
 
 # ADR-0019: Frontend Quality Standards — Accessibility, Testing, and Template Quality Integrated into Existing Skills

--- a/docs/adrs/ADR-0020-governing-comment-reform.md
+++ b/docs/adrs/ADR-0020-governing-comment-reform.md
@@ -2,6 +2,7 @@
 status: proposed
 date: 2026-03-27
 decision-makers: joestump
+related: [ADR-0017]
 ---
 
 # ADR-0020: Governing Comment Reform

--- a/docs/adrs/ADR-0021-skill-evaluation-and-ci-testing.md
+++ b/docs/adrs/ADR-0021-skill-evaluation-and-ci-testing.md
@@ -2,6 +2,7 @@
 status: proposed
 date: 2026-03-27
 decision-makers: Joe Stump
+related: [ADR-0017, ADR-0018]
 ---
 
 # ADR-0021: Skill Evaluation and CI Testing Framework

--- a/docs/adrs/ADR-0023-frontmatter-dag-and-graph-skill.md
+++ b/docs/adrs/ADR-0023-frontmatter-dag-and-graph-skill.md
@@ -2,6 +2,7 @@
 status: accepted
 date: 2026-05-01
 decision-makers: Joe Stump
+related: [ADR-0001, ADR-0014, ADR-0015, ADR-0016, ADR-0020]
 ---
 
 # ADR-0023: Frontmatter DAG and `/sdd:graph` Skill

--- a/docs/openspec/specs/codebase-discovery/spec.md
+++ b/docs/openspec/specs/codebase-discovery/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0005]
+---
+
 # SPEC-0005: Codebase Discovery
 
 ## Overview

--- a/docs/openspec/specs/docs-generation/spec.md
+++ b/docs/openspec/specs/docs-generation/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0004, ADR-0006]
+---
+
 # SPEC-0004: Documentation Site Generation
 
 ## Overview

--- a/docs/openspec/specs/drift-introspection/spec.md
+++ b/docs/openspec/specs/drift-introspection/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0001]
+---
+
 # SPEC-0001: Drift Introspection Skills
 
 ## Overview

--- a/docs/openspec/specs/foundational-artifacts/spec.md
+++ b/docs/openspec/specs/foundational-artifacts/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0003]
+---
+
 # SPEC-0003: Foundational Design Artifact Formats and Core Skills
 
 ## Overview

--- a/docs/openspec/specs/init-and-priming/spec.md
+++ b/docs/openspec/specs/init-and-priming/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0002]
+---
+
 # SPEC-0002: Initialization and Context Priming
 
 ## Overview

--- a/docs/openspec/specs/markdown-native-config-and-workspace/spec.md
+++ b/docs/openspec/specs/markdown-native-config-and-workspace/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0015, ADR-0016]
+---
+
 # SPEC-0014: Markdown-Native Configuration and Workspace Mode
 
 ## Overview

--- a/docs/openspec/specs/parallel-agent-coordination/spec.md
+++ b/docs/openspec/specs/parallel-agent-coordination/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0017]
+---
+
 # SPEC-0015: Parallel Agent Coordination
 
 ## Overview

--- a/docs/openspec/specs/parallel-pr-review/spec.md
+++ b/docs/openspec/specs/parallel-pr-review/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0010]
+---
+
 # SPEC-0009: Parallel PR Review and Response
 
 ## Overview

--- a/docs/openspec/specs/project-workspace-enrichment/spec.md
+++ b/docs/openspec/specs/project-workspace-enrichment/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0011, ADR-0012]
+---
+
 # SPEC-0011: Project Workspace Enrichment
 
 ## Overview

--- a/docs/openspec/specs/retroactive-issue-management/spec.md
+++ b/docs/openspec/specs/retroactive-issue-management/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0009]
+---
+
 # SPEC-0008: Retroactive Issue Management
 
 ## Overview

--- a/docs/openspec/specs/scrum-mode-audit-triage/spec.md
+++ b/docs/openspec/specs/scrum-mode-audit-triage/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0014]
+---
+
 # SPEC-0013: Scrum Mode Audit Triage
 
 ## Overview

--- a/docs/openspec/specs/scrum-mode-sprint-planning/spec.md
+++ b/docs/openspec/specs/scrum-mode-sprint-planning/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0013]
+---
+
 # SPEC-0012: Scrum Mode Sprint Planning
 
 ## Overview

--- a/docs/openspec/specs/security-and-quality-guardrails/spec.md
+++ b/docs/openspec/specs/security-and-quality-guardrails/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0018, ADR-0019, ADR-0020]
+---
+
 # SPEC-0016: Security and Quality Guardrails
 
 ## Overview

--- a/docs/openspec/specs/skill-evaluation-and-ci-testing/spec.md
+++ b/docs/openspec/specs/skill-evaluation-and-ci-testing/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0021]
+---
+
 # SPEC-0017: Skill Evaluation and CI Testing
 
 ## Overview

--- a/docs/openspec/specs/sprint-planning/spec.md
+++ b/docs/openspec/specs/sprint-planning/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0008]
+---
+
 # SPEC-0007: Sprint Planning
 
 ## Overview

--- a/docs/openspec/specs/story-sized-issue-granularity/spec.md
+++ b/docs/openspec/specs/story-sized-issue-granularity/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0011]
+---
+
 # SPEC-0010: Story-Sized Issue Granularity
 
 ## Overview

--- a/docs/openspec/specs/tasks-md-fallback/spec.md
+++ b/docs/openspec/specs/tasks-md-fallback/spec.md
@@ -1,3 +1,7 @@
+---
+implements: [ADR-0007, ADR-0008]
+---
+
 # SPEC-0006: Tasks.md Fallback for Trackerless Projects
 
 ## Overview

--- a/skills/graph/lib/graph.py
+++ b/skills/graph/lib/graph.py
@@ -799,7 +799,23 @@ def _validate_id_resolution(g: Graph) -> None:
 
 
 def _validate_no_cycles(g: Graph) -> None:
-    """Detect cycles in DAG-required edge types via Tarjan-style DFS."""
+    """Detect cycles in DAG-required edge types via Tarjan-style DFS.
+
+    `governs` (ADR→SPEC) and `implements` (SPEC→ADR) are semantic inverses
+    describing the same relationship from opposite ends. Authoring both is
+    valid (and shown in SPEC-0018's own JSON example), but my detector
+    would otherwise treat the round-trip A→governs→B→implements→A as a
+    cycle. To honor dual authoring, an authored `governs` edge is omitted
+    from the cycle-detection adjacency when a matching authored `implements`
+    edge exists in the opposite direction; the implements edge alone
+    covers the relationship.
+    """
+    # Pre-compute the set of (spec, adr) pairs covered by authored `implements`.
+    implements_pairs: set[tuple[str, str]] = {
+        (e.source, e.target)
+        for e in g.edges
+        if e.type == "implements" and not e.derived
+    }
     # Build adjacency for acyclic-required edges only (ignores `related`).
     adj: dict[str, list[tuple[str, str]]] = {}
     for edge in g.edges:
@@ -807,6 +823,8 @@ def _validate_no_cycles(g: Graph) -> None:
             continue
         if edge.target not in g.nodes:
             continue  # already reported by id-resolution
+        if edge.type == "governs" and (edge.target, edge.source) in implements_pairs:
+            continue  # semantic-inverse pair already covered by implements
         adj.setdefault(edge.source, []).append((edge.target, edge.type))
 
     color: dict[str, int] = {}  # 0=white, 1=gray, 2=black
@@ -1020,17 +1038,35 @@ def _edge_label(
 
 
 def _outgoing_authored(graph: Graph, node_id: str) -> list[tuple[str, str]]:
-    """Authored outgoing edges (forward direction). Sorted by (target, type)."""
+    """Authored outgoing edges (forward direction). Sorted by (target, type).
+
+    Excludes `related` (weak association) — this edge type carries no
+    dependency semantics, so propagating through it during transitive
+    traversal produces noise without informational value. `related` edges
+    still appear in `validate`, `orphans`, and `--json` output; they're
+    just not walked by `impact`/`ancestors`/`chain`.
+    """
     src = graph.nodes.get(node_id)
     if src is not None and src.kind == "code":
         return []  # code nodes have only their governing edges, treated separately
-    out = [(e.target, e.type) for e in graph.edges if e.source == node_id and not e.derived]
+    out = [
+        (e.target, e.type) for e in graph.edges
+        if e.source == node_id and not e.derived and e.type != "related"
+    ]
     return sorted(out)
 
 
 def _outgoing_derived(graph: Graph, node_id: str) -> list[tuple[str, str]]:
-    """Derived outgoing edges (inverse direction). Sorted by (target, type)."""
-    out = [(e.target, e.type) for e in graph.edges if e.source == node_id and e.derived]
+    """Derived outgoing edges (inverse direction). Sorted by (target, type).
+
+    Excludes the symmetric `related` derived inverse for the same reason
+    as `_outgoing_authored`: weak associations don't carry dependency
+    semantics worth transitive traversal.
+    """
+    out = [
+        (e.target, e.type) for e in graph.edges
+        if e.source == node_id and e.derived and e.type != "related"
+    ]
     return sorted(out)
 
 


### PR DESCRIPTION
## Summary
Executes Story 8 — runs the freshly-shipped `/sdd:graph backfill` against this repo's 23 ADRs and 18 specs, applies the correct proposals, manually corrects three suspects, and rejects what shouldn't auto-apply. Also two small graph.py fixes that surfaced when the post-backfill graph became more dense.

## Backfill execution

**Spec applies (17 specs):** Each spec's Overview section already named its governing ADR — heuristic proposed correct `implements:` for all 17.

**ADR auto-applies (16 ADRs):**
- `related:` edges only — ADR-0002, ADR-0003, ADR-0005, ADR-0020, ADR-0021, ADR-0023
- `extends + related + governs` (correct as proposed) — ADR-0009, ADR-0010, ADR-0011, ADR-0012
- `governs + related` (correct) — ADR-0014, ADR-0015, ADR-0016, ADR-0017, ADR-0018, ADR-0019

**Manually corrected (3 ADRs):** Heuristic conflated "Related: ADR-X, SPEC-Y" prose with governance claims:
- **ADR-0007** (tasks.md fallback): proposed `governs: [SPEC-0003]` (false — SPEC-0003 belongs to ADR-0003). Edited to `governs: [SPEC-0006]` (the actual fallback spec).
- **ADR-0008** (sprint planning): proposed `governs: [SPEC-0006, SPEC-0007]`. SPEC-0006 belongs to ADR-0007. Edited to `governs: [SPEC-0007]` only.
- **ADR-0013** (scrum mode for plan): proposed governance over four pre-existing specs. ADR-0013 introduces only the new SPEC-0012. Edited accordingly.

Bad proposals recorded in `.sdd-graph-backfill-skip` so re-running `backfill` won't re-surface them. `.gitignore` adds the skip file per design.md guidance (operational state, not config).

## Final graph state
\`\`\`
- Nodes: 41 (ADRs + specs + governed code files)
- Authored edges: 79
- Derived edges: 77
- Errors: 0
- Warnings: 0
\`\`\`

22 ADR orphans → 0 (every ADR now has at least one implementing spec). 18 spec orphans remain (until source code in this repo grows governing comments — a separate effort).

## graph.py fixes uncovered by the densified graph

**1. Cycle detector treats `governs`/`implements` pair as one logical edge.** Per SPEC-0018's own JSON example, both directions of the same relationship may be authored. My detector flagged `A→governs→B→implements→A` as a 2-cycle (6 false-positive cycles after the first ADR batch). Fixed: when an authored `implements` covers a (spec, adr) pair, the matching `governs` edge is omitted from cycle-detection adjacency. Both edges still recorded; only the false cycle is suppressed.

**2. Traversal verbs no longer walk `related` transitively.** Per spec, `related` is "weak association, no semantic claim" — it shouldn't propagate dependency semantics in `impact`/`ancestors`/`chain`. With ~20 `related:` entries across the populated ADRs, `chain SPEC-0018` was enumerating thousands of paths through the ADR-0001 related-hub (80KB+ output). Fixed: `_outgoing_authored` and `_outgoing_derived` skip `related` edges. Direct neighbors via `related` still appear in `validate`, `orphans`, and `--json` — they're just not propagated.

## Sample output

\`\`\`
$ python3 skills/graph/lib/graph.py impact ADR-0008
ADR-0008: Standalone Sprint Planning Skill
├─ ─► [extended-by, derived] ADR-0009: Project Grouping and Developer Workflow Conventions
│ ├─ ─► [extended-by, derived] ADR-0010: Parallel PR Review and Response Skill
│ │ └─ ─► [implemented-by, derived] SPEC-0009: Parallel PR Review and Response
│ ├─ ─► [extended-by, derived] ADR-0011: Story-Sized Issue Granularity
│ │ ├─ ─► [extended-by, derived] ADR-0012: Project Workspace Enrichment
│ │ │ └─ ─► [implemented-by, derived] SPEC-0011: Project Workspace Enrichment
│ │ ├─ ─► [implemented-by, derived] SPEC-0010: Story-Sized Issue Granularity
│ │ └─ ─► [implemented-by, derived] SPEC-0011: Project Workspace Enrichment (already shown)
│ ├─ ─► [extended-by, derived] ADR-0013: Scrum Mode for \`/sdd:plan\` ... (truncated)
\`\`\`

The graph is now meaningfully queryable end-to-end.

## Test plan
- [x] `validate` clean (41 nodes, 79+77 edges, 0 errors)
- [x] `chain SPEC-0018` returns the meaningful direct ancestor (ADR-0023) + queried — was previously thousands of paths
- [x] `impact ADR-0008` produces a clean transitive tree with shared-node markers
- [x] `orphans` drops 22 ADR orphans → 0
- [x] All 17 specs declare `implements:` correctly
- [x] 3 manually-corrected ADRs have right `governs:` targets
- [x] `.sdd-graph-backfill-skip` populated with the 6 rejected (node, field, target) records
- [x] Re-running `backfill` returns "No proposals" (everything is now applied or skipped)

## Stack position
Final story in the artifact-graph chain. Branched off main after Story 7 (#84) merged. Closes the chain that started with #76 (planning) — eight implementation stories plus one independent uplift (Story 9, tracker inference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)