### PR TITLE
evals: trigger eval sets for description optimization (300 queries × 15 skills) — 2/3 of #64

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -17,6 +17,7 @@ Automated evaluation framework for the 15 SDD plugin skills.
 - `tier2.json` - Tier 2 evals only (10 prompts)
 - `tier3.json` - Tier 3 evals only (14 prompts)
 - `pipeline/` - Cross-skill end-to-end scenarios (release-only, see [`pipeline/README.md`](pipeline/README.md))
+- `triggers/` - Per-skill trigger eval sets for description optimization via `run_loop.py` (see [`triggers/README.md`](triggers/README.md))
 - `benchmarks/` - Persisted benchmark results on merge
 
 ## Running Evals Locally

--- a/evals/triggers/README.md
+++ b/evals/triggers/README.md
@@ -1,0 +1,90 @@
+# Trigger Eval Sets
+
+Per-skill query corpora for optimizing each `SKILL.md`'s `description` field via skill-creator's `run_loop.py`.
+
+Governing: [ADR-0021](../../docs/adrs/ADR-0021-skill-evaluation-and-ci-testing.md), SPEC-0017 REQ "Description Optimization".
+
+## What this is for
+
+Each skill's `SKILL.md` frontmatter has a `description` field that determines whether Claude triggers the skill in response to a user prompt. A vague or noisy description means Claude either over-triggers (firing the skill on near-misses) or under-triggers (missing the cases the skill exists to handle).
+
+`run_loop.py` (from the skill-creator skill) iteratively rewrites the description against a graded corpus of trigger queries until it maximizes the trigger-rate for cases that *should* fire and minimizes it for cases that *should not*. This directory holds the corpora.
+
+## Per-skill file format
+
+Each skill has a JSON file at `evals/triggers/{skill_name}.json`:
+
+```json
+[
+  {"query": "Plan SPEC-0015 into stories for joestump/joe-links", "should_trigger": true},
+  {"query": "Plan a vacation to Barcelona", "should_trigger": false}
+]
+```
+
+Per SPEC-0017 each file contains **20 queries: 10 with `should_trigger: true` and 10 with `should_trigger: false`**. The 10/10 balance lets `run_loop.py` compute precision and recall against a stratified train/test split.
+
+## Authoring guidelines
+
+**Should-trigger (positive) queries** — vary the surface form to cover what real users would type:
+- Direct slash invocation: `"/sdd:plan SPEC-0015"`
+- Natural language: `"break SPEC-0015 into trackable issues"`
+- Indirect / inferred intent: `"now that the spec is approved, what's next?"`
+- With workflow context: `"create the GitHub issues for the auth work"`
+- Multi-artifact: `"plan SPEC-0014 and SPEC-0015"`
+- Constraint-bearing: `"plan SPEC-0015 but only foundation stories"`
+
+Avoid 10 paraphrases of the same sentence — variation is the whole point.
+
+**Should-NOT-trigger (adversarial) queries** — pick near-misses, not random off-topic prompts. The optimizer learns most from queries that *look* like the skill's domain but aren't:
+- Same keyword, different meaning: `"plan a vacation to Spain"` (`/sdd:plan` only)
+- Adjacent SDD skill territory: `"create an ADR for using Redis"` (should fire `/sdd:adr`, not `/sdd:plan`)
+- Read-only when the skill writes: `"what does ADR-0012 say?"` (should fire `/sdd:list` or nothing, not `/sdd:adr`)
+- Meta-questions about the skill: `"what does /sdd:plan do?"` (asking *about* the skill is not invoking it)
+- Tooling questions: `"how do I configure GitHub issue templates?"` (Q&A, not a skill task)
+- Generic vocabulary collisions: `"address bar broken in browser"` (collides with ADR / "addr")
+
+A purely off-topic query like `"what's the weather?"` is fine to include 1–2 of but doesn't teach the optimizer much.
+
+## Running optimization for one skill
+
+```bash
+# From the plugin root, with the skill-creator marketplace skill installed:
+SKILL=plan
+python3 ~/.claude/plugins/marketplaces/anthropic-agent-skills/skills/skill-creator/scripts/run_loop.py \
+  --eval-set evals/triggers/${SKILL}.json \
+  --skill-path skills/${SKILL} \
+  --num-workers 5 \
+  --max-iterations 5 \
+  --runs-per-query 3 \
+  --trigger-threshold 0.5 \
+  --holdout 0.3 \
+  --model claude-haiku-4-5
+```
+
+`run_loop.py` writes a `best_description` to stdout (and an HTML report to a temp dir). **Do not auto-commit the result** — per SPEC-0017 REQ "Description Optimization", the before/after must be reviewed by a human before updating `SKILL.md`.
+
+## Running optimization for all skills (manual, expensive)
+
+This is PR 3 territory, not PR 2. Authoring lives here; the actual runs spend real API budget per query × per iteration × per skill, and each result needs human eyes before commit.
+
+## Files
+
+| Skill    | Tier | File |
+|----------|------|------|
+| audit    | 1    | [`audit.json`](audit.json) |
+| plan     | 1    | [`plan.json`](plan.json) |
+| review   | 1    | [`review.json`](review.json) |
+| work     | 1    | [`work.json`](work.json) |
+| check    | 2    | [`check.json`](check.json) |
+| discover | 2    | [`discover.json`](discover.json) |
+| docs     | 2    | [`docs.json`](docs.json) |
+| spec     | 2    | [`spec.json`](spec.json) |
+| adr      | 3    | [`adr.json`](adr.json) |
+| enrich   | 3    | [`enrich.json`](enrich.json) |
+| init     | 3    | [`init.json`](init.json) |
+| list     | 3    | [`list.json`](list.json) |
+| organize | 3    | [`organize.json`](organize.json) |
+| prime    | 3    | [`prime.json`](prime.json) |
+| status   | 3    | [`status.json`](status.json) |
+
+Total: **300 trigger queries** (150 should-trigger, 150 should-NOT-trigger), 20 per skill in a balanced 10/10 split.

