### PR TITLE
fix(status): preserve detected status format; never silently introduce a new one

### DIFF
--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: true
 
 # Change ADR or Spec Status
 
-Update the status field in the YAML frontmatter of an ADR or spec file.
+Update the status of an ADR or spec, **preserving the file's existing status format**. Two formats exist in the wild: YAML frontmatter (canonical SDD template) and inline `- **Status:** {value}` bullets (used by legacy / hand-authored repos that predate the template). This skill detects which format is in use and edits in place — it MUST NOT silently introduce a new format that creates two sources of truth in the same file.
 
 ## Process
 
@@ -20,7 +20,7 @@ Update the status field in the YAML frontmatter of an ADR or spec file.
    - Identifier: `ADR-XXXX` or `SPEC-XXXX` (or a capability name for specs)
    - Status: the new status value
 
-2. **If identifier is missing**: Scan for available ADRs and specs (using `{adr-dir}` and `{spec-dir}`), present a list with current statuses, and use `AskUserQuestion` to ask which to update.
+2. **If identifier is missing**: Scan for available ADRs and specs (using `{adr-dir}` and `{spec-dir}`), present a list with current statuses (using the **Format Detection** algorithm in Step 4a so legacy-format files render their actual status, not blank), and use `AskUserQuestion` to ask which to update.
 
 3. **If status is missing**: Show the current status and use `AskUserQuestion` to ask what to change it to. Show valid options:
    - ADR statuses: `proposed`, `accepted`, `deprecated`, `superseded`
@@ -30,14 +30,47 @@ Update the status field in the YAML frontmatter of an ADR or spec file.
    - For ADRs: Glob `{adr-dir}/ADR-{number}-*.md` to find the matching file
    - For SPECs: Glob `{spec-dir}/*/spec.md` and search for the matching SPEC number in the heading
 
-5. **Update the frontmatter**: Edit the `status:` field in the YAML frontmatter to the new value. If no frontmatter exists, add one with the status field.
+4a. **Format Detection algorithm** (read-only — no mutation in this step). Inspect the located file to determine which format owns the status field:
 
-6. **Report the change**: Tell the user what changed, e.g., "Updated ADR-0003 status: proposed -> accepted"
+   | Format | Detection | Update strategy |
+   |--------|-----------|-----------------|
+   | `yaml-frontmatter` | File has a `---` … `---` frontmatter block at the top AND the block contains a `status:` key | Edit the YAML `status:` value in place |
+   | `inline-bullet` | No frontmatter `status:` key, but the first 30 lines contain a line matching `- **Status:** {value}` (case-insensitive on "Status"; tolerate `*`/`+` markers and `Status:` without bold) | Edit the bullet line in place, preserving any parenthetical refinement notes by default |
+   | `none` | Neither format is present | Ask the user which format to add (Step 5c) — never silently default |
+
+   If BOTH formats are present (a file already has the dual-source-of-truth pathology, perhaps from a prior buggy `/sdd:status` run), report this as an error: "File `{path}` has BOTH a YAML `status:` field AND an inline `- **Status:** {value}` bullet. These are out of sync — the canonical source is ambiguous. Resolve manually (delete one) and re-run." Do NOT proceed with the update; doing so would silently extend the corruption.
+
+5. **Update the status, preserving the detected format**.
+
+   5a. **`yaml-frontmatter`**: Edit the `status:` value in the frontmatter block. Do not touch any other frontmatter keys. Do not reorder keys. Do not insert blank lines.
+
+   5b. **`inline-bullet`**: Edit the `- **Status:** {value}` line in place. Preserve the bullet marker (`-`, `*`, or `+`) exactly as written. Preserve the bold formatting exactly as written. **Refinement notes** (the parenthetical that some inline-bullet files carry, e.g., `accepted (refined by ADR-0010, 2026-05-03)`):
+
+   - **Default**: drop the parenthetical when the status itself is changing (the old refinement note no longer describes the new status). Confirm via `AskUserQuestion` if a refinement note exists: "The current line has a refinement note: `(refined by ADR-0010, ...)`. Drop it now that status is changing? (Recommended yes — the note described the previous status.)"
+   - **Override**: if the user passes `--keep-refinement` flag, preserve the parenthetical verbatim.
+
+   5c. **`none`**: Use `AskUserQuestion` to ask which format to add. Two options:
+
+   - "Add YAML frontmatter (canonical SDD template — `---\nstatus: {value}\n---\n` at file top). Recommended for repos using the current SDD template."
+   - "Add inline bullet `- **Status:** {value}` immediately after the H1 heading. Recommended for repos that already use this format on their other artifacts."
+
+   The default selection should be derived from the surrounding files: if other files in the same `{adr-dir}` (or `{spec-dir}`) use one format dominantly, suggest that one. If the repo is new with no other artifacts, default to YAML frontmatter. **Never silently default** — even with a clear preference, present the question so the user has the chance to override.
+
+6. **Report the change**: Tell the user what changed AND which format was preserved/added, e.g.,
+   - "Updated ADR-0003 status: proposed → accepted (yaml-frontmatter, in place)"
+   - "Updated ADR-0001 status: accepted → superseded (inline-bullet, preserved format; refinement note dropped)"
+   - "Added inline-bullet status to SPEC-0005: draft (file had no prior status field; inline format chosen to match sibling specs)"
 
 ## Rules
 
 - Valid ADR statuses: `proposed`, `accepted`, `deprecated`, `superseded`
 - Valid spec statuses: `draft`, `review`, `approved`, `implemented`, `deprecated`
 - If the user provides an invalid status, show the valid options and ask again
