### PR TITLE
docs: per-page mini-DAGs on ADR pages

### DIFF
--- a/docs-site/scripts/generate-graph.js
+++ b/docs-site/scripts/generate-graph.js
@@ -59,7 +59,7 @@ sidebar_position: 1
 
 # Architecture Graph
 
-The artifact graph captures explicit relationships between ADRs and specs declared in YAML frontmatter (per [ADR-0023](/decisions/0023-frontmatter-dag-and-graph-skill) and [SPEC-0018](/specs/artifact-graph/spec)). Edges describe \`supersedes\`, \`extends\`, \`enables\`, \`governs\`, \`implements\`, \`requires\`, and \`related\` relationships between artifacts. The page below reflects the authored edges only; derived inverses (\`governed-by\`, \`implemented-by\`, etc.) are computed at query time by the \`/sdd:graph\` skill.
+The artifact graph captures explicit relationships between ADRs and specs declared in YAML frontmatter (per [ADR-0023](/decisions/ADR-0023-frontmatter-dag-and-graph-skill) and [SPEC-0018](/specs/artifact-graph/spec)). Edges describe \`supersedes\`, \`extends\`, \`enables\`, \`governs\`, \`implements\`, \`requires\`, and \`related\` relationships between artifacts. The page below reflects the authored edges only; derived inverses (\`governed-by\`, \`implemented-by\`, etc.) are computed at query time by the \`/sdd:graph\` skill.
 
 ## Stats
 

--- a/docs-site/scripts/graph-data.js
+++ b/docs-site/scripts/graph-data.js
@@ -281,9 +281,36 @@ function renderNeighborMermaid(targetId, { nodes, edges }) {
   return lines.join('\n');
 }
 
+/**
+ * Render a "Related Artifacts" Markdown section with a Mermaid mini-DAG
+ * of the artifact's direct neighbors. Returns the empty string when the
+ * artifact has no neighborhood (e.g., a brand-new ADR/spec with no
+ * edges authored or derived) so transforms can unconditionally append
+ * the result. MUST be appended AFTER any MDX-escape pass so the Mermaid
+ * fence stays raw.
+ */
+function buildMiniDagSection(artifactId, graph) {
+  if (!artifactId) return '';
+  const mermaid = renderNeighborMermaid(artifactId, graph);
+  if (!mermaid) return '';
+  return [
+    '',
+    '',
+    '## Related Artifacts',
+    '',
+    `Direct relationships declared in YAML frontmatter (per [ADR-0023](/decisions/ADR-0023-frontmatter-dag-and-graph-skill) / [SPEC-0018](/specs/artifact-graph/spec)). Run \`/sdd:graph chain ${artifactId}\` for the transitive view.`,
+    '',
+    '```mermaid',
+    mermaid,
+    '```',
+    '',
+  ].join('\n');
+}
+
 module.exports = {
   buildGraph,
   parseFrontmatter,
   renderFullMermaid,
   renderNeighborMermaid,
+  buildMiniDagSection,
 };

--- a/docs-site/scripts/transform-adrs.js
+++ b/docs-site/scripts/transform-adrs.js
@@ -16,7 +16,7 @@ const {
   transformAdrReferences,
   fixMarkdownLinks,
 } = require('./transform-utils');
-const { buildGraph, renderNeighborMermaid } = require('./graph-data');
+const { buildGraph, buildMiniDagSection } = require('./graph-data');
 
 const ADRS_SOURCE = path.join(__dirname, '../../docs/adrs');
 const ADRS_DEST = path.join(__dirname, '../../docs-generated/decisions');
