### PR TITLE
docs: add Architecture Graph page to /sdd:docs output

### DIFF
--- a/docs-site/scripts/build-docs.js
+++ b/docs-site/scripts/build-docs.js
@@ -24,6 +24,9 @@ require('./transform-adrs');
 // Generate index page
 require('./generate-index');
 
+// Generate graph page (artifact DAG from frontmatter, per ADR-0023 / SPEC-0018)
+require('./generate-graph');
+
 // Copy static content from content/ to docs-generated/
 const contentDir = path.join(__dirname, '../content');
 const docsDir = path.join(__dirname, '../../docs-generated');

--- a/docs-site/scripts/generate-graph.js
+++ b/docs-site/scripts/generate-graph.js
@@ -40,11 +40,15 @@ function generate() {
 
   const stripIdPrefix = (title, id) =>
     (title || '').replace(new RegExp(`^${id}:\\s*`), '');
-  const orphanAdrRows = orphanAdrs.length
-    ? orphanAdrs.map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`).join('\n')
+  const orphanAdrSection = orphanAdrs.length
+    ? `| ADR | Title |\n|-----|-------|\n${orphanAdrs
+        .map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`)
+        .join('\n')}`
     : '_No orphan ADRs — every ADR has at least one implementing spec._';
-  const orphanSpecRows = orphanSpecs.length
-    ? orphanSpecs.map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`).join('\n')
+  const orphanSpecSection = orphanSpecs.length
+    ? `| Spec | Title |\n|------|-------|\n${orphanSpecs
+        .map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`)
+        .join('\n')}`
     : '_No orphan specs — every spec is governed by at least one ADR._';
 
   const content = `---
@@ -78,17 +82,13 @@ ${mermaid}
 
 ADRs that no spec declares \`implements:\` against. Add an \`implements: [ADR-XXXX]\` line to a spec's frontmatter (or run \`/sdd:graph backfill\`) to remove an ADR from this list.
 
-| ADR | Title |
-|-----|-------|
-${orphanAdrRows}
+${orphanAdrSection}
 
 ## Orphan specs
 
 Specs that no ADR declares \`governs:\` against. (For specs whose source-code coverage is the relevant orphan signal, use \`/sdd:graph orphans\` directly — that walks source files for governing comments and is not reflected in this static page.)
 
-| Spec | Title |
-|------|-------|
-${orphanSpecRows}
+${orphanSpecSection}
 
 ## Querying the graph
 

--- a/docs-site/scripts/generate-graph.js
+++ b/docs-site/scripts/generate-graph.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Generate Graph Page
+ *
+ * Reads ADR and spec frontmatter (the artifact graph schema from
+ * ADR-0023 / SPEC-0018), produces a Docusaurus-ready Graph page with:
+ *   - graph stats (counts of nodes, authored edges, orphans)
+ *   - full-graph Mermaid flowchart
+ *   - orphan tables (ADRs without implementing spec, specs without
+ *     governing ADR)
+ *
+ * The authoritative graph implementation is `skills/graph/lib/graph.py`
+ * — this script is a static-page reflection that runs at docs-build
+ * time without bringing Python into the build pipeline.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { buildGraph, renderFullMermaid } = require('./graph-data');
+
+const ADRS_SOURCE = path.join(__dirname, '../../docs/adrs');
+const SPECS_SOURCE = path.join(__dirname, '../../docs/openspec/specs');
+const DOCS_DEST = path.join(__dirname, '../../docs-generated');
+
+function generate() {
+  const graph = buildGraph({ adrsSource: ADRS_SOURCE, specsSource: SPECS_SOURCE });
+  const { nodes, edges, orphanAdrs, orphanSpecs } = graph;
+
+  const adrCount = Object.values(nodes).filter((n) => n.kind === 'adr').length;
+  const specCount = Object.values(nodes).filter((n) => n.kind === 'spec').length;
+  const authoredEdges = edges.filter((e) => !e.derived);
+  const derivedEdges = edges.filter((e) => e.derived);
+
+  if (adrCount + specCount === 0) {
+    console.log('  Skipped graph page: no artifacts');
+    return;
+  }
+
+  const mermaid = renderFullMermaid(graph);
+
+  const stripIdPrefix = (title, id) =>
+    (title || '').replace(new RegExp(`^${id}:\\s*`), '');
+  const orphanAdrRows = orphanAdrs.length
+    ? orphanAdrs.map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`).join('\n')
+    : '_No orphan ADRs — every ADR has at least one implementing spec._';
+  const orphanSpecRows = orphanSpecs.length
+    ? orphanSpecs.map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`).join('\n')
+    : '_No orphan specs — every spec is governed by at least one ADR._';
+
+  const content = `---
+title: "Architecture Graph"
+sidebar_label: "Graph"
+sidebar_position: 1
+---
+
+# Architecture Graph
+
+The artifact graph captures explicit relationships between ADRs and specs declared in YAML frontmatter (per [ADR-0023](/decisions/0023-frontmatter-dag-and-graph-skill) and [SPEC-0018](/specs/artifact-graph/spec)). Edges describe \`supersedes\`, \`extends\`, \`enables\`, \`governs\`, \`implements\`, \`requires\`, and \`related\` relationships between artifacts. The page below reflects the authored edges only; derived inverses (\`governed-by\`, \`implemented-by\`, etc.) are computed at query time by the \`/sdd:graph\` skill.
+
+## Stats
+
+| Metric | Count |
+|--------|-------|
+| ADRs | ${adrCount} |
+| Specs | ${specCount} |
+| Authored edges | ${authoredEdges.length} |
+| Derived edges (computed) | ${derivedEdges.length} |
+| Orphan ADRs (no implementing spec) | ${orphanAdrs.length} |
+| Orphan specs (no governing ADR) | ${orphanSpecs.length} |
+
+## Full graph
+
+\`\`\`mermaid
+${mermaid}
+\`\`\`
+
+## Orphan ADRs
+
+ADRs that no spec declares \`implements:\` against. Add an \`implements: [ADR-XXXX]\` line to a spec's frontmatter (or run \`/sdd:graph backfill\`) to remove an ADR from this list.
+
+| ADR | Title |
+|-----|-------|
+${orphanAdrRows}
+
+## Orphan specs
+
+Specs that no ADR declares \`governs:\` against. (For specs whose source-code coverage is the relevant orphan signal, use \`/sdd:graph orphans\` directly — that walks source files for governing comments and is not reflected in this static page.)
+
+| Spec | Title |
+|------|-------|
+${orphanSpecRows}
+
+## Querying the graph
+
+The static view above is generated at docs-build time. For interactive queries:
+
+\`\`\`
+/sdd:graph validate                  # full diagnostics
+/sdd:graph impact ADR-XXXX           # what depends on this ADR
+/sdd:graph ancestors SPEC-XXXX       # what this spec depends on
+/sdd:graph chain SPEC-XXXX           # bidirectional view
+/sdd:graph orphans                   # source files, specs, ADRs
+/sdd:graph backfill                  # propose edges from prose
+\`\`\`
+
+JSON output (\`--json\`) is the stable contract for any future MCP, IDE plugin, or dashboard.
+`;
+
+  fs.mkdirSync(DOCS_DEST, { recursive: true });
+  fs.writeFileSync(path.join(DOCS_DEST, 'graph.mdx'), content);
+  console.log('  Generated graph page');
+}
+
+console.log('Generating graph page...');
+generate();
+
+module.exports = { generate };

--- a/docs-site/scripts/graph-data.js
+++ b/docs-site/scripts/graph-data.js
@@ -151,7 +151,9 @@ function buildGraph({ adrsSource, specsSource }) {
       const specPath = path.join(specsSource, dir, 'spec.md');
       if (!fs.existsSync(specPath)) continue;
       const text = fs.readFileSync(specPath, 'utf-8');
-      const titleMatch = text.match(/^#\s+(SPEC-\d{4}):/m);
+      // Match `# SPEC-XXXX:` or `# SPEC-XXXX Title` (no colon) for parity
+      // with the Python helper's word-boundary regex.
+      const titleMatch = text.match(/^#\s+(SPEC-\d{4})\b/m);
       if (!titleMatch) continue;
       const id = titleMatch[1];
       const fm = parseFrontmatter(text);

--- a/docs-site/scripts/graph-data.js
+++ b/docs-site/scripts/graph-data.js
@@ -1,0 +1,287 @@
+/**
+ * Graph Data
+ *
+ * Reads ADR/spec frontmatter and computes the artifact graph nodes,
+ * authored edges, derived inverses, and orphan categories. Exposed for
+ * use by generate-graph.js and any per-artifact mini-graph render in
+ * transform-adrs.js / transform-openspecs.js.
+ *
+ * Authoritative implementation lives in `skills/graph/lib/graph.py`
+ * (per ADR-0023 / SPEC-0018). This is a docs-side reflection used only
+ * for static page rendering — it is intentionally narrow and stdlib-
+ * only-equivalent (no PyYAML / no third-party JS YAML lib).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ADR_EDGE_FIELDS = ['supersedes', 'extends', 'enables', 'governs', 'related'];
+const SPEC_EDGE_FIELDS = ['implements', 'requires', 'extends', 'supersedes'];
+const INVERSE_OF = {
+  supersedes: 'superseded-by',
+  extends: 'extended-by',
+  enables: 'enabled-by',
+  governs: 'governed-by',
+  implements: 'implemented-by',
+  requires: 'depended-on-by',
+  related: 'related',
+};
+
+/**
+ * Parse YAML-ish frontmatter from a markdown body. Recognizes scalars
+ * and inline-bracket lists with quoted scalars. Mirrors the narrow
+ * grammar in `skills/graph/lib/graph.py`.
+ */
+function parseFrontmatter(text) {
+  const m = text.match(/^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/);
+  if (!m) return {};
+  const result = {};
+  for (const raw of m[1].split('\n')) {
+    const line = raw.replace(/\s+$/, '');
+    const stripped = line.replace(/^\s+/, '');
+    if (!stripped || stripped.startsWith('#')) continue;
+    const colonIdx = line.indexOf(':');
+    if (colonIdx < 0) continue;
+    const key = line.slice(0, colonIdx).trim();
+    let value = stripCommentOutsideQuotes(line.slice(colonIdx + 1).trim());
+    if (value.startsWith('[') && value.endsWith(']')) {
+      const inner = value.slice(1, -1).trim();
+      result[key] = splitCsv(inner)
+        .map((item) => unquote(item.trim()))
+        .filter(Boolean);
+    } else {
+      result[key] = unquote(value);
+    }
+  }
+  return result;
+}
+
+function stripCommentOutsideQuotes(value) {
+  let inQuote = null;
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (inQuote) {
+      if (ch === inQuote) inQuote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      inQuote = ch;
+      continue;
+    }
+    if (ch === '#' && (i === 0 || /\s/.test(value[i - 1]))) {
+      return value.slice(0, i).replace(/\s+$/, '');
+    }
+  }
+  return value;
+}
+
+function splitCsv(s) {
+  const out = [];
+  let buf = '';
+  let inQuote = null;
+  let depth = 0;
+  for (const ch of s) {
+    if (inQuote) {
+      buf += ch;
+      if (ch === inQuote) inQuote = null;
+    } else if (ch === '"' || ch === "'") {
+      inQuote = ch;
+      buf += ch;
+    } else if (ch === '[') {
+      depth++;
+      buf += ch;
+    } else if (ch === ']') {
+      depth--;
+      buf += ch;
+    } else if (ch === ',' && depth === 0) {
+      out.push(buf);
+      buf = '';
+    } else {
+      buf += ch;
+    }
+  }
+  if (buf) out.push(buf);
+  return out;
+}
+
+function unquote(value) {
+  if (value.length >= 2 && value[0] === value[value.length - 1] && (value[0] === '"' || value[0] === "'")) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function extractTitle(text) {
+  const m = text.match(/^#\s+(.+?)\s*$/m);
+  return m ? m[1] : '';
+}
+
+/**
+ * Build the artifact graph from an ADR directory + spec directory.
+ *
+ * Returns:
+ *   {
+ *     nodes: { id: { id, kind, title, path } },
+ *     edges: [ { source, target, type, derived } ],
+ *     orphanAdrs: [id],
+ *     orphanSpecs: [id],
+ *   }
+ */
+function buildGraph({ adrsSource, specsSource }) {
+  const nodes = {};
+  const edges = [];
+
+  const adrFileRe = /^ADR-(\d{4})/;
+  if (fs.existsSync(adrsSource)) {
+    for (const f of fs.readdirSync(adrsSource).sort()) {
+      if (!f.endsWith('.md')) continue;
+      const m = f.match(adrFileRe);
+      if (!m) continue;
+      const id = `ADR-${m[1]}`;
+      const text = fs.readFileSync(path.join(adrsSource, f), 'utf-8');
+      const fm = parseFrontmatter(text);
+      const title = extractTitle(text);
+      nodes[id] = { id, kind: 'adr', title, path: path.join(adrsSource, f) };
+      ingestEdges(edges, id, fm, ADR_EDGE_FIELDS);
+    }
+  }
+
+  if (fs.existsSync(specsSource)) {
+    for (const dir of fs.readdirSync(specsSource).sort()) {
+      const specPath = path.join(specsSource, dir, 'spec.md');
+      if (!fs.existsSync(specPath)) continue;
+      const text = fs.readFileSync(specPath, 'utf-8');
+      const titleMatch = text.match(/^#\s+(SPEC-\d{4}):/m);
+      if (!titleMatch) continue;
+      const id = titleMatch[1];
+      const fm = parseFrontmatter(text);
+      const title = extractTitle(text);
+      nodes[id] = { id, kind: 'spec', title, path: specPath, dir };
+      ingestEdges(edges, id, fm, SPEC_EDGE_FIELDS);
+    }
+  }
+
+  // Derive inverse edges for the same SPEC-0018 set; symmetric `related`
+  // is added in both directions only when not already authored.
+  const authoredPairs = new Set(edges.map((e) => `${e.source}|${e.target}|${e.type}`));
+  const derived = [];
+  for (const e of edges) {
+    const inv = INVERSE_OF[e.type];
+    if (!inv) continue;
+    if (!nodes[e.target]) continue;
+    if (e.type === 'related' && authoredPairs.has(`${e.target}|${e.source}|related`)) continue;
+    derived.push({ source: e.target, target: e.source, type: inv, derived: true });
+  }
+  for (const e of edges) e.derived = false;
+  edges.push(...derived);
+
+  // Orphans (per SPEC-0018 categories b and c — no source-tree walk here)
+  const orphanAdrs = [];
+  const orphanSpecs = [];
+  for (const id of Object.keys(nodes).sort()) {
+    const n = nodes[id];
+    if (n.kind === 'adr') {
+      const hasSpecImpl = edges.some(
+        (e) => e.target === id && e.type === 'implements' && !e.derived
+      );
+      if (!hasSpecImpl) orphanAdrs.push(id);
+    }
+    if (n.kind === 'spec') {
+      // No source code in docs-data context, so every spec is an orphan
+      // by definition for category (b). Skip surfacing this here — let
+      // the orphans verb in /sdd:graph carry that detail.
+      // We still surface ADR-orphan-specs (specs that no ADR governs) only
+      // to give users a clean signal in docs context:
+      // A spec is governed if any ADR points at it via authored `governs`
+      // OR the spec's own `implements:` produces a derived `implemented-by`
+      // edge from an ADR back to it. Both signal "this spec realizes some ADR."
+      const hasGoverning = edges.some(
+        (e) =>
+          e.target === id &&
+          ((e.type === 'governs' && !e.derived) || e.type === 'implemented-by')
+      );
+      if (!hasGoverning) orphanSpecs.push(id);
+    }
+  }
+
+  return { nodes, edges, orphanAdrs, orphanSpecs };
+}
+
+function ingestEdges(edges, sourceId, fm, allowed) {
+  for (const field of allowed) {
+    const value = fm[field];
+    if (!Array.isArray(value)) continue;
+    for (const target of value) {
+      const t = String(target).trim();
+      if (!t) continue;
+      edges.push({ source: sourceId, target: t, type: field });
+    }
+  }
+}
+
+/**
+ * Render the entire authored graph as a Mermaid flowchart. Nodes are
+ * ADR/spec IDs only; cross-module IDs ([module]/X) are sanitized to
+ * Mermaid-safe identifiers.
+ */
+function renderFullMermaid({ nodes, edges }) {
+  const lines = ['flowchart TB'];
+  const seen = new Set();
+  const nodeId = (id) => id.replace(/[^A-Za-z0-9_]/g, '_');
+  const nodeLabel = (n) => (n.title || n.id).replace(/"/g, '\\"');
+
+  for (const id of Object.keys(nodes).sort()) {
+    const n = nodes[id];
+    if (seen.has(id)) continue;
+    seen.add(id);
+    lines.push(`  ${nodeId(id)}["${nodeLabel(n)}"]`);
+  }
+  for (const e of edges) {
+    if (e.derived) continue; // authored only — derived would double the diagram
+    if (!nodes[e.source] || !nodes[e.target]) continue;
+    const arrow = '-->';
+    const label = e.type;
+    lines.push(`  ${nodeId(e.source)} ${arrow}|"${label}"| ${nodeId(e.target)}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Render the immediate-neighborhood mini-Mermaid for a single artifact:
+ * the queried node plus its direct neighbors via authored edges
+ * (outgoing) and authored inverses (incoming). Used in per-page
+ * "Related artifacts" footers if the docs transforms opt in.
+ */
+function renderNeighborMermaid(targetId, { nodes, edges }) {
+  if (!nodes[targetId]) return null;
+  const lines = ['flowchart TB'];
+  const nodeId = (id) => id.replace(/[^A-Za-z0-9_]/g, '_');
+  const nodeLabel = (n) => (n.title || n.id).replace(/"/g, '\\"');
+  const neighborhood = new Set([targetId]);
+  for (const e of edges) {
+    if (e.source === targetId || e.target === targetId) {
+      neighborhood.add(e.source);
+      neighborhood.add(e.target);
+    }
+  }
+  if (neighborhood.size <= 1) return null;
+  for (const id of [...neighborhood].sort()) {
+    if (!nodes[id]) continue;
+    lines.push(`  ${nodeId(id)}["${nodeLabel(nodes[id])}"]`);
+  }
+  for (const e of edges) {
+    if (e.source !== targetId && e.target !== targetId) continue;
+    if (!nodes[e.source] || !nodes[e.target]) continue;
+    const arrow = e.derived ? '-.->' : '-->';
+    const label = e.derived ? `${e.type} (derived)` : e.type;
+    lines.push(`  ${nodeId(e.source)} ${arrow}|"${label}"| ${nodeId(e.target)}`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = {
+  buildGraph,
+  parseFrontmatter,
+  renderFullMermaid,
+  renderNeighborMermaid,
+};

--- a/templates/docusaurus/scripts/build-docs.js
+++ b/templates/docusaurus/scripts/build-docs.js
@@ -20,4 +20,7 @@ require('./transform-adrs');
 // Generate index page
 require('./generate-index');
 
+// Generate graph page (artifact DAG from frontmatter, per ADR-0023 / SPEC-0018)
+require('./generate-graph');
+
 console.log('\nDocumentation content build complete!');

--- a/templates/docusaurus/scripts/generate-graph.js
+++ b/templates/docusaurus/scripts/generate-graph.js
@@ -40,11 +40,15 @@ function generate() {
 
   const stripIdPrefix = (title, id) =>
     (title || '').replace(new RegExp(`^${id}:\\s*`), '');
-  const orphanAdrRows = orphanAdrs.length
-    ? orphanAdrs.map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`).join('\n')
+  const orphanAdrSection = orphanAdrs.length
+    ? `| ADR | Title |\n|-----|-------|\n${orphanAdrs
+        .map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`)
+        .join('\n')}`
     : '_No orphan ADRs — every ADR has at least one implementing spec._';
-  const orphanSpecRows = orphanSpecs.length
-    ? orphanSpecs.map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`).join('\n')
+  const orphanSpecSection = orphanSpecs.length
+    ? `| Spec | Title |\n|------|-------|\n${orphanSpecs
+        .map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`)
+        .join('\n')}`
     : '_No orphan specs — every spec is governed by at least one ADR._';
 
   const content = `---
@@ -78,17 +82,13 @@ ${mermaid}
 
 ADRs that no spec declares \`implements:\` against. Add an \`implements: [ADR-XXXX]\` line to a spec's frontmatter (or run \`/sdd:graph backfill\`) to remove an ADR from this list.
 
-| ADR | Title |
-|-----|-------|
-${orphanAdrRows}
+${orphanAdrSection}
 
 ## Orphan specs
 
 Specs that no ADR declares \`governs:\` against. (For specs whose source-code coverage is the relevant orphan signal, use \`/sdd:graph orphans\` directly — that walks source files for governing comments and is not reflected in this static page.)
 
-| Spec | Title |
-|------|-------|
-${orphanSpecRows}
+${orphanSpecSection}
 
 ## Querying the graph
 

--- a/templates/docusaurus/scripts/generate-graph.js
+++ b/templates/docusaurus/scripts/generate-graph.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Generate Graph Page
+ *
+ * Reads ADR and spec frontmatter (the artifact graph schema from
+ * ADR-0023 / SPEC-0018), produces a Docusaurus-ready Graph page with:
+ *   - graph stats (counts of nodes, authored edges, orphans)
+ *   - full-graph Mermaid flowchart
+ *   - orphan tables (ADRs without implementing spec, specs without
+ *     governing ADR)
+ *
+ * The authoritative graph implementation is `skills/graph/lib/graph.py`
+ * — this script is a static-page reflection that runs at docs-build
+ * time without bringing Python into the build pipeline.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { buildGraph, renderFullMermaid } = require('./graph-data');
+
+const ADRS_SOURCE = path.join(__dirname, '../../docs/adrs');
+const SPECS_SOURCE = path.join(__dirname, '../../docs/openspec/specs');
+const DOCS_DEST = path.join(__dirname, '../../docs-generated');
+
+function generate() {
+  const graph = buildGraph({ adrsSource: ADRS_SOURCE, specsSource: SPECS_SOURCE });
+  const { nodes, edges, orphanAdrs, orphanSpecs } = graph;
+
+  const adrCount = Object.values(nodes).filter((n) => n.kind === 'adr').length;
+  const specCount = Object.values(nodes).filter((n) => n.kind === 'spec').length;
+  const authoredEdges = edges.filter((e) => !e.derived);
+  const derivedEdges = edges.filter((e) => e.derived);
+
+  if (adrCount + specCount === 0) {
+    console.log('  Skipped graph page: no artifacts');
+    return;
+  }
+
+  const mermaid = renderFullMermaid(graph);
+
+  const stripIdPrefix = (title, id) =>
+    (title || '').replace(new RegExp(`^${id}:\\s*`), '');
+  const orphanAdrRows = orphanAdrs.length
+    ? orphanAdrs.map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`).join('\n')
+    : '_No orphan ADRs — every ADR has at least one implementing spec._';
+  const orphanSpecRows = orphanSpecs.length
+    ? orphanSpecs.map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`).join('\n')
+    : '_No orphan specs — every spec is governed by at least one ADR._';
+
+  const content = `---
+title: "Architecture Graph"
+sidebar_label: "Graph"
+sidebar_position: 1
+---
+
+# Architecture Graph
+
+The artifact graph captures explicit relationships between ADRs and specs declared in YAML frontmatter (per [ADR-0023](/decisions/0023-frontmatter-dag-and-graph-skill) and [SPEC-0018](/specs/artifact-graph/spec)). Edges describe \`supersedes\`, \`extends\`, \`enables\`, \`governs\`, \`implements\`, \`requires\`, and \`related\` relationships between artifacts. The page below reflects the authored edges only; derived inverses (\`governed-by\`, \`implemented-by\`, etc.) are computed at query time by the \`/sdd:graph\` skill.
+
+## Stats
+
+| Metric | Count |
+|--------|-------|
+| ADRs | ${adrCount} |
+| Specs | ${specCount} |
+| Authored edges | ${authoredEdges.length} |
+| Derived edges (computed) | ${derivedEdges.length} |
+| Orphan ADRs (no implementing spec) | ${orphanAdrs.length} |
+| Orphan specs (no governing ADR) | ${orphanSpecs.length} |
+
+## Full graph
+
+\`\`\`mermaid
+${mermaid}
+\`\`\`
+
+## Orphan ADRs
+
+ADRs that no spec declares \`implements:\` against. Add an \`implements: [ADR-XXXX]\` line to a spec's frontmatter (or run \`/sdd:graph backfill\`) to remove an ADR from this list.
+
+| ADR | Title |
+|-----|-------|
+${orphanAdrRows}
+
+## Orphan specs
+
+Specs that no ADR declares \`governs:\` against. (For specs whose source-code coverage is the relevant orphan signal, use \`/sdd:graph orphans\` directly — that walks source files for governing comments and is not reflected in this static page.)
+
+| Spec | Title |
+|------|-------|
+${orphanSpecRows}
+
+## Querying the graph
+
+The static view above is generated at docs-build time. For interactive queries:
+
+\`\`\`
+/sdd:graph validate                  # full diagnostics
+/sdd:graph impact ADR-XXXX           # what depends on this ADR
+/sdd:graph ancestors SPEC-XXXX       # what this spec depends on
+/sdd:graph chain SPEC-XXXX           # bidirectional view
+/sdd:graph orphans                   # source files, specs, ADRs
+/sdd:graph backfill                  # propose edges from prose
+\`\`\`
+
+JSON output (\`--json\`) is the stable contract for any future MCP, IDE plugin, or dashboard.
+`;
+
+  fs.mkdirSync(DOCS_DEST, { recursive: true });
+  fs.writeFileSync(path.join(DOCS_DEST, 'graph.mdx'), content);
+  console.log('  Generated graph page');
+}
+
+console.log('Generating graph page...');
+generate();
+
+module.exports = { generate };

--- a/templates/docusaurus/scripts/graph-data.js
+++ b/templates/docusaurus/scripts/graph-data.js
@@ -151,7 +151,9 @@ function buildGraph({ adrsSource, specsSource }) {
       const specPath = path.join(specsSource, dir, 'spec.md');
       if (!fs.existsSync(specPath)) continue;
       const text = fs.readFileSync(specPath, 'utf-8');
-      const titleMatch = text.match(/^#\s+(SPEC-\d{4}):/m);
+      // Match `# SPEC-XXXX:` or `# SPEC-XXXX Title` (no colon) for parity
+      // with the Python helper's word-boundary regex.
+      const titleMatch = text.match(/^#\s+(SPEC-\d{4})\b/m);
       if (!titleMatch) continue;
       const id = titleMatch[1];
       const fm = parseFrontmatter(text);

--- a/templates/docusaurus/scripts/graph-data.js
+++ b/templates/docusaurus/scripts/graph-data.js
@@ -1,0 +1,287 @@
+/**
+ * Graph Data
+ *
+ * Reads ADR/spec frontmatter and computes the artifact graph nodes,
+ * authored edges, derived inverses, and orphan categories. Exposed for
+ * use by generate-graph.js and any per-artifact mini-graph render in
+ * transform-adrs.js / transform-openspecs.js.
+ *
+ * Authoritative implementation lives in `skills/graph/lib/graph.py`
+ * (per ADR-0023 / SPEC-0018). This is a docs-side reflection used only
+ * for static page rendering — it is intentionally narrow and stdlib-
+ * only-equivalent (no PyYAML / no third-party JS YAML lib).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ADR_EDGE_FIELDS = ['supersedes', 'extends', 'enables', 'governs', 'related'];
+const SPEC_EDGE_FIELDS = ['implements', 'requires', 'extends', 'supersedes'];
+const INVERSE_OF = {
+  supersedes: 'superseded-by',
+  extends: 'extended-by',
+  enables: 'enabled-by',
+  governs: 'governed-by',
+  implements: 'implemented-by',
+  requires: 'depended-on-by',
+  related: 'related',
+};
+
+/**
+ * Parse YAML-ish frontmatter from a markdown body. Recognizes scalars
+ * and inline-bracket lists with quoted scalars. Mirrors the narrow
+ * grammar in `skills/graph/lib/graph.py`.
+ */
+function parseFrontmatter(text) {
+  const m = text.match(/^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/);
+  if (!m) return {};
+  const result = {};
+  for (const raw of m[1].split('\n')) {
+    const line = raw.replace(/\s+$/, '');
+    const stripped = line.replace(/^\s+/, '');
+    if (!stripped || stripped.startsWith('#')) continue;
+    const colonIdx = line.indexOf(':');
+    if (colonIdx < 0) continue;
+    const key = line.slice(0, colonIdx).trim();
+    let value = stripCommentOutsideQuotes(line.slice(colonIdx + 1).trim());
+    if (value.startsWith('[') && value.endsWith(']')) {
+      const inner = value.slice(1, -1).trim();
+      result[key] = splitCsv(inner)
+        .map((item) => unquote(item.trim()))
+        .filter(Boolean);
+    } else {
+      result[key] = unquote(value);
+    }
+  }
+  return result;
+}
+
+function stripCommentOutsideQuotes(value) {
+  let inQuote = null;
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (inQuote) {
+      if (ch === inQuote) inQuote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      inQuote = ch;
+      continue;
+    }
+    if (ch === '#' && (i === 0 || /\s/.test(value[i - 1]))) {
+      return value.slice(0, i).replace(/\s+$/, '');
+    }
+  }
+  return value;
+}
+
+function splitCsv(s) {
+  const out = [];
+  let buf = '';
+  let inQuote = null;
+  let depth = 0;
+  for (const ch of s) {
+    if (inQuote) {
+      buf += ch;
+      if (ch === inQuote) inQuote = null;
+    } else if (ch === '"' || ch === "'") {
+      inQuote = ch;
+      buf += ch;
+    } else if (ch === '[') {
+      depth++;
+      buf += ch;
+    } else if (ch === ']') {
+      depth--;
+      buf += ch;
+    } else if (ch === ',' && depth === 0) {
+      out.push(buf);
+      buf = '';
+    } else {
+      buf += ch;
+    }
+  }
+  if (buf) out.push(buf);
+  return out;
+}
+
+function unquote(value) {
+  if (value.length >= 2 && value[0] === value[value.length - 1] && (value[0] === '"' || value[0] === "'")) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function extractTitle(text) {
+  const m = text.match(/^#\s+(.+?)\s*$/m);
+  return m ? m[1] : '';
+}
+
+/**
+ * Build the artifact graph from an ADR directory + spec directory.
+ *
+ * Returns:
+ *   {
+ *     nodes: { id: { id, kind, title, path } },
+ *     edges: [ { source, target, type, derived } ],
+ *     orphanAdrs: [id],
+ *     orphanSpecs: [id],
+ *   }
+ */
+function buildGraph({ adrsSource, specsSource }) {
+  const nodes = {};
+  const edges = [];
+
+  const adrFileRe = /^ADR-(\d{4})/;
+  if (fs.existsSync(adrsSource)) {
+    for (const f of fs.readdirSync(adrsSource).sort()) {
+      if (!f.endsWith('.md')) continue;
+      const m = f.match(adrFileRe);
+      if (!m) continue;
+      const id = `ADR-${m[1]}`;
+      const text = fs.readFileSync(path.join(adrsSource, f), 'utf-8');
+      const fm = parseFrontmatter(text);
+      const title = extractTitle(text);
+      nodes[id] = { id, kind: 'adr', title, path: path.join(adrsSource, f) };
+      ingestEdges(edges, id, fm, ADR_EDGE_FIELDS);
+    }
+  }
+
+  if (fs.existsSync(specsSource)) {
+    for (const dir of fs.readdirSync(specsSource).sort()) {
+      const specPath = path.join(specsSource, dir, 'spec.md');
+      if (!fs.existsSync(specPath)) continue;
+      const text = fs.readFileSync(specPath, 'utf-8');
+      const titleMatch = text.match(/^#\s+(SPEC-\d{4}):/m);
+      if (!titleMatch) continue;
+      const id = titleMatch[1];
+      const fm = parseFrontmatter(text);
+      const title = extractTitle(text);
+      nodes[id] = { id, kind: 'spec', title, path: specPath, dir };
+      ingestEdges(edges, id, fm, SPEC_EDGE_FIELDS);
+    }
+  }
+
+  // Derive inverse edges for the same SPEC-0018 set; symmetric `related`
+  // is added in both directions only when not already authored.
+  const authoredPairs = new Set(edges.map((e) => `${e.source}|${e.target}|${e.type}`));
+  const derived = [];
+  for (const e of edges) {
+    const inv = INVERSE_OF[e.type];
+    if (!inv) continue;
+    if (!nodes[e.target]) continue;
+    if (e.type === 'related' && authoredPairs.has(`${e.target}|${e.source}|related`)) continue;
+    derived.push({ source: e.target, target: e.source, type: inv, derived: true });
+  }
+  for (const e of edges) e.derived = false;
+  edges.push(...derived);
+
+  // Orphans (per SPEC-0018 categories b and c — no source-tree walk here)
+  const orphanAdrs = [];
+  const orphanSpecs = [];
+  for (const id of Object.keys(nodes).sort()) {
+    const n = nodes[id];
+    if (n.kind === 'adr') {
+      const hasSpecImpl = edges.some(
+        (e) => e.target === id && e.type === 'implements' && !e.derived
+      );
+      if (!hasSpecImpl) orphanAdrs.push(id);
+    }
+    if (n.kind === 'spec') {
+      // No source code in docs-data context, so every spec is an orphan
+      // by definition for category (b). Skip surfacing this here — let
+      // the orphans verb in /sdd:graph carry that detail.
+      // We still surface ADR-orphan-specs (specs that no ADR governs) only
+      // to give users a clean signal in docs context:
+      // A spec is governed if any ADR points at it via authored `governs`
+      // OR the spec's own `implements:` produces a derived `implemented-by`
+      // edge from an ADR back to it. Both signal "this spec realizes some ADR."
+      const hasGoverning = edges.some(
+        (e) =>
+          e.target === id &&
+          ((e.type === 'governs' && !e.derived) || e.type === 'implemented-by')
+      );
+      if (!hasGoverning) orphanSpecs.push(id);
+    }
+  }
+
+  return { nodes, edges, orphanAdrs, orphanSpecs };
+}
+
+function ingestEdges(edges, sourceId, fm, allowed) {
+  for (const field of allowed) {
+    const value = fm[field];
+    if (!Array.isArray(value)) continue;
+    for (const target of value) {
+      const t = String(target).trim();
+      if (!t) continue;
+      edges.push({ source: sourceId, target: t, type: field });
+    }
+  }
+}
+
+/**
+ * Render the entire authored graph as a Mermaid flowchart. Nodes are
+ * ADR/spec IDs only; cross-module IDs ([module]/X) are sanitized to
+ * Mermaid-safe identifiers.
+ */
+function renderFullMermaid({ nodes, edges }) {
+  const lines = ['flowchart TB'];
+  const seen = new Set();
+  const nodeId = (id) => id.replace(/[^A-Za-z0-9_]/g, '_');
+  const nodeLabel = (n) => (n.title || n.id).replace(/"/g, '\\"');
+
+  for (const id of Object.keys(nodes).sort()) {
+    const n = nodes[id];
+    if (seen.has(id)) continue;
+    seen.add(id);
+    lines.push(`  ${nodeId(id)}["${nodeLabel(n)}"]`);
+  }
+  for (const e of edges) {
+    if (e.derived) continue; // authored only — derived would double the diagram
+    if (!nodes[e.source] || !nodes[e.target]) continue;
+    const arrow = '-->';
+    const label = e.type;
+    lines.push(`  ${nodeId(e.source)} ${arrow}|"${label}"| ${nodeId(e.target)}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Render the immediate-neighborhood mini-Mermaid for a single artifact:
+ * the queried node plus its direct neighbors via authored edges
+ * (outgoing) and authored inverses (incoming). Used in per-page
+ * "Related artifacts" footers if the docs transforms opt in.
+ */
+function renderNeighborMermaid(targetId, { nodes, edges }) {
+  if (!nodes[targetId]) return null;
+  const lines = ['flowchart TB'];
+  const nodeId = (id) => id.replace(/[^A-Za-z0-9_]/g, '_');
+  const nodeLabel = (n) => (n.title || n.id).replace(/"/g, '\\"');
+  const neighborhood = new Set([targetId]);
+  for (const e of edges) {
+    if (e.source === targetId || e.target === targetId) {
+      neighborhood.add(e.source);
+      neighborhood.add(e.target);
+    }
+  }
+  if (neighborhood.size <= 1) return null;
+  for (const id of [...neighborhood].sort()) {
+    if (!nodes[id]) continue;
+    lines.push(`  ${nodeId(id)}["${nodeLabel(nodes[id])}"]`);
+  }
+  for (const e of edges) {
+    if (e.source !== targetId && e.target !== targetId) continue;
+    if (!nodes[e.source] || !nodes[e.target]) continue;
+    const arrow = e.derived ? '-.->' : '-->';
+    const label = e.derived ? `${e.type} (derived)` : e.type;
+    lines.push(`  ${nodeId(e.source)} ${arrow}|"${label}"| ${nodeId(e.target)}`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = {
+  buildGraph,
+  parseFrontmatter,
+  renderFullMermaid,
+  renderNeighborMermaid,
+};

--- a/templates/integration/sync-spec-docs/index.js
+++ b/templates/integration/sync-spec-docs/index.js
@@ -33,6 +33,7 @@ const { buildSpecMapping } = require('./lib/build-spec-mapping');
 const { transformAdrs } = require('./lib/transform-adrs');
 const { transformOpenspecs } = require('./lib/transform-openspecs');
 const { generateIndex } = require('./lib/generate-index');
+const { generateGraph } = require('./lib/generate-graph');
 
 module.exports = function pluginSyncSpecDocs(context, options = {}) {
   const projectRoot = path.resolve(context.siteDir, options.projectRoot || '..');
@@ -93,6 +94,13 @@ module.exports = function pluginSyncSpecDocs(context, options = {}) {
         specsSource,
         outputDir: outputBase,
         projectTitle: context.siteConfig.title,
+      });
+
+      // 5. Generate graph page (artifact DAG, per ADR-0023 / SPEC-0018)
+      generateGraph({
+        adrsSource,
+        specsSource,
+        outputDir: outputBase,
       });
 
       console.log('[sync-spec-docs] Sync complete.');

--- a/templates/integration/sync-spec-docs/lib/generate-graph.js
+++ b/templates/integration/sync-spec-docs/lib/generate-graph.js
@@ -11,8 +11,6 @@
  * @param {string} config.adrsSource - Absolute path to the ADR source directory
  * @param {string} config.specsSource - Absolute path to the specs source directory
  * @param {string} config.outputDir - Absolute path to the output directory
- * @param {string} [config.adrPathPrefix] - URL prefix for ADR cross-links (default `/decisions`)
- * @param {string} [config.specPathPrefix] - URL prefix for spec cross-links (default `/specs`)
  */
 
 const fs = require('fs');
@@ -20,13 +18,7 @@ const path = require('path');
 const { buildGraph, renderFullMermaid } = require('./graph-data');
 
 function generateGraph(config) {
-  const {
-    adrsSource,
-    specsSource,
-    outputDir,
-    adrPathPrefix = '/decisions',
-    specPathPrefix = '/specs',
-  } = config;
+  const { adrsSource, specsSource, outputDir } = config;
 
   const graph = buildGraph({ adrsSource, specsSource });
   const { nodes, edges, orphanAdrs, orphanSpecs } = graph;
@@ -45,11 +37,15 @@ function generateGraph(config) {
 
   const stripIdPrefix = (title, id) =>
     (title || '').replace(new RegExp(`^${id}:\\s*`), '');
-  const orphanAdrRows = orphanAdrs.length
-    ? orphanAdrs.map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`).join('\n')
+  const orphanAdrSection = orphanAdrs.length
+    ? `| ADR | Title |\n|-----|-------|\n${orphanAdrs
+        .map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`)
+        .join('\n')}`
     : '_No orphan ADRs — every ADR has at least one implementing spec._';
-  const orphanSpecRows = orphanSpecs.length
-    ? orphanSpecs.map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`).join('\n')
+  const orphanSpecSection = orphanSpecs.length
+    ? `| Spec | Title |\n|------|-------|\n${orphanSpecs
+        .map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`)
+        .join('\n')}`
     : '_No orphan specs — every spec is governed by at least one ADR._';
 
   const content = `---
@@ -83,17 +79,13 @@ ${mermaid}
 
 ADRs that no spec declares \`implements:\` against. Add an \`implements: [ADR-XXXX]\` line to a spec's frontmatter (or run \`/sdd:graph backfill\`) to remove an ADR from this list.
 
-| ADR | Title |
-|-----|-------|
-${orphanAdrRows}
+${orphanAdrSection}
 
 ## Orphan specs
 
 Specs that no ADR declares \`governs:\` against.
 
-| Spec | Title |
-|------|-------|
-${orphanSpecRows}
+${orphanSpecSection}
 
 ## Querying the graph
 

--- a/templates/integration/sync-spec-docs/lib/generate-graph.js
+++ b/templates/integration/sync-spec-docs/lib/generate-graph.js
@@ -1,0 +1,119 @@
+/**
+ * Generate Graph Page (Integration Mode)
+ *
+ * Reads ADR and spec frontmatter (the artifact graph schema from
+ * ADR-0023 / SPEC-0018), produces a Docusaurus-ready Graph page with
+ * stats, full-graph Mermaid flowchart, and orphan tables.
+ *
+ * Adapted for integration mode: all paths received via parameters.
+ *
+ * @param {Object} config
+ * @param {string} config.adrsSource - Absolute path to the ADR source directory
+ * @param {string} config.specsSource - Absolute path to the specs source directory
+ * @param {string} config.outputDir - Absolute path to the output directory
+ * @param {string} [config.adrPathPrefix] - URL prefix for ADR cross-links (default `/decisions`)
+ * @param {string} [config.specPathPrefix] - URL prefix for spec cross-links (default `/specs`)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { buildGraph, renderFullMermaid } = require('./graph-data');
+
+function generateGraph(config) {
+  const {
+    adrsSource,
+    specsSource,
+    outputDir,
+    adrPathPrefix = '/decisions',
+    specPathPrefix = '/specs',
+  } = config;
+
+  const graph = buildGraph({ adrsSource, specsSource });
+  const { nodes, edges, orphanAdrs, orphanSpecs } = graph;
+
+  const adrCount = Object.values(nodes).filter((n) => n.kind === 'adr').length;
+  const specCount = Object.values(nodes).filter((n) => n.kind === 'spec').length;
+  const authoredEdges = edges.filter((e) => !e.derived);
+  const derivedEdges = edges.filter((e) => e.derived);
+
+  if (adrCount + specCount === 0) {
+    console.log('[sync-spec-docs] Skipped graph page: no artifacts');
+    return;
+  }
+
+  const mermaid = renderFullMermaid(graph);
+
+  const stripIdPrefix = (title, id) =>
+    (title || '').replace(new RegExp(`^${id}:\\s*`), '');
+  const orphanAdrRows = orphanAdrs.length
+    ? orphanAdrs.map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`).join('\n')
+    : '_No orphan ADRs — every ADR has at least one implementing spec._';
+  const orphanSpecRows = orphanSpecs.length
+    ? orphanSpecs.map((id) => `| ${id} | ${stripIdPrefix(nodes[id] && nodes[id].title, id)} |`).join('\n')
+    : '_No orphan specs — every spec is governed by at least one ADR._';
+
+  const content = `---
+title: "Architecture Graph"
+sidebar_label: "Graph"
+sidebar_position: 1
+---
+
+# Architecture Graph
+
+The artifact graph captures explicit relationships between ADRs and specs declared in YAML frontmatter (per ADR-0023 / SPEC-0018). Edges describe \`supersedes\`, \`extends\`, \`enables\`, \`governs\`, \`implements\`, \`requires\`, and \`related\` relationships. The page below reflects the authored edges only; derived inverses (\`governed-by\`, \`implemented-by\`, etc.) are computed at query time by the \`/sdd:graph\` skill.
+
+## Stats
+
+| Metric | Count |
+|--------|-------|
+| ADRs | ${adrCount} |
+| Specs | ${specCount} |
+| Authored edges | ${authoredEdges.length} |
+| Derived edges (computed) | ${derivedEdges.length} |
+| Orphan ADRs (no implementing spec) | ${orphanAdrs.length} |
+| Orphan specs (no governing ADR) | ${orphanSpecs.length} |
+
+## Full graph
+
+\`\`\`mermaid
+${mermaid}
+\`\`\`
+
+## Orphan ADRs
+
+ADRs that no spec declares \`implements:\` against. Add an \`implements: [ADR-XXXX]\` line to a spec's frontmatter (or run \`/sdd:graph backfill\`) to remove an ADR from this list.
+
+| ADR | Title |
+|-----|-------|
+${orphanAdrRows}
+
+## Orphan specs
+
+Specs that no ADR declares \`governs:\` against.
+
+| Spec | Title |
+|------|-------|
+${orphanSpecRows}
+
+## Querying the graph
+
+The static view above is generated at docs-build time. For interactive queries:
+
+\`\`\`
+/sdd:graph validate                  # full diagnostics
+/sdd:graph impact ADR-XXXX           # what depends on this ADR
+/sdd:graph ancestors SPEC-XXXX       # what this spec depends on
+/sdd:graph chain SPEC-XXXX           # bidirectional view
+/sdd:graph orphans                   # source files, specs, ADRs
+/sdd:graph backfill                  # propose edges from prose
+\`\`\`
+
+JSON output (\`--json\`) is the stable contract for any future MCP, IDE plugin, or dashboard.
+`;
+
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.writeFileSync(path.join(outputDir, 'graph.mdx'), content);
+  console.log('[sync-spec-docs] Generated graph page');
+}
+
+module.exports = { generateGraph };

--- a/templates/integration/sync-spec-docs/lib/graph-data.js
+++ b/templates/integration/sync-spec-docs/lib/graph-data.js
@@ -135,7 +135,9 @@ function buildGraph({ adrsSource, specsSource }) {
       const specPath = path.join(specsSource, dir, 'spec.md');
       if (!fs.existsSync(specPath)) continue;
       const text = fs.readFileSync(specPath, 'utf-8');
-      const titleMatch = text.match(/^#\s+(SPEC-\d{4}):/m);
+      // Match `# SPEC-XXXX:` or `# SPEC-XXXX Title` (no colon) for parity
+      // with the Python helper's word-boundary regex.
+      const titleMatch = text.match(/^#\s+(SPEC-\d{4})\b/m);
       if (!titleMatch) continue;
       const id = titleMatch[1];
       const fm = parseFrontmatter(text);

--- a/templates/integration/sync-spec-docs/lib/graph-data.js
+++ b/templates/integration/sync-spec-docs/lib/graph-data.js
@@ -1,0 +1,252 @@
+/**
+ * Graph Data (Integration Mode)
+ *
+ * Reads ADR/spec frontmatter and computes the artifact graph nodes,
+ * authored edges, derived inverses, and orphan categories. Mirrors
+ * `templates/docusaurus/scripts/graph-data.js`. The integration variant
+ * is path-agnostic (paths come via parameters) but the algorithms are
+ * identical to the scaffold variant.
+ *
+ * Authoritative implementation: `skills/graph/lib/graph.py`
+ * (per ADR-0023 / SPEC-0018). This is a docs-side reflection used only
+ * for static page rendering.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ADR_EDGE_FIELDS = ['supersedes', 'extends', 'enables', 'governs', 'related'];
+const SPEC_EDGE_FIELDS = ['implements', 'requires', 'extends', 'supersedes'];
+const INVERSE_OF = {
+  supersedes: 'superseded-by',
+  extends: 'extended-by',
+  enables: 'enabled-by',
+  governs: 'governed-by',
+  implements: 'implemented-by',
+  requires: 'depended-on-by',
+  related: 'related',
+};
+
+function parseFrontmatter(text) {
+  const m = text.match(/^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/);
+  if (!m) return {};
+  const result = {};
+  for (const raw of m[1].split('\n')) {
+    const line = raw.replace(/\s+$/, '');
+    const stripped = line.replace(/^\s+/, '');
+    if (!stripped || stripped.startsWith('#')) continue;
+    const colonIdx = line.indexOf(':');
+    if (colonIdx < 0) continue;
+    const key = line.slice(0, colonIdx).trim();
+    let value = stripCommentOutsideQuotes(line.slice(colonIdx + 1).trim());
+    if (value.startsWith('[') && value.endsWith(']')) {
+      const inner = value.slice(1, -1).trim();
+      result[key] = splitCsv(inner)
+        .map((item) => unquote(item.trim()))
+        .filter(Boolean);
+    } else {
+      result[key] = unquote(value);
+    }
+  }
+  return result;
+}
+
+function stripCommentOutsideQuotes(value) {
+  let inQuote = null;
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (inQuote) {
+      if (ch === inQuote) inQuote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      inQuote = ch;
+      continue;
+    }
+    if (ch === '#' && (i === 0 || /\s/.test(value[i - 1]))) {
+      return value.slice(0, i).replace(/\s+$/, '');
+    }
+  }
+  return value;
+}
+
+function splitCsv(s) {
+  const out = [];
+  let buf = '';
+  let inQuote = null;
+  let depth = 0;
+  for (const ch of s) {
+    if (inQuote) {
+      buf += ch;
+      if (ch === inQuote) inQuote = null;
+    } else if (ch === '"' || ch === "'") {
+      inQuote = ch;
+      buf += ch;
+    } else if (ch === '[') {
+      depth++;
+      buf += ch;
+    } else if (ch === ']') {
+      depth--;
+      buf += ch;
+    } else if (ch === ',' && depth === 0) {
+      out.push(buf);
+      buf = '';
+    } else {
+      buf += ch;
+    }
+  }
+  if (buf) out.push(buf);
+  return out;
+}
+
+function unquote(value) {
+  if (value.length >= 2 && value[0] === value[value.length - 1] && (value[0] === '"' || value[0] === "'")) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function extractTitle(text) {
+  const m = text.match(/^#\s+(.+?)\s*$/m);
+  return m ? m[1] : '';
+}
+
+function buildGraph({ adrsSource, specsSource }) {
+  const nodes = {};
+  const edges = [];
+
+  const adrFileRe = /^ADR-(\d{4})/;
+  if (fs.existsSync(adrsSource)) {
+    for (const f of fs.readdirSync(adrsSource).sort()) {
+      if (!f.endsWith('.md')) continue;
+      const m = f.match(adrFileRe);
+      if (!m) continue;
+      const id = `ADR-${m[1]}`;
+      const text = fs.readFileSync(path.join(adrsSource, f), 'utf-8');
+      const fm = parseFrontmatter(text);
+      const title = extractTitle(text);
+      nodes[id] = { id, kind: 'adr', title, path: path.join(adrsSource, f) };
+      ingestEdges(edges, id, fm, ADR_EDGE_FIELDS);
+    }
+  }
+
+  if (fs.existsSync(specsSource)) {
+    for (const dir of fs.readdirSync(specsSource).sort()) {
+      const specPath = path.join(specsSource, dir, 'spec.md');
+      if (!fs.existsSync(specPath)) continue;
+      const text = fs.readFileSync(specPath, 'utf-8');
+      const titleMatch = text.match(/^#\s+(SPEC-\d{4}):/m);
+      if (!titleMatch) continue;
+      const id = titleMatch[1];
+      const fm = parseFrontmatter(text);
+      const title = extractTitle(text);
+      nodes[id] = { id, kind: 'spec', title, path: specPath, dir };
+      ingestEdges(edges, id, fm, SPEC_EDGE_FIELDS);
+    }
+  }
+
+  const authoredPairs = new Set(edges.map((e) => `${e.source}|${e.target}|${e.type}`));
+  const derived = [];
+  for (const e of edges) {
+    const inv = INVERSE_OF[e.type];
+    if (!inv) continue;
+    if (!nodes[e.target]) continue;
+    if (e.type === 'related' && authoredPairs.has(`${e.target}|${e.source}|related`)) continue;
+    derived.push({ source: e.target, target: e.source, type: inv, derived: true });
+  }
+  for (const e of edges) e.derived = false;
+  edges.push(...derived);
+
+  const orphanAdrs = [];
+  const orphanSpecs = [];
+  for (const id of Object.keys(nodes).sort()) {
+    const n = nodes[id];
+    if (n.kind === 'adr') {
+      const hasSpecImpl = edges.some(
+        (e) => e.target === id && e.type === 'implements' && !e.derived
+      );
+      if (!hasSpecImpl) orphanAdrs.push(id);
+    }
+    if (n.kind === 'spec') {
+      // A spec is governed if any ADR points at it via authored `governs`
+      // OR the spec's own `implements:` produces a derived `implemented-by`
+      // edge from an ADR back to it. Both signal "this spec realizes some ADR."
+      const hasGoverning = edges.some(
+        (e) =>
+          e.target === id &&
+          ((e.type === 'governs' && !e.derived) || e.type === 'implemented-by')
+      );
+      if (!hasGoverning) orphanSpecs.push(id);
+    }
+  }
+
+  return { nodes, edges, orphanAdrs, orphanSpecs };
+}
+
+function ingestEdges(edges, sourceId, fm, allowed) {
+  for (const field of allowed) {
+    const value = fm[field];
+    if (!Array.isArray(value)) continue;
+    for (const target of value) {
+      const t = String(target).trim();
+      if (!t) continue;
+      edges.push({ source: sourceId, target: t, type: field });
+    }
+  }
+}
+
+function renderFullMermaid({ nodes, edges }) {
+  const lines = ['flowchart TB'];
+  const seen = new Set();
+  const nodeId = (id) => id.replace(/[^A-Za-z0-9_]/g, '_');
+  const nodeLabel = (n) => (n.title || n.id).replace(/"/g, '\\"');
+
+  for (const id of Object.keys(nodes).sort()) {
+    const n = nodes[id];
+    if (seen.has(id)) continue;
+    seen.add(id);
+    lines.push(`  ${nodeId(id)}["${nodeLabel(n)}"]`);
+  }
+  for (const e of edges) {
+    if (e.derived) continue;
+    if (!nodes[e.source] || !nodes[e.target]) continue;
+    const arrow = '-->';
+    const label = e.type;
+    lines.push(`  ${nodeId(e.source)} ${arrow}|"${label}"| ${nodeId(e.target)}`);
+  }
+  return lines.join('\n');
+}
+
+function renderNeighborMermaid(targetId, { nodes, edges }) {
+  if (!nodes[targetId]) return null;
+  const lines = ['flowchart TB'];
+  const nodeId = (id) => id.replace(/[^A-Za-z0-9_]/g, '_');
+  const nodeLabel = (n) => (n.title || n.id).replace(/"/g, '\\"');
+  const neighborhood = new Set([targetId]);
+  for (const e of edges) {
+    if (e.source === targetId || e.target === targetId) {
+      neighborhood.add(e.source);
+      neighborhood.add(e.target);
+    }
+  }
+  if (neighborhood.size <= 1) return null;
+  for (const id of [...neighborhood].sort()) {
+    if (!nodes[id]) continue;
+    lines.push(`  ${nodeId(id)}["${nodeLabel(nodes[id])}"]`);
+  }
+  for (const e of edges) {
+    if (e.source !== targetId && e.target !== targetId) continue;
+    if (!nodes[e.source] || !nodes[e.target]) continue;
+    const arrow = e.derived ? '-.->' : '-->';
+    const label = e.derived ? `${e.type} (derived)` : e.type;
+    lines.push(`  ${nodeId(e.source)} ${arrow}|"${label}"| ${nodeId(e.target)}`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = {
+  buildGraph,
+  parseFrontmatter,
+  renderFullMermaid,
+  renderNeighborMermaid,
+};


### PR DESCRIPTION
## Summary
The /sdd:docs site previously had no view of the artifact graph. Stories 1–8 (#76 → #85) shipped the graph layer; this PR makes it visible in the generated documentation site.

## What lands
A new `graph.mdx` page produced at docs-build time, with:
- Stats: ADR/spec counts, authored & derived edges, orphan counts
- Full-graph Mermaid flowchart (authored edges only — Mermaid can render the inverse direction if Docusaurus is configured for it; deriving them in the diagram would just double the lines)
- Orphan ADRs (no implementing spec)
- Orphan specs (no governing ADR — accounting for both authored `governs:` and derived `implemented-by` from a spec's authored `implements:`)
- Pointer to interactive `/sdd:graph` verbs (the Mermaid is a static snapshot; the Python helper handles real queries)

## Sample output (this repo's actual graph.mdx)

\`\`\`
| Metric | Count |
|--------|-------|
| ADRs | 23 |
| Specs | 18 |
| Authored edges | 79 |
| Derived edges (computed) | 77 |
| Orphan ADRs (no implementing spec) | 1 |
| Orphan specs (no governing ADR) | 0 |
\`\`\`

The 1 orphan ADR is ADR-0022 (Rename Plugin to \`sdd\`) — a meta-decision without a paired spec. Expected.

## No Python dependency at docs-build time
The graph computation is reflected in JS (`graph-data.js`) using the same algorithms as `skills/graph/lib/graph.py`, but stdlib-equivalent: no PyYAML, no third-party YAML lib. The Python helper remains authoritative for query verbs (`/sdd:graph impact ...`); the docs-side reflection is purely for static page rendering.

## Three deployment surfaces updated in lockstep

| Surface | Files |
|---------|-------|
| Scaffold mode (canonical template) | `templates/docusaurus/scripts/{graph-data,generate-graph}.js` + `build-docs.js` orchestration |
| This repo's live docs-site | `docs-site/scripts/{graph-data,generate-graph}.js` + `build-docs.js` orchestration |
| Integration mode (parameterized) | `templates/integration/sync-spec-docs/lib/{graph-data,generate-graph}.js` + `index.js` orchestration |

## Future work (not in this PR)
`renderNeighborMermaid` is exported from `graph-data.js` and ready to use for per-artifact mini-DAG footers in ADR/spec pages — but `transform-adrs.js` / `transform-openspecs.js` don't call it yet. Embedding needs careful escaping vs the existing MDX pipeline. Worth a follow-up if you want each ADR/spec page to show its own neighborhood graph.

## Test plan
- [x] `node docs-site/scripts/generate-graph.js` produces a valid `docs-generated/graph.mdx`
- [x] Stats match what `/sdd:graph validate` reports (41 nodes, 79 authored, 77 derived)
- [x] Orphan ADR list matches expectations (only ADR-0022, the rename meta-ADR)
- [x] Orphan spec list is empty (every spec implements an ADR after Story 8 backfill)
- [x] Full-graph Mermaid block is well-formed (sanitized IDs, escaped quotes, no derived-edge double-rendering)
- [x] `build-docs.js` runs the new step after `generate-index` in all three surfaces
- [x] No regression: existing index/spec/ADR transforms unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)