-- Do not modify any content outside the YAML frontmatter
-- If the file has no YAML frontmatter, add `---\nstatus: {value}\n---\n` at the top
+- MUST run the **Format Detection** algorithm in Step 4a before any mutation — never assume a file's status format
+- MUST preserve the detected format when updating — `yaml-frontmatter` files stay YAML; `inline-bullet` files stay inline. The "if no frontmatter, add one" rule from prior versions of this skill was a real-world bug that silently created two sources of truth in legacy-format files
+- MUST refuse to update a file that already contains BOTH formats — that is an existing corruption, and updating it would extend the damage. Report and halt
+- MUST use `AskUserQuestion` when the file has no status field — never silently default to a format
+- When the format is `inline-bullet` and a parenthetical refinement note exists, MUST ask whether to drop it (recommended) or preserve it via `--keep-refinement`
+- MUST report which format was preserved or added in the success message — silent mutations are how the previous bug went undetected
+- Do not modify any content outside the status field — neither YAML keys nor body content nor adjacent bullets
+- Refinement note format is preserved in source files (per the prior `/sdd:prime` and `/sdd:list` updates that strip parentheticals from the table view) — this skill's job is to update the lifecycle word, not the refinement annotation, and only on explicit user direction

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -35,7 +35,7 @@ Update the status of an ADR or spec, **preserving the file's existing status for
    | Format | Detection | Update strategy |
    |--------|-----------|-----------------|
    | `yaml-frontmatter` | File has a `---` … `---` frontmatter block at the top AND the block contains a `status:` key | Edit the YAML `status:` value in place |
-   | `inline-bullet` | No frontmatter `status:` key, but the first 30 lines contain a line matching `- **Status:** {value}` (case-insensitive on "Status"; tolerate `*`/`+` markers and `Status:` without bold) | Edit the bullet line in place, preserving any parenthetical refinement notes by default |
+   | `inline-bullet` | No frontmatter `status:` key, but the **20 lines following the first H1 heading** (`# `) contain a line matching `- **Status:** {value}` (case-insensitive on "Status"; tolerate `*`/`+` markers and `Status:` without bold). Anchoring on the H1 rather than file top makes the scan robust to long license headers, copyright comments, or other preamble some repos place before the title | Edit the bullet line in place, preserving any parenthetical refinement notes by default |
    | `none` | Neither format is present | Ask the user which format to add (Step 5c) — never silently default |
 
    If BOTH formats are present (a file already has the dual-source-of-truth pathology, perhaps from a prior buggy `/sdd:status` run), report this as an error: "File `{path}` has BOTH a YAML `status:` field AND an inline `- **Status:** {value}` bullet. These are out of sync — the canonical source is ambiguous. Resolve manually (delete one) and re-run." Do NOT proceed with the update; doing so would silently extend the corruption.

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -2,7 +2,7 @@
 name: status
 description: Change the status of an ADR or spec (e.g., proposed to accepted, draft to review). Use when the user says "accept ADR", "approve the spec", "mark as accepted", or wants to update decision status.
 allowed-tools: Read, Write, Edit, Glob, Grep, AskUserQuestion