--- a/evals/triggers/README.md
+++ b/evals/triggers/README.md
@@ -58,8 +58,17 @@ python3 ~/.claude/plugins/marketplaces/anthropic-agent-skills/skills/skill-creat
   --runs-per-query 3 \
   --trigger-threshold 0.5 \
   --holdout 0.3 \
-  --model claude-haiku-4-5
+  --model claude-sonnet-4-6
 ```
+
+### Picking `--model`
+
+`run_loop.py`'s `--model` flag controls which model the trigger-test runs use, which in turn determines whose decision boundary the optimizer is tuning against. **Choose the model your team actually runs in their Claude Code sessions** — typically Sonnet 4.6 (the default).
+
+If you optimize against Haiku and your team runs Sonnet, the resulting `best_description` is locally optimal on Haiku and may behave differently in real sessions. Two reasonable strategies:
+
+- **Single model (recommended):** run optimization with the same model your team uses day-to-day. Sonnet 4.6 is the right default for most users.
+- **Two-pass:** iterate quickly on the corpus with `claude-haiku-4-5` (cheaper, faster), then do the final commit-worthy pass with the production model.
 
 `run_loop.py` writes a `best_description` to stdout (and an HTML report to a temp dir). **Do not auto-commit the result** — per SPEC-0017 REQ "Description Optimization", the before/after must be reviewed by a human before updating `SKILL.md`.
 

--- a/evals/triggers/adr.json
+++ b/evals/triggers/adr.json
@@ -1,0 +1,23 @@
+[
+  {"query": "create an ADR for our decision to use Redis as the session store instead of Postgres", "should_trigger": true},
+  {"query": "/sdd:adr", "should_trigger": true},
+  {"query": "we just agreed to ship HTMX over React for the new dashboard — write that up as an architecture decision record", "should_trigger": true},
+  {"query": "I need to ADR this: we're going with event sourcing for the orders service", "should_trigger": true},
+  {"query": "document the rationale for picking Go over Rust for the worker pool", "should_trigger": true},
+  {"query": "after that design discussion, can you capture the JWT-vs-sessions decision as an ADR?", "should_trigger": true},
+  {"query": "record the decision to use OIDC via Pocket ID for all internal services", "should_trigger": true},
+  {"query": "make a new architecture decision record for the JSON-over-HTTP-vs-gRPC choice", "should_trigger": true},
+  {"query": "write up why we're sunsetting MariaDB in favor of standardizing on Postgres — should be an ADR", "should_trigger": true},
+  {"query": "log this decision as an ADR with consequences and alternatives sections filled out", "should_trigger": true},
+
+  {"query": "plan SPEC-0015 into stories for the team", "should_trigger": false},
+  {"query": "list all the ADRs in this repo, grouped by status", "should_trigger": false},
+  {"query": "what does ADR-0023 say about cross-module references?", "should_trigger": false},
+  {"query": "update ADR-0012 status from proposed to accepted", "should_trigger": false},
+  {"query": "review my decision tree implementation — I think the recursion is wrong", "should_trigger": false},
+  {"query": "what's an ADR? I keep seeing the term but I'm not sure what they're for", "should_trigger": false},
+  {"query": "write an Address Resolution Protocol parser in Python", "should_trigger": false},
+  {"query": "address bar in the browser is broken on the staging build", "should_trigger": false},
+  {"query": "should I order pizza or pasta for dinner tonight?", "should_trigger": false},
+  {"query": "audit our existing ADRs for drift against the codebase", "should_trigger": false}
+]

--- a/evals/triggers/audit.json
+++ b/evals/triggers/audit.json
@@ -1,0 +1,23 @@
+[
+  {"query": "audit all our ADRs and specs against the codebase", "should_trigger": true},
+  {"query": "/sdd:audit", "should_trigger": true},
+  {"query": "do a thorough drift audit across the whole repo", "should_trigger": true},
+  {"query": "we're prepping for release; run a comprehensive design alignment check", "should_trigger": true},
+  {"query": "find every place the code has drifted from the governing artifacts", "should_trigger": true},
+  {"query": "produce an audit report with all violations grouped by severity", "should_trigger": true},
+  {"query": "comprehensive audit of design alignment for the auth module", "should_trigger": true},
+  {"query": "scrub our specs for orphaned requirements that no code implements", "should_trigger": true},
+  {"query": "run the full SDD audit, not the quick check", "should_trigger": true},
+  {"query": "audit triage time — let's see what's drifted in the last quarter", "should_trigger": true},
+
+  {"query": "audit npm dependencies for vulnerabilities", "should_trigger": false},
+  {"query": "audit my code for performance bottlenecks", "should_trigger": false},
+  {"query": "/sdd:check the new auth code for drift", "should_trigger": false},
+  {"query": "list all ADRs", "should_trigger": false},
+  {"query": "what does scrum mode do in /sdd:audit?", "should_trigger": false},
+  {"query": "show audit log entries from yesterday", "should_trigger": false},
+  {"query": "review PR #88 for me", "should_trigger": false},
+  {"query": "check this PR against SPEC-0014", "should_trigger": false},
+  {"query": "do a security audit on the auth code", "should_trigger": false},
+  {"query": "audit our cloud spending for last quarter", "should_trigger": false}
+]

--- a/evals/triggers/check.json
+++ b/evals/triggers/check.json
@@ -1,0 +1,23 @@
+[
+  {"query": "check this PR against our ADRs for drift", "should_trigger": true},
+  {"query": "/sdd:check", "should_trigger": true},
+  {"query": "does this implementation comply with SPEC-0017?", "should_trigger": true},
+  {"query": "quick drift check on the new auth code in skills/auth/", "should_trigger": true},
+  {"query": "verify the docs-generation refactor still aligns with ADR-0023", "should_trigger": true},
+  {"query": "is this code consistent with our governing artifacts?", "should_trigger": true},
+  {"query": "scan this branch for SDD compliance violations", "should_trigger": true},
+  {"query": "I'm about to commit; check it against the specs first", "should_trigger": true},
+  {"query": "compare my changes to ADR-0019 — am I deviating?", "should_trigger": true},
+  {"query": "drift-check the recent changes in skills/work/", "should_trigger": true},
+
+  {"query": "git status", "should_trigger": false},
+  {"query": "check my PR for typos and grammar", "should_trigger": false},
+  {"query": "audit our ADRs against the code", "should_trigger": false},
+  {"query": "review PR #88", "should_trigger": false},
+  {"query": "lint the code with golangci-lint", "should_trigger": false},
+  {"query": "what does drift mean in the SDD context?", "should_trigger": false},
+  {"query": "check the weather in Dublin tomorrow", "should_trigger": false},
+  {"query": "list all ADRs", "should_trigger": false},
+  {"query": "checkpoint the state of this branch as a tag", "should_trigger": false},
+  {"query": "run the test suite and report failures", "should_trigger": false}
+]

--- a/evals/triggers/discover.json
+++ b/evals/triggers/discover.json
@@ -1,0 +1,23 @@
+[
+  {"query": "discover the implicit architecture in this legacy codebase", "should_trigger": true},
+  {"query": "/sdd:discover", "should_trigger": true},
+  {"query": "reverse-engineer ADRs from this existing repo", "should_trigger": true},
+  {"query": "I inherited this code; figure out the architectural decisions baked in", "should_trigger": true},
+  {"query": "what implicit invariants does this code enforce? extract them as candidate ADRs", "should_trigger": true},
+  {"query": "scan the codebase and propose ADRs for the patterns you find", "should_trigger": true},
+  {"query": "extract design artifacts from the existing implementation", "should_trigger": true},
+  {"query": "we have a 5-year-old service with no docs; tease out the architecture", "should_trigger": true},
+  {"query": "find the undocumented decisions in the auth module", "should_trigger": true},
+  {"query": "produce candidate ADRs and specs from this code", "should_trigger": true},
+
+  {"query": "discover all the bugs in this code", "should_trigger": false},
+  {"query": "create a new ADR for our caching choice", "should_trigger": false},
+  {"query": "init this repo for SDD usage", "should_trigger": false},
+  {"query": "what's discovery in agile?", "should_trigger": false},
+  {"query": "search Discovery+ for nature documentaries", "should_trigger": false},
+  {"query": "audit our existing ADRs against the code", "should_trigger": false},
+  {"query": "discover Kubernetes services in this cluster", "should_trigger": false},
+  {"query": "what does /sdd:discover output?", "should_trigger": false},
+  {"query": "find the entry point of this Go program", "should_trigger": false},
+  {"query": "use net discovery to find devices on the LAN", "should_trigger": false}
+]

--- a/evals/triggers/docs.json
+++ b/evals/triggers/docs.json
@@ -1,0 +1,23 @@
+[
+  {"query": "generate the docs site from our ADRs and specs", "should_trigger": true},
+  {"query": "/sdd:docs", "should_trigger": true},
+  {"query": "scaffold a Docusaurus site that mirrors our design artifacts", "should_trigger": true},
+  {"query": "rebuild the documentation site with the latest ADRs", "should_trigger": true},
+  {"query": "set up a docs site so we can publish our architecture decisions", "should_trigger": true},
+  {"query": "create a static site with all our governing artifacts", "should_trigger": true},
+  {"query": "deploy our SDD docs to GitHub Pages", "should_trigger": true},
+  {"query": "regenerate the docs after I added ADR-0024", "should_trigger": true},
+  {"query": "wire up our existing Docusaurus site with the SDD plugin's transforms", "should_trigger": true},
+  {"query": "publish our ADRs as a browsable docs site", "should_trigger": true},
+
+  {"query": "write API docs for this Go function", "should_trigger": false},
+  {"query": "create an ADR documenting the docusaurus choice", "should_trigger": false},
+  {"query": "what's Docusaurus, technically?", "should_trigger": false},
+  {"query": "list all the docs in this repo", "should_trigger": false},
+  {"query": "generate Swagger docs from my OpenAPI YAML", "should_trigger": false},
+  {"query": "where do the docs live in this repo?", "should_trigger": false},
+  {"query": "deploy my README to a single GitHub Pages site", "should_trigger": false},
+  {"query": "audit ADR coverage against the implementation", "should_trigger": false},
+  {"query": "build the project docs with mkdocs", "should_trigger": false},
+  {"query": "where can I find docs for the artifact-graph feature?", "should_trigger": false}
+]

--- a/evals/triggers/enrich.json
+++ b/evals/triggers/enrich.json
@@ -1,0 +1,23 @@
+[
+  {"query": "enrich our existing issues with branch and PR conventions", "should_trigger": true},
+  {"query": "/sdd:enrich", "should_trigger": true},
+  {"query": "add the feature/N-slug branch convention to all open issues from SPEC-0017", "should_trigger": true},
+  {"query": "the issues are missing PR Convention sections — add them retroactively", "should_trigger": true},
+  {"query": "format these existing issues with our standard branch and PR sections", "should_trigger": true},
+  {"query": "I planned without conventions; backfill them now on the open stories", "should_trigger": true},
+  {"query": "/sdd:enrich SPEC-0014 issues with branch + PR boilerplate", "should_trigger": true},
+  {"query": "add Closes #N keyword guidance to the open stories", "should_trigger": true},
+  {"query": "enrich the issue bodies with the metadata SDD's other skills expect", "should_trigger": true},
+  {"query": "format these issues so /sdd:work can pick them up cleanly", "should_trigger": true},
+
+  {"query": "plan SPEC-0015 into issues", "should_trigger": false},
+  {"query": "organize issues into projects on the tracker", "should_trigger": false},
+  {"query": "enrich my data with metadata from this third-party API", "should_trigger": false},
+  {"query": "what's the difference between enrich and organize in the SDD plugin?", "should_trigger": false},
+  {"query": "list issues with branch conventions filled in", "should_trigger": false},
+  {"query": "audit our open issues for missing fields", "should_trigger": false},
+  {"query": "review my PR template before I save it", "should_trigger": false},
+  {"query": "enrich the readme with examples", "should_trigger": false},
+  {"query": "create a GitHub issue template for bug reports", "should_trigger": false},
+  {"query": "update the project README with the new branch convention", "should_trigger": false}
+]

--- a/evals/triggers/init.json
+++ b/evals/triggers/init.json
@@ -1,0 +1,23 @@
+[
+  {"query": "set up SDD plugin context in this new repo", "should_trigger": true},
+  {"query": "/sdd:init", "should_trigger": true},
+  {"query": "initialize sdd for this project", "should_trigger": true},
+  {"query": "add the SDD CLAUDE.md sections so I can start tracking decisions", "should_trigger": true},
+  {"query": "I just installed the plugin; configure SDD here", "should_trigger": true},
+  {"query": "wire up CLAUDE.md so /sdd:prime works in this codebase", "should_trigger": true},
+  {"query": "bootstrap the design plugin in our new microservice", "should_trigger": true},
+  {"query": "add the architecture configuration block to CLAUDE.md", "should_trigger": true},
+  {"query": "I want to start using the SDD plugin here — what's the setup step?", "should_trigger": true},
+  {"query": "scaffold the SDD context for this repo", "should_trigger": true},
+
+  {"query": "git init", "should_trigger": false},
+  {"query": "npm init -y", "should_trigger": false},
+  {"query": "create my CLAUDE.md from scratch with my own conventions", "should_trigger": false},
+  {"query": "what does SDD stand for?", "should_trigger": false},
+  {"query": "init a new Vite project", "should_trigger": false},
+  {"query": "plan SPEC-0015 into stories", "should_trigger": false},
+  {"query": "discover the implicit architecture in this codebase", "should_trigger": false},
+  {"query": "load architecture context for this session", "should_trigger": false},
+  {"query": "create ADR-0001 for our initial choices", "should_trigger": false},
+  {"query": "initialize a new database migration", "should_trigger": false}
+]

--- a/evals/triggers/list.json
+++ b/evals/triggers/list.json
@@ -1,0 +1,23 @@
+[
+  {"query": "list all ADRs in this repo", "should_trigger": true},
+  {"query": "/sdd:list", "should_trigger": true},
+  {"query": "show me every accepted spec", "should_trigger": true},
+  {"query": "what ADRs are still in proposed state?", "should_trigger": true},
+  {"query": "give me a table of all ADRs with their status and date", "should_trigger": true},
+  {"query": "I want to see all specs grouped by domain", "should_trigger": true},
+  {"query": "what decisions have we made on this codebase?", "should_trigger": true},
+  {"query": "show specs and ADRs together with their statuses", "should_trigger": true},
+  {"query": "give me an overview of our governing artifacts", "should_trigger": true},
+  {"query": "list every ADR that's not yet accepted, with links", "should_trigger": true},
+
+  {"query": "create a new ADR for the Redis decision", "should_trigger": false},
+  {"query": "list the open PRs on this repo", "should_trigger": false},
+  {"query": "ls -la", "should_trigger": false},
+  {"query": "list the dependencies in package.json", "should_trigger": false},
+  {"query": "what's the difference between an ADR and a SPEC?", "should_trigger": false},
+  {"query": "update ADR-0012 status to accepted", "should_trigger": false},
+  {"query": "audit our ADRs against the code", "should_trigger": false},
+  {"query": "list directories under skills/", "should_trigger": false},
+  {"query": "list of contributors to this repo", "should_trigger": false},
+  {"query": "list the steps to brew a Chemex", "should_trigger": false}
+]

--- a/evals/triggers/organize.json
+++ b/evals/triggers/organize.json
@@ -1,0 +1,23 @@
+[
+  {"query": "organize our existing GitHub issues into a project board", "should_trigger": true},
+  {"query": "/sdd:organize", "should_trigger": true},
+  {"query": "retroactively group these issues into tracker projects by spec", "should_trigger": true},
+  {"query": "we have 50 stale issues; group them under the right epics", "should_trigger": true},
+  {"query": "set up a Gitea project board for the open issues from SPEC-0017", "should_trigger": true},
+  {"query": "I planned without using projects; organize the existing issues now", "should_trigger": true},
+  {"query": "tag and group all open issues into Linear projects by spec", "should_trigger": true},
+  {"query": "make project columns for our backlog issues, grouped by epic", "should_trigger": true},
+  {"query": "retroactively label issues by spec and group them into a project", "should_trigger": true},
+  {"query": "organize the disparate issues into coherent epics across the tracker", "should_trigger": true},
+
+  {"query": "/sdd:plan SPEC-0015 into stories", "should_trigger": false},
+  {"query": "enrich existing issues with branch conventions", "should_trigger": false},
+  {"query": "organize my desk before the standup", "should_trigger": false},
+  {"query": "what's the difference between organize and plan?", "should_trigger": false},
+  {"query": "list all open issues in the tracker", "should_trigger": false},
+  {"query": "create a new GitHub project board from scratch", "should_trigger": false},
+  {"query": "organize my dotfiles repo into directories", "should_trigger": false},
+  {"query": "review PR #88 and merge if good", "should_trigger": false},
+  {"query": "organize a team offsite for next quarter", "should_trigger": false},
+  {"query": "audit our ADRs for drift", "should_trigger": false}
+]

--- a/evals/triggers/plan.json
+++ b/evals/triggers/plan.json
@@ -1,0 +1,23 @@
+[
+  {"query": "Plan SPEC-0015 into trackable issues for joestump/joe-links", "should_trigger": true},
+  {"query": "/sdd:plan SPEC-0017", "should_trigger": true},
+  {"query": "break this approved spec into stories the team can pick up", "should_trigger": true},
+  {"query": "create GitHub issues for the auth-rewrite spec, foundation stories first", "should_trigger": true},
+  {"query": "now that SPEC-0014 is accepted, turn it into work for next sprint", "should_trigger": true},
+  {"query": "plan SPEC-0015 and SPEC-0016 together as one epic; they share a foundation", "should_trigger": true},
+  {"query": "I have a finished spec — what's next, do we just start coding or is there a planning step?", "should_trigger": true},
+  {"query": "decompose the artifact-graph spec into stories with branch and PR conventions filled in", "should_trigger": true},
+  {"query": "use tasks.md fallback (no tracker) and plan SPEC-0018 into 4–5 stories", "should_trigger": true},
+  {"query": "set up the issue tickets for our spec; we use Gitea, not GitHub", "should_trigger": true},
+
+  {"query": "plan a one-week vacation to Lisbon for two people, including hotel and flights", "should_trigger": false},
+  {"query": "what's the difference between an epic and a story in agile?", "should_trigger": false},
+  {"query": "create an ADR for our decision to use Redis as the session store", "should_trigger": false},
+  {"query": "list all open ADRs in this repo", "should_trigger": false},
+  {"query": "review PR #88 for me", "should_trigger": false},
+  {"query": "explain what the /sdd:plan skill actually does — I'm reading the README", "should_trigger": false},
+  {"query": "how do I configure GitHub issue templates in .github/ISSUE_TEMPLATE/?", "should_trigger": false},
+  {"query": "write a function that plans the shortest route between two points on a graph", "should_trigger": false},
+  {"query": "estimate how long this sprint should take based on past velocity", "should_trigger": false},
+  {"query": "help me plan my morning routine so I'm not late for standup", "should_trigger": false}
+]

--- a/evals/triggers/prime.json
+++ b/evals/triggers/prime.json
@@ -1,0 +1,23 @@
+[
+  {"query": "load the architecture context for this session", "should_trigger": true},
+  {"query": "/sdd:prime", "should_trigger": true},
+  {"query": "prime the SDD context before I start working on the auth flow", "should_trigger": true},
+  {"query": "give me the relevant ADRs and specs for the artifact-graph topic", "should_trigger": true},
+  {"query": "before I dive in, load context on the docs-generation feature", "should_trigger": true},
+  {"query": "show me ADRs and specs relevant to the worktree work", "should_trigger": true},
+  {"query": "I'm about to refactor the spec parser; load relevant artifacts", "should_trigger": true},
+  {"query": "/sdd:prime worktrees", "should_trigger": true},
+  {"query": "prep my session with the SDD artifacts that govern this module", "should_trigger": true},
+  {"query": "warm up your context with the design decisions I'll need today", "should_trigger": true},
+
+  {"query": "list all ADRs in this repo", "should_trigger": false},
+  {"query": "what's the prime number after 17?", "should_trigger": false},
+  {"query": "prime the pump on the espresso machine", "should_trigger": false},
+  {"query": "init the SDD plugin in a new repo", "should_trigger": false},
+  {"query": "load my dotfiles config", "should_trigger": false},
+  {"query": "what does /sdd:prime do?", "should_trigger": false},
+  {"query": "discover the implicit architecture in this code", "should_trigger": false},
+  {"query": "audit ADR coverage against the implementation", "should_trigger": false},
+  {"query": "prime the language model with system instructions", "should_trigger": false},
+  {"query": "give me a primer on event sourcing", "should_trigger": false}
+]

--- a/evals/triggers/review.json
+++ b/evals/triggers/review.json
@@ -1,0 +1,23 @@
+[
+  {"query": "review PR #88", "should_trigger": true},
+  {"query": "/sdd:review 93", "should_trigger": true},
+  {"query": "kick off a reviewer-responder pair for the open SPEC-0017 PRs", "should_trigger": true},
+  {"query": "review and merge the open PRs from this sprint", "should_trigger": true},
+  {"query": "do an adversarial review of my PR before I merge", "should_trigger": true},
+  {"query": "/sdd:review and merge if it looks clean", "should_trigger": true},
+  {"query": "review PRs #88 and #93 in parallel using two reviewer pairs", "should_trigger": true},
+  {"query": "spec-aware review of PR #93 please", "should_trigger": true},
+  {"query": "run the reviewer-responder cycle on the auth-rewrite PR", "should_trigger": true},
+  {"query": "review PR #88 and post structured feedback as comments", "should_trigger": true},
+
+  {"query": "review my code for typos and grammar", "should_trigger": false},
+  {"query": "review my decision to use Redis as a session store", "should_trigger": false},
+  {"query": "what does adversarial review mean in this plugin?", "should_trigger": false},
+  {"query": "review of last quarter's spending", "should_trigger": false},
+  {"query": "/sdd:audit our ADRs for drift", "should_trigger": false},
+  {"query": "review the morning news headlines", "should_trigger": false},
+  {"query": "look at this code and tell me if the algorithm is right", "should_trigger": false},
+  {"query": "approve PR #88 directly via gh pr review --approve", "should_trigger": false},
+  {"query": "merge PR #88 already, I've reviewed it manually", "should_trigger": false},
+  {"query": "review my essay for the Substack post", "should_trigger": false}
+]

--- a/evals/triggers/spec.json
+++ b/evals/triggers/spec.json
@@ -1,0 +1,23 @@
+[
+  {"query": "create a spec for the webhook delivery service", "should_trigger": true},
+  {"query": "/sdd:spec", "should_trigger": true},
+  {"query": "we need to formalize the auth requirements; turn ADR-0019 into a SPEC", "should_trigger": true},
+  {"query": "write up the requirements for the new payment processor with RFC 2119 keywords", "should_trigger": true},
+  {"query": "draft the specification document for the artifact-graph feature", "should_trigger": true},
+  {"query": "given this design discussion, produce a SPEC-formatted requirements doc", "should_trigger": true},
+  {"query": "make a spec for the new caching layer covering all WHEN/THEN scenarios", "should_trigger": true},
+  {"query": "we need a structured spec, not just a brain dump — formalize this", "should_trigger": true},
+  {"query": "spec out the rate-limiting feature with explicit invariants and design rationale", "should_trigger": true},
+  {"query": "I have an accepted ADR; write the spec that implements it", "should_trigger": true},
+
+  {"query": "create an ADR for the caching choice", "should_trigger": false},
+  {"query": "list all specs in this repo", "should_trigger": false},
+  {"query": "what's the difference between an ADR and a SPEC?", "should_trigger": false},
+  {"query": "plan SPEC-0017 into stories", "should_trigger": false},
+  {"query": "review my code for SPEC-0014 compliance", "should_trigger": false},
+  {"query": "write a unit test spec for this function", "should_trigger": false},
+  {"query": "specifically, what does the term 'governing artifact' mean here?", "should_trigger": false},
+  {"query": "generate Swagger from my OpenAPI spec file", "should_trigger": false},
+  {"query": "spec out a meal plan for the week", "should_trigger": false},
+  {"query": "draw up a tech spec template for our org's confluence", "should_trigger": false}
+]

--- a/evals/triggers/status.json
+++ b/evals/triggers/status.json
@@ -1,0 +1,23 @@
+[
+  {"query": "mark ADR-0012 as accepted", "should_trigger": true},
+  {"query": "/sdd:status ADR-0023 accepted", "should_trigger": true},
+  {"query": "ADR-0008 is no longer relevant; supersede it", "should_trigger": true},
+  {"query": "update SPEC-0014's status to active now that it's implemented", "should_trigger": true},
+  {"query": "deprecate ADR-0005 — we're moving away from JWT", "should_trigger": true},
+  {"query": "set the status of all the proposed ADRs to accepted now that the team approved them", "should_trigger": true},
+  {"query": "approve the spec — change its status from draft to active", "should_trigger": true},
+  {"query": "change ADR-0019's status; we just accepted it in the design review", "should_trigger": true},
+  {"query": "I need to bump the status field on ADR-0012 to deprecated", "should_trigger": true},
+  {"query": "transition this spec from draft to approved in the frontmatter", "should_trigger": true},
+
+  {"query": "create a new ADR for the JWT decision", "should_trigger": false},
+  {"query": "list all ADR statuses", "should_trigger": false},
+  {"query": "check the build status", "should_trigger": false},
+  {"query": "what's the project status going into Q3?", "should_trigger": false},
+  {"query": "what does deprecated mean for an ADR?", "should_trigger": false},
+  {"query": "git status", "should_trigger": false},
+  {"query": "show me the HTTP status code for unauthorized", "should_trigger": false},
+  {"query": "is the ADR-0012 PR ready to merge yet?", "should_trigger": false},
+  {"query": "rerun the status check workflow on PR #88", "should_trigger": false},
+  {"query": "review the status of our open PRs and tell me what to do next", "should_trigger": false}
+]

--- a/evals/triggers/work.json
+++ b/evals/triggers/work.json
@@ -1,0 +1,23 @@
+[
+  {"query": "pick up issue #64 and start implementing it", "should_trigger": true},
+  {"query": "/sdd:work", "should_trigger": true},
+  {"query": "implement the foundation stories from the auth-rewrite plan, in parallel", "should_trigger": true},
+  {"query": "spawn agents to work on issues #45, #46, #47 in worktrees", "should_trigger": true},
+  {"query": "/sdd:work issue 64", "should_trigger": true},
+  {"query": "start work on the next open story in the tracker", "should_trigger": true},
+  {"query": "let's tackle these issues with parallel git worktrees", "should_trigger": true},
+  {"query": "implement the highest-priority issue and open a PR when done", "should_trigger": true},
+  {"query": "pick up the next planned story and code it up", "should_trigger": true},
+  {"query": "fan out work across multiple SPEC-0017 stories using worktrees", "should_trigger": true},
+
+  {"query": "what's a git worktree?", "should_trigger": false},
+  {"query": "review the existing PRs", "should_trigger": false},
+  {"query": "plan SPEC-0015 into stories", "should_trigger": false},
+  {"query": "I'm working from home today; don't bother me", "should_trigger": false},
+  {"query": "open a worktree for this branch with git worktree add", "should_trigger": false},
+  {"query": "what does /sdd:work output when it finishes?", "should_trigger": false},
+  {"query": "list the open issues on this repo", "should_trigger": false},
+  {"query": "audit the codebase against our specs", "should_trigger": false},
+  {"query": "let's work on the design before coding anything", "should_trigger": false},
+  {"query": "make this code work — it's throwing an error", "should_trigger": false}
+]


### PR DESCRIPTION
## Summary
- Adds `evals/triggers/` with one JSON file per skill plus a README documenting authoring guidelines, file format, and how to invoke `run_loop.py` against a single corpus.
- 15 skills × 20 queries = **300 trigger queries** total. Perfect 10 should-trigger / 10 should-NOT-trigger split per skill.
- Implements SPEC-0017 REQ "Description Optimization" *partially*: this PR ships the corpora; PR 3 will actually run `run_loop.py` per skill with human review of each `best_description` before commit.

## Authoring approach (signed off in conversation before bulk authoring)
- **Should-trigger queries** vary surface form (slash invocation, natural language, indirect intent, multi-artifact, with constraints) so the optimizer doesn't over-fit on any one phrasing.
- **Should-NOT-trigger queries** lean on near-misses rather than random off-topic prompts: same-keyword-different-meaning, adjacent SDD skill territory (e.g., "list ADRs" as a negative for `/sdd:adr`), meta-questions about the skill, read-only-when-the-skill-writes, plus a couple of vocabulary collisions per file.

## Files

| Tier | Files |
|------|-------|
| 1 | `audit.json`, `plan.json`, `review.json`, `work.json` |
| 2 | `check.json`, `discover.json`, `docs.json`, `spec.json` |
| 3 | `adr.json`, `enrich.json`, `init.json`, `list.json`, `organize.json`, `prime.json`, `status.json` |

## Test plan
- [x] All 15 files JSON-valid (`python3 -c "import json; ..."` pass)
- [x] Every file has exactly 20 queries with 10/10 should-trigger split (validated by counting script in commit)
- [x] Per-skill near-miss queries cross-reference adjacent SDD skills (e.g., `/sdd:adr` negatives include `/sdd:list`, `/sdd:status`, `/sdd:audit` cases)
- [ ] Actual `run_loop.py` runs deferred to PR 3 (real API spend; per-skill human review of `best_description` required before commit)

## What's NOT in this PR
- Optimization runs themselves (`run_loop.py` against each corpus). That's PR 3 of 3 for issue #64.
- Any change to existing SKILL.md descriptions. The current descriptions stay until PR 3's human-reviewed optimization output lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)