@@ -117,31 +117,6 @@ function fixCrossSectionPaths(content) {
   return content.replace(/\]\(\.\.\/openspec\/specs\//g, '](../specs/');
 }
 
-/**
- * Render a "Related Artifacts" section with a Mermaid mini-DAG of the
- * artifact's direct neighbors. Returns the empty string when the
- * artifact has no neighborhood (e.g., a brand-new ADR with no edges
- * authored or derived). MUST be appended AFTER `escapeMdxUnsafe` so the
- * Mermaid fence stays raw.
- */
-function buildMiniDagSection(artifactId) {
-  if (!artifactId) return '';
-  const mermaid = renderNeighborMermaid(artifactId, ARTIFACT_GRAPH);
-  if (!mermaid) return '';
-  return [
-    '',
-    '',
-    '## Related Artifacts',
-    '',
-    `Direct relationships declared in YAML frontmatter (per [ADR-0023](/decisions/ADR-0023-frontmatter-dag-and-graph-skill) / [SPEC-0018](/specs/artifact-graph/spec)). Run \`/sdd:graph chain ${artifactId}\` for the transitive view.`,
-    '',
-    '```mermaid',
-    mermaid,
-    '```',
-    '',
-  ].join('\n');
-}
-
 function transformAdr(srcPath, destPath, fileName) {
   let content = fs.readFileSync(srcPath, 'utf-8');
 
@@ -197,7 +172,7 @@ ${badgeHeader}
   // Extract canonical artifact ID for the per-page mini-DAG.
   const adrIdMatch = fileName.match(/^(ADR-\d{4})/);
   const artifactId = adrIdMatch ? adrIdMatch[1] : null;
-  const miniDag = buildMiniDagSection(artifactId);
+  const miniDag = buildMiniDagSection(artifactId, ARTIFACT_GRAPH);
 
   fs.mkdirSync(path.dirname(destPath), { recursive: true });
   fs.writeFileSync(destPath, frontmatter + escapeMdxUnsafe(escapedContent) + miniDag);

--- a/docs-site/scripts/transform-adrs.js
+++ b/docs-site/scripts/transform-adrs.js
@@ -16,9 +16,18 @@ const {
   transformAdrReferences,
   fixMarkdownLinks,
 } = require('./transform-utils');
+const { buildGraph, renderNeighborMermaid } = require('./graph-data');
 
 const ADRS_SOURCE = path.join(__dirname, '../../docs/adrs');
 const ADRS_DEST = path.join(__dirname, '../../docs-generated/decisions');
+const SPECS_SOURCE_FOR_GRAPH = path.join(__dirname, '../../docs/openspec/specs');
+
+// Build the artifact graph once at module init — used to render per-page
+// mini-DAGs showing each ADR's direct neighbors (per ADR-0023 / SPEC-0018).
+const ARTIFACT_GRAPH = buildGraph({
+  adrsSource: ADRS_SOURCE,
+  specsSource: SPECS_SOURCE_FOR_GRAPH,
+});
 
 // Read baseUrl from docusaurus.config.ts
 const configPath = path.join(__dirname, '../docusaurus.config.ts');
@@ -108,6 +117,31 @@ function fixCrossSectionPaths(content) {
   return content.replace(/\]\(\.\.\/openspec\/specs\//g, '](../specs/');
 }
 
+/**
+ * Render a "Related Artifacts" section with a Mermaid mini-DAG of the
+ * artifact's direct neighbors. Returns the empty string when the
+ * artifact has no neighborhood (e.g., a brand-new ADR with no edges
+ * authored or derived). MUST be appended AFTER `escapeMdxUnsafe` so the
+ * Mermaid fence stays raw.
+ */
+function buildMiniDagSection(artifactId) {
+  if (!artifactId) return '';
+  const mermaid = renderNeighborMermaid(artifactId, ARTIFACT_GRAPH);
+  if (!mermaid) return '';
+  return [
+    '',
+    '',
+    '## Related Artifacts',
+    '',
+    `Direct relationships declared in YAML frontmatter (per [ADR-0023](/decisions/0023-frontmatter-dag-and-graph-skill) / [SPEC-0018](/specs/artifact-graph/spec)). Run \`/sdd:graph chain ${artifactId}\` for the transitive view.`,
+    '',
+    '```mermaid',
+    mermaid,
+    '```',
+    '',
+  ].join('\n');
+}
+
 function transformAdr(srcPath, destPath, fileName) {
   let content = fs.readFileSync(srcPath, 'utf-8');
 
@@ -160,8 +194,13 @@ slug: /decisions/${slug}${sidebarClassName}
 ${badgeHeader}
 `;
 
+  // Extract canonical artifact ID for the per-page mini-DAG.
+  const adrIdMatch = fileName.match(/^(ADR-\d{4})/);
+  const artifactId = adrIdMatch ? adrIdMatch[1] : null;
+  const miniDag = buildMiniDagSection(artifactId);
+
   fs.mkdirSync(path.dirname(destPath), { recursive: true });
-  fs.writeFileSync(destPath, frontmatter + escapeMdxUnsafe(escapedContent));
+  fs.writeFileSync(destPath, frontmatter + escapeMdxUnsafe(escapedContent) + miniDag);
 }
 
 function main() {

--- a/docs-site/scripts/transform-adrs.js
+++ b/docs-site/scripts/transform-adrs.js
@@ -133,7 +133,7 @@ function buildMiniDagSection(artifactId) {
     '',
     '## Related Artifacts',
     '',
-    `Direct relationships declared in YAML frontmatter (per [ADR-0023](/decisions/0023-frontmatter-dag-and-graph-skill) / [SPEC-0018](/specs/artifact-graph/spec)). Run \`/sdd:graph chain ${artifactId}\` for the transitive view.`,
+    `Direct relationships declared in YAML frontmatter (per [ADR-0023](/decisions/ADR-0023-frontmatter-dag-and-graph-skill) / [SPEC-0018](/specs/artifact-graph/spec)). Run \`/sdd:graph chain ${artifactId}\` for the transitive view.`,
     '',
     '```mermaid',
     mermaid,

--- a/docs-site/scripts/transform-openspecs.js
+++ b/docs-site/scripts/transform-openspecs.js
@@ -18,7 +18,7 @@ const {
   transformAdrReferences,
   fixMarkdownLinks,
 } = require('./transform-utils');
-const { buildGraph, renderNeighborMermaid } = require('./graph-data');
+const { buildGraph, buildMiniDagSection } = require('./graph-data');
 
 const SPECS_SOURCE = path.join(__dirname, '../../docs/openspec/specs');
 const SPECS_DEST = path.join(__dirname, '../../docs-generated/specs');
@@ -167,31 +167,6 @@ function transformRequirementTables(content) {
   });
 }
 
-/**
- * Render a "Related Artifacts" section with a Mermaid mini-DAG of the
- * artifact's direct neighbors. Returns the empty string when the
- * artifact has no neighborhood (e.g., a brand-new spec with no edges
- * authored or derived). MUST be appended AFTER `escapeMdxUnsafe` so the
- * Mermaid fence stays raw.
- */
-function buildMiniDagSection(artifactId) {
-  if (!artifactId) return '';
-  const mermaid = renderNeighborMermaid(artifactId, ARTIFACT_GRAPH);
-  if (!mermaid) return '';
-  return [
-    '',
-    '',
-    '## Related Artifacts',
-    '',
-    `Direct relationships declared in YAML frontmatter (per [ADR-0023](/decisions/ADR-0023-frontmatter-dag-and-graph-skill) / [SPEC-0018](/specs/artifact-graph/spec)). Run \`/sdd:graph chain ${artifactId}\` for the transitive view.`,
-    '',
-    '```mermaid',
-    mermaid,
-    '```',
-    '',
-  ].join('\n');
-}
-
 function transformSpec(srcPath, destPath, domain, fileType, domainConfig, flat) {
   let content = fs.readFileSync(srcPath, 'utf-8');
   const config = domainConfig[domain] || { order: 99, label: domain };
@@ -242,8 +217,8 @@ ${metadataHeader}
   // get the same neighbor graph; the mini-DAG renders identically on
   // each, which matches user expectation that "this artifact's
   // relationships" is an attribute of the artifact, not the page.
-  const artifactId = SPEC_DOMAIN_TO_ID[domain] || null;
-  const miniDag = buildMiniDagSection(artifactId);
+  const artifactId = SPEC_DOMAIN_TO_ID[domain];
+  const miniDag = buildMiniDagSection(artifactId, ARTIFACT_GRAPH);
 
   fs.mkdirSync(path.dirname(destPath), { recursive: true });
   fs.writeFileSync(destPath, frontmatter + escapeMdxUnsafe(content) + miniDag);

--- a/docs-site/scripts/transform-openspecs.js
+++ b/docs-site/scripts/transform-openspecs.js
@@ -18,6 +18,7 @@ const {
   transformAdrReferences,
   fixMarkdownLinks,
 } = require('./transform-utils');
+const { buildGraph, renderNeighborMermaid } = require('./graph-data');
 
 const SPECS_SOURCE = path.join(__dirname, '../../docs/openspec/specs');
 const SPECS_DEST = path.join(__dirname, '../../docs-generated/specs');
@@ -46,6 +47,28 @@ const ADR_EMOJI = '\ud83d\udcdd';
 const ADRS_SOURCE = path.join(__dirname, '../../docs/adrs');
 
 const ADR_MAPPING = buildAdrMapping(ADRS_SOURCE);
+
+// Build the artifact graph once at module init -- used to render
+// per-page mini-DAGs showing each spec's direct neighbors (per
+// ADR-0023 / SPEC-0018). The same graph is rebuilt by
+// transform-adrs.js; the cost is negligible (file reads + a narrow
+// YAML parser) and keeping the two scripts independent avoids a
+// shared-state ordering hazard at build time.
+const ARTIFACT_GRAPH = buildGraph({
+  adrsSource: ADRS_SOURCE,
+  specsSource: SPECS_SOURCE,
+});
+
+// Domain directory -> canonical SPEC-XXXX id, derived from the graph's
+// spec nodes (which carry their source `dir` alongside the parsed id).
+// design.md files don't carry the SPEC-XXXX in their own H1, so we look
+// up by the directory both spec.md and design.md share.
+const SPEC_DOMAIN_TO_ID = {};
+for (const node of Object.values(ARTIFACT_GRAPH.nodes)) {
+  if (node.kind === 'spec' && node.dir) {
+    SPEC_DOMAIN_TO_ID[node.dir] = node.id;
+  }
+}
 
 /** Escape double quotes for YAML frontmatter values */
 function escapeYaml(str) {
@@ -144,6 +167,31 @@ function transformRequirementTables(content) {
   });
 }
 
+/**
+ * Render a "Related Artifacts" section with a Mermaid mini-DAG of the
+ * artifact's direct neighbors. Returns the empty string when the
+ * artifact has no neighborhood (e.g., a brand-new spec with no edges
+ * authored or derived). MUST be appended AFTER `escapeMdxUnsafe` so the
+ * Mermaid fence stays raw.
+ */
+function buildMiniDagSection(artifactId) {
+  if (!artifactId) return '';
+  const mermaid = renderNeighborMermaid(artifactId, ARTIFACT_GRAPH);
+  if (!mermaid) return '';
+  return [
+    '',
+    '',
+    '## Related Artifacts',
+    '',
+    `Direct relationships declared in YAML frontmatter (per [ADR-0023](/decisions/ADR-0023-frontmatter-dag-and-graph-skill) / [SPEC-0018](/specs/artifact-graph/spec)). Run \`/sdd:graph chain ${artifactId}\` for the transitive view.`,
+    '',
+    '```mermaid',
+    mermaid,
+    '```',
+    '',
+  ].join('\n');
+}
+
 function transformSpec(srcPath, destPath, domain, fileType, domainConfig, flat) {
   let content = fs.readFileSync(srcPath, 'utf-8');
   const config = domainConfig[domain] || { order: 99, label: domain };
@@ -190,8 +238,15 @@ ${metadataHeader}
 
 `;
 
+  // Both spec.md and design.md describe the same SPEC-XXXX artifact and
+  // get the same neighbor graph; the mini-DAG renders identically on
+  // each, which matches user expectation that "this artifact's
+  // relationships" is an attribute of the artifact, not the page.
+  const artifactId = SPEC_DOMAIN_TO_ID[domain] || null;
+  const miniDag = buildMiniDagSection(artifactId);
+
   fs.mkdirSync(path.dirname(destPath), { recursive: true });
-  fs.writeFileSync(destPath, frontmatter + escapeMdxUnsafe(content));
+  fs.writeFileSync(destPath, frontmatter + escapeMdxUnsafe(content) + miniDag);
 }
 
 function generateCategoryJson(destDir, domain, domainConfig) {

--- a/skills/graph/lib/graph.py
+++ b/skills/graph/lib/graph.py
@@ -772,15 +772,12 @@ def _validate(g: Graph) -> None:
 def _validate_id_resolution(g: Graph) -> None:
     """Every artifact ID in a frontmatter edge MUST exist as a node.
 
-    TODO(Story 5): When workspace mode lands, this check must understand
-    `[module]/SPEC-XXXX` cross-module references. Today the parser
-    coerces both quoted (`["[shared-lib]/SPEC-0001"]`) and unquoted
-    (`[[shared-lib]/SPEC-0001]`) forms into the same string target, so
-    the unquoted-YAML case from SPEC-0018 REQ "Workspace Mode
-    Aggregation" Scenario "Cross-module edge with unquoted YAML rejected"
-    falls out as a generic `unresolved-id` rather than the specified
-    hard error about YAML nested-list parsing. Detect-and-distinguish in
-    Story 5.
+    Cross-module references (`[module]/SPEC-XXXX`) resolve against the
+    aggregate graph in workspace mode (per SPEC-0018 § Workspace Mode
+    Aggregation). The unquoted YAML form (`[[module]/SPEC-XXXX]`) is
+    intercepted at parse time by `_UNQUOTED_CROSS_MODULE_RE` and
+    surfaced as a `malformed-yaml` hard error before reaching this
+    check.
     """
     for edge in g.edges:
         if edge.derived:

--- a/templates/docusaurus/scripts/generate-graph.js
+++ b/templates/docusaurus/scripts/generate-graph.js
@@ -59,7 +59,7 @@ sidebar_position: 1
 
 # Architecture Graph
 
-The artifact graph captures explicit relationships between ADRs and specs declared in YAML frontmatter (per [ADR-0023](/decisions/0023-frontmatter-dag-and-graph-skill) and [SPEC-0018](/specs/artifact-graph/spec)). Edges describe \`supersedes\`, \`extends\`, \`enables\`, \`governs\`, \`implements\`, \`requires\`, and \`related\` relationships between artifacts. The page below reflects the authored edges only; derived inverses (\`governed-by\`, \`implemented-by\`, etc.) are computed at query time by the \`/sdd:graph\` skill.
+The artifact graph captures explicit relationships between ADRs and specs declared in YAML frontmatter (per [ADR-0023](/decisions/ADR-0023-frontmatter-dag-and-graph-skill) and [SPEC-0018](/specs/artifact-graph/spec)). Edges describe \`supersedes\`, \`extends\`, \`enables\`, \`governs\`, \`implements\`, \`requires\`, and \`related\` relationships between artifacts. The page below reflects the authored edges only; derived inverses (\`governed-by\`, \`implemented-by\`, etc.) are computed at query time by the \`/sdd:graph\` skill.
 
 ## Stats
 

--- a/templates/docusaurus/scripts/graph-data.js
+++ b/templates/docusaurus/scripts/graph-data.js
@@ -281,9 +281,36 @@ function renderNeighborMermaid(targetId, { nodes, edges }) {
   return lines.join('\n');
 }
 
+/**
+ * Render a "Related Artifacts" Markdown section with a Mermaid mini-DAG
+ * of the artifact's direct neighbors. Returns the empty string when the
+ * artifact has no neighborhood (e.g., a brand-new ADR/spec with no
+ * edges authored or derived) so transforms can unconditionally append
+ * the result. MUST be appended AFTER any MDX-escape pass so the Mermaid
+ * fence stays raw.
+ */
+function buildMiniDagSection(artifactId, graph) {
+  if (!artifactId) return '';
+  const mermaid = renderNeighborMermaid(artifactId, graph);
+  if (!mermaid) return '';
+  return [
+    '',
+    '',
+    '## Related Artifacts',
+    '',
+    `Direct relationships declared in YAML frontmatter (per [ADR-0023](/decisions/ADR-0023-frontmatter-dag-and-graph-skill) / [SPEC-0018](/specs/artifact-graph/spec)). Run \`/sdd:graph chain ${artifactId}\` for the transitive view.`,
+    '',
+    '```mermaid',
+    mermaid,
+    '```',
+    '',
+  ].join('\n');
+}
+
 module.exports = {
   buildGraph,
   parseFrontmatter,
   renderFullMermaid,
   renderNeighborMermaid,
+  buildMiniDagSection,
 };

--- a/templates/docusaurus/scripts/transform-adrs.js
+++ b/templates/docusaurus/scripts/transform-adrs.js
@@ -16,7 +16,7 @@ const {
   transformAdrReferences,
   fixMarkdownLinks,
 } = require('./transform-utils');
-const { buildGraph, renderNeighborMermaid } = require('./graph-data');
+const { buildGraph, buildMiniDagSection } = require('./graph-data');
 
 const ADRS_SOURCE = path.join(__dirname, '../../docs/adrs');
 const ADRS_DEST = path.join(__dirname, '../../docs-generated/decisions');
@@ -117,31 +117,6 @@ function fixCrossSectionPaths(content) {
   return content.replace(/\]\(\.\.\/openspec\/specs\//g, '](../specs/');
 }
 
-/**
- * Render a "Related Artifacts" section with a Mermaid mini-DAG of the
- * artifact's direct neighbors. Returns the empty string when the
- * artifact has no neighborhood (e.g., a brand-new ADR with no edges
- * authored or derived). MUST be appended AFTER `escapeMdxUnsafe` so the
- * Mermaid fence stays raw.
- */
-function buildMiniDagSection(artifactId) {
-  if (!artifactId) return '';
-  const mermaid = renderNeighborMermaid(artifactId, ARTIFACT_GRAPH);
-  if (!mermaid) return '';
-  return [
-    '',
-    '',
-    '## Related Artifacts',
-    '',
-    `Direct relationships declared in YAML frontmatter (per [ADR-0023](/decisions/ADR-0023-frontmatter-dag-and-graph-skill) / [SPEC-0018](/specs/artifact-graph/spec)). Run \`/sdd:graph chain ${artifactId}\` for the transitive view.`,
-    '',
-    '```mermaid',
-    mermaid,
-    '```',
-    '',
-  ].join('\n');
-}
-
 function transformAdr(srcPath, destPath, fileName) {
   let content = fs.readFileSync(srcPath, 'utf-8');
 
@@ -197,7 +172,7 @@ ${badgeHeader}
   // Extract canonical artifact ID for the per-page mini-DAG.
   const adrIdMatch = fileName.match(/^(ADR-\d{4})/);
   const artifactId = adrIdMatch ? adrIdMatch[1] : null;
-  const miniDag = buildMiniDagSection(artifactId);
+  const miniDag = buildMiniDagSection(artifactId, ARTIFACT_GRAPH);
 
   fs.mkdirSync(path.dirname(destPath), { recursive: true });
   fs.writeFileSync(destPath, frontmatter + escapeMdxUnsafe(escapedContent) + miniDag);

--- a/templates/docusaurus/scripts/transform-adrs.js
+++ b/templates/docusaurus/scripts/transform-adrs.js
@@ -16,9 +16,18 @@ const {
   transformAdrReferences,
   fixMarkdownLinks,
 } = require('./transform-utils');
+const { buildGraph, renderNeighborMermaid } = require('./graph-data');
 
 const ADRS_SOURCE = path.join(__dirname, '../../docs/adrs');
 const ADRS_DEST = path.join(__dirname, '../../docs-generated/decisions');
+const SPECS_SOURCE_FOR_GRAPH = path.join(__dirname, '../../docs/openspec/specs');
+
+// Build the artifact graph once at module init — used to render per-page
+// mini-DAGs showing each ADR's direct neighbors (per ADR-0023 / SPEC-0018).
+const ARTIFACT_GRAPH = buildGraph({
+  adrsSource: ADRS_SOURCE,
+  specsSource: SPECS_SOURCE_FOR_GRAPH,
+});
 
 // Read baseUrl from docusaurus.config.ts
 const configPath = path.join(__dirname, '../docusaurus.config.ts');
@@ -108,6 +117,31 @@ function fixCrossSectionPaths(content) {
   return content.replace(/\]\(\.\.\/openspec\/specs\//g, '](../specs/');
 }
 
+/**
+ * Render a "Related Artifacts" section with a Mermaid mini-DAG of the
+ * artifact's direct neighbors. Returns the empty string when the
+ * artifact has no neighborhood (e.g., a brand-new ADR with no edges
+ * authored or derived). MUST be appended AFTER `escapeMdxUnsafe` so the
+ * Mermaid fence stays raw.
+ */
+function buildMiniDagSection(artifactId) {
+  if (!artifactId) return '';
+  const mermaid = renderNeighborMermaid(artifactId, ARTIFACT_GRAPH);
+  if (!mermaid) return '';
+  return [
+    '',
+    '',
+    '## Related Artifacts',
+    '',
+    `Direct relationships declared in YAML frontmatter (per [ADR-0023](/decisions/0023-frontmatter-dag-and-graph-skill) / [SPEC-0018](/specs/artifact-graph/spec)). Run \`/sdd:graph chain ${artifactId}\` for the transitive view.`,
+    '',
+    '```mermaid',
+    mermaid,
+    '```',
+    '',
+  ].join('\n');
+}
+
 function transformAdr(srcPath, destPath, fileName) {
   let content = fs.readFileSync(srcPath, 'utf-8');
 
@@ -160,8 +194,13 @@ slug: /decisions/${slug}${sidebarClassName}
 ${badgeHeader}
 `;
 
+  // Extract canonical artifact ID for the per-page mini-DAG.
+  const adrIdMatch = fileName.match(/^(ADR-\d{4})/);
+  const artifactId = adrIdMatch ? adrIdMatch[1] : null;
+  const miniDag = buildMiniDagSection(artifactId);
+
   fs.mkdirSync(path.dirname(destPath), { recursive: true });
-  fs.writeFileSync(destPath, frontmatter + escapeMdxUnsafe(escapedContent));
+  fs.writeFileSync(destPath, frontmatter + escapeMdxUnsafe(escapedContent) + miniDag);
 }
 
 function main() {

--- a/templates/docusaurus/scripts/transform-adrs.js
+++ b/templates/docusaurus/scripts/transform-adrs.js
@@ -133,7 +133,7 @@ function buildMiniDagSection(artifactId) {
     '',
     '## Related Artifacts',
     '',
-    `Direct relationships declared in YAML frontmatter (per [ADR-0023](/decisions/0023-frontmatter-dag-and-graph-skill) / [SPEC-0018](/specs/artifact-graph/spec)). Run \`/sdd:graph chain ${artifactId}\` for the transitive view.`,
+    `Direct relationships declared in YAML frontmatter (per [ADR-0023](/decisions/ADR-0023-frontmatter-dag-and-graph-skill) / [SPEC-0018](/specs/artifact-graph/spec)). Run \`/sdd:graph chain ${artifactId}\` for the transitive view.`,
     '',
     '```mermaid',
     mermaid,

--- a/templates/docusaurus/scripts/transform-openspecs.js
+++ b/templates/docusaurus/scripts/transform-openspecs.js
@@ -18,7 +18,7 @@ const {
   transformAdrReferences,
   fixMarkdownLinks,
 } = require('./transform-utils');
-const { buildGraph, renderNeighborMermaid } = require('./graph-data');
+const { buildGraph, buildMiniDagSection } = require('./graph-data');
 
 const SPECS_SOURCE = path.join(__dirname, '../../docs/openspec/specs');
 const SPECS_DEST = path.join(__dirname, '../../docs-generated/specs');
@@ -167,31 +167,6 @@ function transformRequirementTables(content) {
   });
 }
 
-/**
- * Render a "Related Artifacts" section with a Mermaid mini-DAG of the
- * artifact's direct neighbors. Returns the empty string when the
- * artifact has no neighborhood (e.g., a brand-new spec with no edges
- * authored or derived). MUST be appended AFTER `escapeMdxUnsafe` so the
- * Mermaid fence stays raw.
- */
-function buildMiniDagSection(artifactId) {
-  if (!artifactId) return '';
-  const mermaid = renderNeighborMermaid(artifactId, ARTIFACT_GRAPH);
-  if (!mermaid) return '';
-  return [
-    '',
-    '',
-    '## Related Artifacts',
-    '',
-    `Direct relationships declared in YAML frontmatter (per [ADR-0023](/decisions/ADR-0023-frontmatter-dag-and-graph-skill) / [SPEC-0018](/specs/artifact-graph/spec)). Run \`/sdd:graph chain ${artifactId}\` for the transitive view.`,
-    '',
-    '```mermaid',
-    mermaid,
-    '```',
-    '',
-  ].join('\n');
-}
-
 function transformSpec(srcPath, destPath, domain, fileType, domainConfig, flat) {
   let content = fs.readFileSync(srcPath, 'utf-8');
   const config = domainConfig[domain] || { order: 99, label: domain };
@@ -242,8 +217,8 @@ ${metadataHeader}
   // get the same neighbor graph; the mini-DAG renders identically on
   // each, which matches user expectation that "this artifact's
   // relationships" is an attribute of the artifact, not the page.
-  const artifactId = SPEC_DOMAIN_TO_ID[domain] || null;
-  const miniDag = buildMiniDagSection(artifactId);
+  const artifactId = SPEC_DOMAIN_TO_ID[domain];
+  const miniDag = buildMiniDagSection(artifactId, ARTIFACT_GRAPH);
 
   fs.mkdirSync(path.dirname(destPath), { recursive: true });
   fs.writeFileSync(destPath, frontmatter + escapeMdxUnsafe(content) + miniDag);

--- a/templates/docusaurus/scripts/transform-openspecs.js
+++ b/templates/docusaurus/scripts/transform-openspecs.js
@@ -18,6 +18,7 @@ const {
   transformAdrReferences,
   fixMarkdownLinks,
 } = require('./transform-utils');
+const { buildGraph, renderNeighborMermaid } = require('./graph-data');
 
 const SPECS_SOURCE = path.join(__dirname, '../../docs/openspec/specs');
 const SPECS_DEST = path.join(__dirname, '../../docs-generated/specs');
@@ -46,6 +47,28 @@ const ADR_EMOJI = '\ud83d\udcdd';
 const ADRS_SOURCE = path.join(__dirname, '../../docs/adrs');
 
 const ADR_MAPPING = buildAdrMapping(ADRS_SOURCE);
+
+// Build the artifact graph once at module init -- used to render
+// per-page mini-DAGs showing each spec's direct neighbors (per
+// ADR-0023 / SPEC-0018). The same graph is rebuilt by
+// transform-adrs.js; the cost is negligible (file reads + a narrow
+// YAML parser) and keeping the two scripts independent avoids a
+// shared-state ordering hazard at build time.
+const ARTIFACT_GRAPH = buildGraph({
+  adrsSource: ADRS_SOURCE,
+  specsSource: SPECS_SOURCE,
+});
+
+// Domain directory -> canonical SPEC-XXXX id, derived from the graph's
+// spec nodes (which carry their source `dir` alongside the parsed id).
+// design.md files don't carry the SPEC-XXXX in their own H1, so we look
+// up by the directory both spec.md and design.md share.
+const SPEC_DOMAIN_TO_ID = {};
+for (const node of Object.values(ARTIFACT_GRAPH.nodes)) {
+  if (node.kind === 'spec' && node.dir) {
+    SPEC_DOMAIN_TO_ID[node.dir] = node.id;
+  }
+}
 
 /** Escape double quotes for YAML frontmatter values */
 function escapeYaml(str) {
@@ -144,6 +167,31 @@ function transformRequirementTables(content) {
   });
 }
 
+/**
+ * Render a "Related Artifacts" section with a Mermaid mini-DAG of the
+ * artifact's direct neighbors. Returns the empty string when the
+ * artifact has no neighborhood (e.g., a brand-new spec with no edges
+ * authored or derived). MUST be appended AFTER `escapeMdxUnsafe` so the
+ * Mermaid fence stays raw.
+ */
+function buildMiniDagSection(artifactId) {
+  if (!artifactId) return '';
+  const mermaid = renderNeighborMermaid(artifactId, ARTIFACT_GRAPH);
+  if (!mermaid) return '';
+  return [
+    '',
+    '',
+    '## Related Artifacts',
+    '',
+    `Direct relationships declared in YAML frontmatter (per [ADR-0023](/decisions/ADR-0023-frontmatter-dag-and-graph-skill) / [SPEC-0018](/specs/artifact-graph/spec)). Run \`/sdd:graph chain ${artifactId}\` for the transitive view.`,
+    '',
+    '```mermaid',
+    mermaid,
+    '```',
+    '',
+  ].join('\n');
+}
+
 function transformSpec(srcPath, destPath, domain, fileType, domainConfig, flat) {
   let content = fs.readFileSync(srcPath, 'utf-8');
   const config = domainConfig[domain] || { order: 99, label: domain };
@@ -190,8 +238,15 @@ ${metadataHeader}
 
 `;
 
+  // Both spec.md and design.md describe the same SPEC-XXXX artifact and
+  // get the same neighbor graph; the mini-DAG renders identically on
+  // each, which matches user expectation that "this artifact's
+  // relationships" is an attribute of the artifact, not the page.
+  const artifactId = SPEC_DOMAIN_TO_ID[domain] || null;
+  const miniDag = buildMiniDagSection(artifactId);
+
   fs.mkdirSync(path.dirname(destPath), { recursive: true });
-  fs.writeFileSync(destPath, frontmatter + escapeMdxUnsafe(content));
+  fs.writeFileSync(destPath, frontmatter + escapeMdxUnsafe(content) + miniDag);
 }
 
 function generateCategoryJson(destDir, domain, domainConfig) {


### PR DESCRIPTION
## Summary
- Adds a **Related Artifacts** section to every generated ADR, spec, and design page with a Mermaid mini-DAG of the artifact's direct neighbors (authored edges out, derived inverses in). Implements the per-page footer hook that `graph-data.js` was already designed for (per ADR-0023 / SPEC-0018).
- Wires the change into **both** copies of each script: `templates/docusaurus/scripts/` (the scaffold downstream projects pick up) and `docs-site/scripts/` (this repo's own published docs) — staying in sync with the pattern from #87.
- For specs, both `spec.md` and `design.md` describe the same `SPEC-XXXX` artifact and render the same neighborhood graph. `design.md` files don't carry the SPEC-XXXX in their own H1, so the artifact ID is looked up via a domain-directory → SPEC-XXXX map derived from the graph's spec nodes.
- Drops a stale `TODO(Story 5)` in `skills/graph/lib/graph.py`. Stories 5/6/7 shipped; the unquoted-YAML cross-module form is now intercepted at parse time as `malformed-yaml`, so the docstring rationale matches the actual code path.

## Drive-by fix
The mini-DAG section text and the Architecture Graph index page (added in #87) linked to `/decisions/0023-frontmatter-dag-and-graph-skill`, but ADR pages are emitted at `/decisions/ADR-XXXX-<slug>`. Fixed in three places (both ADR + spec mini-DAG sections, and `generate-graph.js`), in both `docs-site/` and `templates/docusaurus/` copies.

## Test plan
- [x] `npm run build-content` → 22/23 ADRs and 36/36 spec+design pages get a Related Artifacts block (the ADR without one has zero edges, correctly skipped)
- [x] `npx docusaurus build` → completes with `[SUCCESS]`, no MDX parse errors
- [x] `grep -rn "decisions/0023" docs-generated/ scripts/` returns empty — slug fix landed everywhere
- [x] Broken link count unchanged at 88 (all pre-existing, none from this PR)
- [x] `transform-adrs.js`, `transform-openspecs.js`, and `generate-graph.js` are byte-identical between `docs-site/` and `templates/docusaurus/`
- [ ] Visual spot-check on ADR + spec + design pages once the GitHub Pages workflow runs (or `npm run serve` locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)