-argument-hint: [ADR-XXXX or SPEC-XXXX] [new status] [--module <name>]
+argument-hint: [ADR-XXXX or SPEC-XXXX] [new status] [--module <name>] [--keep-refinement]
 disable-model-invocation: true
 ---
 


### PR DESCRIPTION
## Summary

Closes a real-world data-integrity bug surfaced during the reduit polish audit: `/sdd:status`'s prior \"if no frontmatter, add one\" rule would silently prepend a YAML block to a file that already carried inline `- **Status:** accepted`, creating two sources of truth that would diverge on every subsequent update.

## The bug

`skills/status/SKILL.md` step 5 (before this PR):

> **Update the frontmatter**: Edit the \`status:\` field in the YAML frontmatter to the new value. **If no frontmatter exists, add one with the status field.**

Run against a reduit-style ADR like:

```markdown
# ADR-0001: Use go-proton-api as the Proton Mail client

- **Status:** accepted
- **Date:** 2026-04-25
```

…this would prepend:

```markdown
---
status: superseded
---

# ADR-0001: ...
- **Status:** accepted   ← stale; never updated again
```

`/sdd:prime` and `/sdd:list` (which read YAML preferentially) would now report `superseded`. A human opening the file, or any other tool parsing the inline bullet, would see `accepted`. Subsequent `/sdd:status` calls would update the YAML side, never the inline side. The drift compounds.

## The fix

`skills/status/SKILL.md`:

1. New **Format Detection** step (4a) inspects the file before mutation. Three states: `yaml-frontmatter`, `inline-bullet`, `none`.
2. Step 5 updates the status **in the detected format only** — YAML files stay YAML; inline files get their bullet line edited in place (preserving bullet marker, bold formatting, and refinement parentheticals by default).
3. Files already containing BOTH formats (the dual-source-of-truth pathology, possibly from a prior buggy run) cause the skill to **refuse and report** — \"resolve manually, then re-run\". Updating either side would extend existing corruption.
4. Files with **no status field at all** trigger an `AskUserQuestion` choice between YAML and inline, with the default derived from sibling files in the same directory. Never silently defaults.
5. The success message now includes which format was preserved/added — \"silent mutations are how the previous bug went undetected.\"

## Why isolated PR

Per request: the inline-format mutation risk is a real bug, ship it as its own PR so it gets safety-focused review on its own. The complementary parser changes in `/sdd:prime` and `/sdd:list` (which only **read** the inline format, never mutate it) are in the polish PR #98 and are independent of this change.

## Test plan

- [ ] Create a test file with inline-bullet format and run `/sdd:status ADR-XXXX accepted` — verify the inline bullet is updated in place, no YAML block appears.
- [ ] Create a test file with YAML frontmatter and run `/sdd:status ADR-XXXX accepted` — verify the YAML field is updated, no inline bullet appears.
- [ ] Create a test file with NEITHER format and run `/sdd:status ADR-XXXX accepted` — verify the AskUserQuestion fires and asks which format to add.
- [ ] Create a test file with BOTH formats (YAML + inline bullet) and run `/sdd:status ADR-XXXX accepted` — verify the skill refuses and reports the corruption.
- [ ] Test refinement-note preservation: file has `- **Status:** accepted (refined by ADR-0010, 2026-05-03)`. Run `/sdd:status ADR-XXXX superseded`. Verify the AskUserQuestion fires asking whether to drop the refinement note (recommended yes — it described the previous status).
- [ ] Test `--keep-refinement` flag: same file, but pass the flag. Verify the parenthetical is preserved verbatim.

## Adversarial review checklist

- [ ] **Detection algorithm correctness** — does \"first 30 lines\" cover real-world inline-bullet placements? Reduit's are at line 3-5; if a file has a long header comment block before the H1, the bullet might be later. Consider: detect the H1 first, then scan the next 20 lines after it.
- [ ] **Both-formats refusal** — is \"refuse and halt\" the right behavior, or should the skill offer a guided cleanup (\"the YAML says X, the bullet says Y; which is canonical?\")? Refuse is safer; offering cleanup risks adding a new bug. Suggest: refuse for V1, file a follow-up issue for guided cleanup if it comes up.
- [ ] **`none` format default** — derived from sibling files. What if the directory is empty (first ever ADR)? Default should be YAML (canonical SDD template). Verify this branch is covered.
- [ ] **`--keep-refinement` flag** — net-new flag introduced by this PR. Documented in the body but not in `argument-hint` frontmatter. Update the frontmatter or document why it's intentionally hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)