### PR TITLE
evals: cross-skill pipeline test scaffold (spec → plan → work) — 1/3 of #64

### DIFF
--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -237,10 +237,11 @@ jobs:
 
   eval-pipeline:
     # Cross-skill pipeline scenarios (per SPEC-0017 REQ "Cross-Skill Pipeline
-    # Testing"). Expensive -- each scenario invokes 4+ skills end-to-end on
-    # a disposable repo. Runs ONLY on release-targeting PRs or manual
-    # workflow_dispatch with mode=pipeline. Not part of per-PR quick mode.
-    needs: determine-mode
+    # Testing"). Expensive -- each scenario invokes multiple skills
+    # end-to-end on a disposable repo. Runs ONLY on release-targeting PRs
+    # or manual workflow_dispatch with mode=pipeline. Not part of per-PR
+    # quick mode. Independent of determine-mode (no needs:) since the if:
+    # is purely event-driven.
     if: |
       (github.event_name == 'workflow_dispatch' && inputs.mode == 'pipeline') ||
       (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release/'))
@@ -349,21 +350,48 @@ jobs:
           prompt: |
             Aggregate eval results from eval-results/*.json and post a summary PR comment.
 
-            1. Read all JSON files in eval-results/
-            2. Build a benchmark summary table with columns: Skill | Tier | Evals | Passed | Rate
-            3. Calculate overall pass rate and per-tier pass rates
+            Two result shapes exist in eval-results/:
+
+            (A) Per-skill eval files (tier3.json, changed.json, full.json) -
+                each contains `results[]` where each entry has
+                {eval_id, skill, passed, assertions[]}. Aggregate these
+                into the per-skill summary table.
+
+            (B) Pipeline file (pipeline.json) - contains `scenarios[]`
+                where each entry has {id, passed, steps[],
+                final_assertion_results[]}. This is a fundamentally
+                different shape (scenarios, not evals; steps, not
+                skills). Render it as a SEPARATE section, not in the
+                per-skill table.
+
+            1. Read all JSON files in eval-results/. Classify each by
+               shape (A or B).
+            2. For shape (A): build a benchmark summary table with
+               columns: Skill | Tier | Evals | Passed | Rate.
+               Calculate overall pass rate and per-tier pass rates.
+            3. For shape (B): build a pipeline section listing each
+               scenario with its id, pass/fail, the per-step verify
+               summary, and the final_assertion_results. Include in the
+               PR comment ONLY if pipeline.json is present (most PRs
+               don't run pipeline mode).
             4. Format as a GitHub PR comment with:
                - Header: "## Skill Eval Results"
-               - Mode badge: quick or full
-               - Summary table
-               - Per-tier breakdown
+               - Mode badge: quick / full / pipeline (whichever ran)
+               - Summary table (shape A)
+               - Per-tier breakdown (shape A)
+               - Pipeline section (shape B, if present)
                - Threshold check: Tier 1 must be >80% pass rate
                - If Tier 1 < 80%, add a prominent warning
             5. Post the comment on PR #${{ github.event.pull_request.number }} using:
                gh pr comment ${{ github.event.pull_request.number }} --body "<comment>"
-            6. Write the aggregated results to eval-results/summary.json
+            6. Write the aggregated results to eval-results/summary.json,
+               including a top-level `pipeline` key when shape (B) data
+               exists: {"pipeline": {"scenarios": <n>, "passed": <n>}}.
 
-            If Tier 1 pass rate is below 80%, exit with code 1 to fail the check.
+            If Tier 1 pass rate is below 80%, exit with code 1 to fail
+            the check. Pipeline scenario failures do NOT fail the
+            workflow at this layer -- they're advisory until the
+            scenarios stabilize.
 
       - name: Upload summary
         if: always()

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -16,6 +16,7 @@ on:
         options:
           - quick
           - full
+          - pipeline
 
 permissions:
   contents: read
@@ -234,8 +235,95 @@ jobs:
           path: eval-results/full.json
           if-no-files-found: warn
 
+  eval-pipeline:
+    # Cross-skill pipeline scenarios (per SPEC-0017 REQ "Cross-Skill Pipeline
+    # Testing"). Expensive -- each scenario invokes 4+ skills end-to-end on
+    # a disposable repo. Runs ONLY on release-targeting PRs or manual
+    # workflow_dispatch with mode=pipeline. Not part of per-PR quick mode.
+    needs: determine-mode
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.mode == 'pipeline') ||
+      (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release/'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run pipeline scenarios
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Run every scenario in evals/pipeline/*.json against a disposable
+            test repository, per SPEC-0017 REQ "Cross-Skill Pipeline Testing".
+
+            For each scenario file:
+            1. Read the scenario JSON (id, description, setup, steps,
+               final_assertions).
+            2. Create a disposable test repo per setup.repo_strategy:
+               - "local-tmp-init": mktemp -d, cd into it, git init, write
+                 setup.seed.claude_md to ./CLAUDE.md, write each
+                 setup.seed.files entry, git add + initial commit.
+               - "gh-template": gh repo create with --template, clone, then
+                 enter the clone. Record the repo URL for cleanup.
+            3. Execute each step in order:
+               a. cd into the test repo.
+               b. Invoke the named skill via the matching slash command
+                  (e.g., step.skill="spec" -> /sdd:spec) using step.prompt.
+               c. Check each assertion in step.verify against the repo
+                  state. Record pass/fail with a short reason.
+               d. If a verify check fails, record it but continue to the
+                  next step so we surface as much information as possible.
+            4. Run final_assertions against the final repo state.
+            5. Clean up:
+               - local-tmp-init: rm -rf the temp dir.
+               - gh-template: gh repo delete --yes the created repo.
+
+            Output results to eval-results/pipeline.json:
+            {
+              "tier": "pipeline",
+              "timestamp": "<ISO 8601>",
+              "scenarios": [
+                {
+                  "id": "<scenario-id>",
+                  "passed": <boolean>,
+                  "steps": [
+                    {
+                      "step": <number>,
+                      "skill": "<name>",
+                      "passed": <boolean>,
+                      "verify_results": [
+                        { "text": "<assertion>", "passed": <boolean>, "reason": "<why>" }
+                      ]
+                    }
+                  ],
+                  "final_assertion_results": [
+                    { "text": "<assertion>", "passed": <boolean>, "reason": "<why>" }
+                  ]
+                }
+              ],
+              "summary": { "scenarios": <n>, "passed": <n>, "failed": <n> }
+            }
+
+            IMPORTANT: pipeline scenarios MUST NOT push branches, open PRs,
+            or create issues against any real tracker. The seeded CLAUDE.md
+            in each scenario configures the tasks.md fallback to enforce
+            this. If you detect outbound calls to api.github.com,
+            gitea.*, or gitlab.*, fail the scenario and record the
+            attempted call in the verify_results.
+
+      - name: Upload pipeline results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results-pipeline
+          path: eval-results/pipeline.json
+          if-no-files-found: warn
+
   report:
-    needs: [eval-tier3, eval-changed, eval-full]
+    needs: [eval-tier3, eval-changed, eval-full, eval-pipeline]
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:

--- a/evals/README.md
+++ b/evals/README.md
@@ -45,16 +45,16 @@ The `skill-evals.yml` workflow triggers automatically on PRs that modify:
 
 - **Quick mode** (default): Runs Tier 3 evals + evals for changed skills
 - **Full mode**: Runs all 39 evals across all tiers
-- **Pipeline mode**: Runs cross-skill end-to-end scenarios from `pipeline/` against a disposable test repo
+- **Pipeline mode**: Runs the cross-skill end-to-end scenarios from `pipeline/` _in addition to_ the Tier 3 baseline (so a manual pipeline run still gets baseline regression signal)
 
 Full mode activates when:
 - PR has the `full-eval` label
 - Manual workflow dispatch with `mode: full`
 - PR targets a `release/*` branch
 
-Pipeline mode activates when:
-- Manual workflow dispatch with `mode: pipeline`
-- PR targets a `release/*` branch (alongside full mode)
+Pipeline-mode scenarios run when:
+- Manual workflow dispatch with `mode: pipeline` (Tier 3 + pipeline)
+- PR targets a `release/*` branch (full mode + pipeline together)
 
 ### Manual Trigger
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -16,6 +16,7 @@ Automated evaluation framework for the 15 SDD plugin skills.
 - `tier1.json` - Tier 1 evals only (15 prompts)
 - `tier2.json` - Tier 2 evals only (10 prompts)
 - `tier3.json` - Tier 3 evals only (14 prompts)
+- `pipeline/` - Cross-skill end-to-end scenarios (release-only, see [`pipeline/README.md`](pipeline/README.md))
 - `benchmarks/` - Persisted benchmark results on merge
 
 ## Running Evals Locally
@@ -44,15 +45,20 @@ The `skill-evals.yml` workflow triggers automatically on PRs that modify:
 
 - **Quick mode** (default): Runs Tier 3 evals + evals for changed skills
 - **Full mode**: Runs all 39 evals across all tiers
+- **Pipeline mode**: Runs cross-skill end-to-end scenarios from `pipeline/` against a disposable test repo
 
 Full mode activates when:
 - PR has the `full-eval` label
 - Manual workflow dispatch with `mode: full`
 - PR targets a `release/*` branch
 
+Pipeline mode activates when:
+- Manual workflow dispatch with `mode: pipeline`
+- PR targets a `release/*` branch (alongside full mode)
+
 ### Manual Trigger
 
-Go to Actions > Skill Evaluations > Run workflow, and select `quick` or `full`.
+Go to Actions > Skill Evaluations > Run workflow, and select `quick`, `full`, or `pipeline`.
 
 ## Adding Evals for a New Skill
 

--- a/evals/pipeline/README.md
+++ b/evals/pipeline/README.md
@@ -8,7 +8,9 @@ Governing: [ADR-0021](../../docs/adrs/ADR-0021-skill-evaluation-and-ci-testing.m
 
 The standard evals in `evals/evals.json` test each skill in isolation: one prompt, one skill, one set of assertions. That doesn't catch regressions in the *handoff* between skills — a `/sdd:plan` issue body that `/sdd:work` can't parse, a worktree branch that `/sdd:review` can't open a PR against, a spec format that `/sdd:plan` reads differently than `/sdd:spec` writes.
 
-Pipeline scenarios run a sequence (spec → plan → work → review) on a disposable repo and verify that the artifacts each skill produces are consumable by the next.
+Pipeline scenarios run a sequence (spec → plan → work, with review coverage planned) on a disposable repo and verify that the artifacts each skill produces are consumable by the next.
+
+> **Coverage note:** SPEC-0017 REQ "Cross-Skill Pipeline Testing" Scenario "Full pipeline test" specifies the full chain through `/sdd:review`. The current scaffold covers spec → plan → work only. `/sdd:review` operates against real GitHub/Gitea PRs, which is incompatible with the `local-tmp-init` repo strategy this scaffold uses. Review coverage will land in a follow-up scenario that adopts the `gh-template` strategy (real disposable repo, real PR), tracked separately.
 
 ## When these run
 
@@ -86,4 +88,4 @@ The CI runner (`eval-pipeline` job in `skill-evals.yml`) automates all of the ab
 
 | ID | Description |
 |----|-------------|
-| [`core-workflow`](core-workflow.json) | Spec → plan → work → review on a fresh local-tmp repo, verifying artifact flow at each handoff |
+| [`core-workflow`](core-workflow.json) | Spec → plan → work on a fresh local-tmp repo, verifying artifact flow at each handoff. Review coverage deferred (see "Coverage note" above) |

--- a/evals/pipeline/README.md
+++ b/evals/pipeline/README.md
@@ -1,0 +1,89 @@
+# Pipeline Eval Scenarios
+
+End-to-end test scenarios that invoke multiple skills in sequence against a disposable test repository.
+
+Governing: [ADR-0021](../../docs/adrs/ADR-0021-skill-evaluation-and-ci-testing.md), SPEC-0017 REQ "Cross-Skill Pipeline Testing".
+
+## What this is for
+
+The standard evals in `evals/evals.json` test each skill in isolation: one prompt, one skill, one set of assertions. That doesn't catch regressions in the *handoff* between skills — a `/sdd:plan` issue body that `/sdd:work` can't parse, a worktree branch that `/sdd:review` can't open a PR against, a spec format that `/sdd:plan` reads differently than `/sdd:spec` writes.
+
+Pipeline scenarios run a sequence (spec → plan → work → review) on a disposable repo and verify that the artifacts each skill produces are consumable by the next.
+
+## When these run
+
+Pipeline tests are **not** part of the per-PR eval suite — each scenario takes minutes and consumes meaningful API budget. They run only when:
+
+- A PR targets a `release/*` branch (release-gate)
+- Someone manually triggers the workflow via `Actions → Skill Evaluations → Run workflow` and selects pipeline mode
+- A maintainer runs the scenario locally for debugging (see "Running locally" below)
+
+## Scenario file format
+
+Each scenario is a JSON file in this directory. Schema:
+
+```json
+{
+  "id": "core-workflow",
+  "description": "Human-readable summary of what this scenario covers",
+  "setup": {
+    "repo_strategy": "local-tmp-init",
+    "seed": {
+      "claude_md": "<contents of CLAUDE.md to seed the disposable repo with>",
+      "files": []
+    }
+  },
+  "steps": [
+    {
+      "step": 1,
+      "skill": "spec",
+      "prompt": "<prompt to send when invoking the skill>",
+      "verify": [
+        "<assertion>",
+        "..."
+      ]
+    }
+  ],
+  "final_assertions": [
+    "<cross-step assertion verifying artifact handoff>"
+  ]
+}
+```
+
+Field reference:
+
+- `id` — kebab-case identifier, must match the filename stem
+- `description` — short human-readable purpose
+- `setup.repo_strategy` — `local-tmp-init` (preferred; `git init` in a temp dir) or `gh-template` (creates a real disposable repo via `gh repo create --template`)
+- `setup.seed.claude_md` — content for the seed `CLAUDE.md`. Tracker config in this file MUST select `tasks.md` fallback so the scenario doesn't pollute real issue trackers
+- `setup.seed.files` — additional seed files (e.g., a starter ADR if the scenario needs one)
+- `steps` — ordered skill invocations. Each step's `verify` list is checked before the next step runs
+- `final_assertions` — cross-step checks verifying artifacts flowed correctly between skills
+
+## Running locally
+
+```bash
+# From the plugin root, with claude-code installed:
+mkdir -p /tmp/sdd-pipeline-eval && cd /tmp/sdd-pipeline-eval
+git init
+# ...seed files per the scenario's setup section...
+# ...invoke each skill via `claude -p "/sdd:<skill> <prompt>"`...
+# Verify artifacts after each step.
+# Clean up: rm -rf /tmp/sdd-pipeline-eval
+```
+
+The CI runner (`eval-pipeline` job in `skill-evals.yml`) automates all of the above using `claude-code-action`.
+
+## Adding a new scenario
+
+1. Pick a kebab-case `id` (e.g., `discover-then-spec`)
+2. Create `evals/pipeline/{id}.json` matching the schema above
+3. Use `tasks.md` fallback in the seeded CLAUDE.md so the scenario doesn't depend on a tracker
+4. Verify locally before pushing — pipeline tests are expensive in CI
+5. Update this README's scenario list
+
+## Current scenarios
+
+| ID | Description |
+|----|-------------|
+| [`core-workflow`](core-workflow.json) | Spec → plan → work → review on a fresh local-tmp repo, verifying artifact flow at each handoff |

--- a/evals/pipeline/core-workflow.json
+++ b/evals/pipeline/core-workflow.json
@@ -1,16 +1,15 @@
 {
   "id": "core-workflow",
-  "description": "spec -> plan -> work -> review on a disposable local-tmp repo. Verifies that each skill consumes the prior skill's artifacts cleanly: the spec is parseable by /sdd:plan, the issue bodies are parseable by /sdd:work, and the work branch is reviewable by /sdd:review.",
+  "description": "spec -> plan -> work on a disposable local-tmp repo. Verifies that each skill consumes the prior skill's artifacts cleanly: the spec is parseable by /sdd:plan and the issue bodies are parseable by /sdd:work. Review coverage is deferred -- /sdd:review operates against real PRs and the offline-review path it would need for a local-tmp scenario does not exist yet (tracked separately).",
   "setup": {
     "repo_strategy": "local-tmp-init",
     "seed": {
-      "claude_md": "# Pipeline Eval Test Repo\n\nDisposable repo seeded by the SDD plugin's pipeline eval suite. Do not push to a remote; do not open issues against any real tracker. The absence of a tracker section below is intentional -- it forces the `tasks.md` fallback per SPEC \"tasks-md-fallback\".\n\n## SDD Configuration\n\n### Branch Conventions\n- **Prefix**: feature/\n- **Slug length**: 40\n\n### PR Conventions\n- **Close keyword**: Closes\n- **Spec reference**: Include SPEC-XXXX in PR body\n\n### Review\n- **Max pairs**: 1\n- **Merge strategy**: squash\n",
+      "claude_md": "# Pipeline Eval Test Repo\n\nDisposable repo seeded by the SDD plugin's pipeline eval suite. Do not push to a remote; do not open issues against any real tracker. The absence of a tracker section below is intentional -- it forces the `tasks.md` fallback per SPEC \"tasks-md-fallback\".\n\n## SDD Configuration\n\n### Branch Conventions\n- **Prefix**: feature/\n- **Slug length**: 40\n\n### PR Conventions\n- **Close keyword**: Closes\n- **Spec reference**: Include SPEC-XXXX in PR body\n",
       "files": []
     }
   },
   "steps": [
     {
-      "step": 1,
       "skill": "spec",
       "prompt": "Create a spec for a small webhook-delivery service: it accepts JSON payloads at POST /webhook, validates an HMAC-SHA256 signature header, and forwards verified payloads to a configurable downstream URL with at-most-once-per-request retry semantics.",
       "verify": [
@@ -21,9 +20,8 @@
       ]
     },
     {
-      "step": 2,
       "skill": "plan",
-      "prompt": "Plan the spec we just created into trackable issues. Use the tasks.md fallback configured in CLAUDE.md. Don't open any GitHub or Gitea issues.",
+      "prompt": "Plan the spec we just created into trackable issues using the tasks.md fallback (no tracker is configured in CLAUDE.md, so the fallback should engage automatically).",
       "verify": [
         "tasks.md exists at the repo root",
         "tasks.md contains at least one epic entry and at least three story entries",
@@ -33,31 +31,19 @@
       ]
     },
     {
-      "step": 3,
       "skill": "work",
-      "prompt": "Pick the foundation story (or the first story if no foundation was detected) from tasks.md and implement it. Use a worktree under .git/worktrees/. Stop after the implementation is committed locally; do not push or open a PR.",
+      "prompt": "Pick the foundation story (or the first story if no foundation was detected) from tasks.md and implement it via a git worktree. Stop after the implementation is committed locally; do not push or open a PR.",
       "verify": [
+        "`git worktree list` reports at least one worktree besides the main one",
         "A new git branch matching feature/{N}-{slug} exists locally",
         "At least one commit was made on that branch with files implementing the chosen story",
-        "The commit message references the story id from tasks.md",
-        "If a worktree was created, it lives under the main repo's .git/worktrees/ directory"
-      ]
-    },
-    {
-      "step": 4,
-      "skill": "review",
-      "prompt": "Review the work branch we just created using a single reviewer-responder agent pair. Operate offline against the local branch (no remote, no real PR). Produce review feedback as a markdown file at .sdd-pipeline-review.md and have the responder either rebut or apply changes.",
-      "verify": [
-        ".sdd-pipeline-review.md exists at the repo root with a 'Reviewer' section and a 'Responder' section",
-        "The review references the story id from tasks.md and the SPEC-XXXX id from step 1",
-        "The responder section either contains rebuttals or a list of follow-up commit hashes on the work branch"
+        "The commit message references the story id from tasks.md"
       ]
     }
   ],
   "final_assertions": [
     "Step 2's plan references the SPEC-XXXX id created in step 1 (verifies spec -> plan handoff)",
     "Step 3's branch name matches a Branch line from a story entry in tasks.md (verifies plan -> work handoff)",
-    "Step 4's review references both the SPEC-XXXX id and the work branch (verifies work -> review handoff)",
     "No outbound network calls were made to api.github.com, gitea.*, or gitlab.* (the scenario must not pollute real trackers)",
     "The temp repo was cleaned up after the run (the runner removes the working tree on completion)"
   ]

--- a/evals/pipeline/core-workflow.json
+++ b/evals/pipeline/core-workflow.json
@@ -1,0 +1,64 @@
+{
+  "id": "core-workflow",
+  "description": "spec -> plan -> work -> review on a disposable local-tmp repo. Verifies that each skill consumes the prior skill's artifacts cleanly: the spec is parseable by /sdd:plan, the issue bodies are parseable by /sdd:work, and the work branch is reviewable by /sdd:review.",
+  "setup": {
+    "repo_strategy": "local-tmp-init",
+    "seed": {
+      "claude_md": "# Pipeline Eval Test Repo\n\nDisposable repo seeded by the SDD plugin's pipeline eval suite. Do not push to a remote; do not open issues against any real tracker. The absence of a tracker section below is intentional -- it forces the `tasks.md` fallback per SPEC \"tasks-md-fallback\".\n\n## SDD Configuration\n\n### Branch Conventions\n- **Prefix**: feature/\n- **Slug length**: 40\n\n### PR Conventions\n- **Close keyword**: Closes\n- **Spec reference**: Include SPEC-XXXX in PR body\n\n### Review\n- **Max pairs**: 1\n- **Merge strategy**: squash\n",
+      "files": []
+    }
+  },
+  "steps": [
+    {
+      "step": 1,
+      "skill": "spec",
+      "prompt": "Create a spec for a small webhook-delivery service: it accepts JSON payloads at POST /webhook, validates an HMAC-SHA256 signature header, and forwards verified payloads to a configurable downstream URL with at-most-once-per-request retry semantics.",
+      "verify": [
+        "A directory under docs/openspec/specs/ was created and contains a spec.md file",
+        "spec.md has a top-level heading matching '# SPEC-XXXX: <title>'",
+        "spec.md uses RFC 2119 keywords (MUST, SHOULD, MAY) at least three times",
+        "spec.md contains at least one '#### Scenario:' subsection per requirement"
+      ]
+    },
+    {
+      "step": 2,
+      "skill": "plan",
+      "prompt": "Plan the spec we just created into trackable issues. Use the tasks.md fallback configured in CLAUDE.md. Don't open any GitHub or Gitea issues.",
+      "verify": [
+        "tasks.md exists at the repo root",
+        "tasks.md contains at least one epic entry and at least three story entries",
+        "Each story entry includes a Branch line matching the feature/{N}-{slug} convention from CLAUDE.md",
+        "Each story entry includes a PR Convention section with a 'Closes #N' close keyword",
+        "Each story entry references the spec by its SPEC-XXXX id"
+      ]
+    },
+    {
+      "step": 3,
+      "skill": "work",
+      "prompt": "Pick the foundation story (or the first story if no foundation was detected) from tasks.md and implement it. Use a worktree under .git/worktrees/. Stop after the implementation is committed locally; do not push or open a PR.",
+      "verify": [
+        "A new git branch matching feature/{N}-{slug} exists locally",
+        "At least one commit was made on that branch with files implementing the chosen story",
+        "The commit message references the story id from tasks.md",
+        "If a worktree was created, it lives under the main repo's .git/worktrees/ directory"
+      ]
+    },
+    {
+      "step": 4,
+      "skill": "review",
+      "prompt": "Review the work branch we just created using a single reviewer-responder agent pair. Operate offline against the local branch (no remote, no real PR). Produce review feedback as a markdown file at .sdd-pipeline-review.md and have the responder either rebut or apply changes.",
+      "verify": [
+        ".sdd-pipeline-review.md exists at the repo root with a 'Reviewer' section and a 'Responder' section",
+        "The review references the story id from tasks.md and the SPEC-XXXX id from step 1",
+        "The responder section either contains rebuttals or a list of follow-up commit hashes on the work branch"
+      ]
+    }
+  ],
+  "final_assertions": [
+    "Step 2's plan references the SPEC-XXXX id created in step 1 (verifies spec -> plan handoff)",
+    "Step 3's branch name matches a Branch line from a story entry in tasks.md (verifies plan -> work handoff)",
+    "Step 4's review references both the SPEC-XXXX id and the work branch (verifies work -> review handoff)",
+    "No outbound network calls were made to api.github.com, gitea.*, or gitlab.* (the scenario must not pollute real trackers)",
+    "The temp repo was cleaned up after the run (the runner removes the working tree on completion)"
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `evals/pipeline/` with one initial scenario (`core-workflow.json`) covering **spec → plan → work** on a disposable local-tmp repo. Each step's verify list checks that the artifacts the prior skill produced are consumable by the next.
- Wires a new `eval-pipeline` job into `.github/workflows/skill-evals.yml`, gated to PRs targeting `release/*` and manual `workflow_dispatch` with `mode=pipeline`. Pipeline tests are deliberately not part of the per-PR quick suite.
- Extends the `report` job's prompt so it knows about pipeline-shaped results (`scenarios[]` with `final_assertion_results[]`) and renders them in a separate section instead of trying to coerce them into the per-skill table.
- Seeded CLAUDE.md for the disposable repo intentionally omits the tracker section to force the `tasks.md` fallback, so no scenario run can pollute real GitHub/Gitea/GitLab projects.

## Coverage gap (deliberate)
SPEC-0017 REQ "Cross-Skill Pipeline Testing" Scenario "Full pipeline test" specifies the full chain through `/sdd:review`. This PR ships **only spec → plan → work** because `/sdd:review` operates against real PRs, which is incompatible with the `local-tmp-init` strategy used here. Closing the gap requires a second scenario using `repo_strategy: gh-template` (real disposable repo, real PR). Tracked in #94.

## What's NOT in this PR
This is **PR 1 of 3** for issue #64. The "Description Optimization" requirement (20 trigger queries × 15 skills = 300 queries, plus actual `run_loop.py` runs) lands in two follow-up PRs:
- PR 2: author the 300 trigger queries (no API spend, pure content)
- PR 3: run `run_loop.py` per skill, human-review each best_description, commit accepted ones

## Review feedback addressed
Adversarial review surfaced 4 must-fix issues, all addressed in commit `a44e223`:
- **B1** dropped step 4 (broken: /sdd:review can't run offline) — gap tracked in #94
- **B2** tightened step 3's worktree verify (uses `git worktree list` instead of confusing the metadata path with the working-tree path)
- **H1** reworded the README so `mode=pipeline` is described as running pipeline scenarios *in addition to* tier3 baseline, matching actual workflow behavior
- **H2** extended the `report` prompt to handle pipeline-shaped JSON in a separate section
- **M1** dropped unused `needs: determine-mode` from `eval-pipeline`

## Test plan
- [x] `python3 -c "import json; json.load(open('evals/pipeline/core-workflow.json'))"` — JSON valid
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/skill-evals.yml'))"` — YAML valid
- [x] `eval-pipeline` job correctly gated (skips on regular PRs, runs on `release/*` and `workflow_dispatch mode=pipeline`)
- [x] `report` job's `needs` updated and still uses `if: always()`, so it runs on regular PRs where eval-pipeline is skipped
- [ ] First real pipeline run: deferred to first `release/*` PR or manual trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)