### PR TITLE
docs: add /sdd:graph to README and CLAUDE.md skill tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ This project uses the [SDD plugin](https://github.com/joestump/claude-plugin-sdd
 | `/sdd:enrich` | Add branch naming and PR conventions to existing issues |
 | `/sdd:work` | Pick up tracker issues and implement them in parallel using git worktrees |
 | `/sdd:review` | Review and merge PRs using reviewer-responder agent pairs |
+| `/sdd:graph` | Build and query the artifact graph (validate, impact, ancestors, chain, orphans, cycles, backfill) |
 
 Run `/sdd:prime [topic]` at the start of a session to load relevant ADRs and specs into context.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A Claude Code plugin for architecture governance: ADRs, specifications, sprint p
 | **Work** | `/sdd:work [SPEC-XXXX \| issue numbers \| (empty = propose from backlog)] [--max-agents N] [--draft] [--dry-run] [--no-tests] [--module <name>]` | Pick up tracker issues and implement them in parallel using git worktrees |
 | **Review** | `/sdd:review [SPEC-XXXX or PR numbers] [--pairs N] [--no-merge] [--dry-run] [--module <name>]` | Review and merge PRs using reviewer-responder agent pairs |
 | **Status** | `/sdd:status [ID] [status]` | Change the status of an ADR or spec |
+| **Graph** | `/sdd:graph <verb> [<artifact-id>] [--scope <subtree>] [--module <name>] [--table\|--mermaid\|--json]` | Build and query the artifact graph: `validate`, `impact`, `ancestors`, `chain`, `orphans`, `cycles`, `backfill`. ASCII DAG default; `--json` is the stable contract for downstream consumers |
 
 ## Install
 
@@ -42,7 +43,7 @@ Add to your project's `.claude/settings.json`:
 }
 ```
 
-Then restart Claude Code. The plugin's 15 skills will be available as `/sdd:init`, `/sdd:prime`, `/sdd:adr`, `/sdd:spec`, `/sdd:plan`, `/sdd:organize`, `/sdd:enrich`, `/sdd:work`, `/sdd:review`, `/sdd:check`, `/sdd:audit`, `/sdd:discover`, `/sdd:docs`, `/sdd:list`, and `/sdd:status`.
+Then restart Claude Code. The plugin's 16 skills will be available as `/sdd:init`, `/sdd:prime`, `/sdd:adr`, `/sdd:spec`, `/sdd:plan`, `/sdd:organize`, `/sdd:enrich`, `/sdd:work`, `/sdd:review`, `/sdd:check`, `/sdd:audit`, `/sdd:discover`, `/sdd:docs`, `/sdd:list`, `/sdd:status`, and `/sdd:graph`.
 
 ## Configuration
 

--- a/references/claude-md-template.md
+++ b/references/claude-md-template.md
@@ -24,6 +24,7 @@ This project uses the [SDD plugin](https://github.com/joestump/claude-plugin-sdd
 | `/sdd:enrich` | Add branch naming and PR conventions to existing issues |
 | `/sdd:work` | Pick up tracker issues and implement them in parallel using git worktrees |
 | `/sdd:review` | Review and merge PRs using reviewer-responder agent pairs |
+| `/sdd:graph` | Build and query the artifact graph (validate, impact, ancestors, chain, orphans, cycles, backfill) |
 
 Run `/sdd:prime [topic]` at the start of a session to load relevant ADRs and specs into context.
 


### PR DESCRIPTION
## Summary
The artifact-graph chain (#76 → #85) shipped `/sdd:graph` over 8 stories, but I missed updating the user-facing skill tables. This PR adds the missing row to both `README.md` and the project's own `CLAUDE.md`, and bumps the README's skill count from 15 to 16.

## What's NOT in scope
- Regenerating `docs-generated/` or `docs-site/` — those are gitignored and produced on-demand by `/sdd:docs`. A subsequent `/sdd:docs` run will pick up ADR-0023 and SPEC-0018 automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)