### PR TITLE
docs(adr): v5 architecture — ADR-0024 qmd hard dep, ADR-0025 issues collection, ADR-0026 freshness

### DIFF
--- a/docs/adrs/ADR-0024-qmd-as-hard-dependency.md
+++ b/docs/adrs/ADR-0024-qmd-as-hard-dependency.md
@@ -1,0 +1,172 @@
+---
+status: proposed
+date: 2026-05-03
+decision-makers: Joe Stump
+related: [ADR-0015, ADR-0017, ADR-0023]
+enables: [ADR-0025]
+---
+
+# ADR-0024: Make qmd a Hard Dependency of the SDD Plugin (v5)
+
+## Context and Problem Statement
+
+The plugin's read-side skills (`/sdd:prime`, `/sdd:check`, `/sdd:audit`, `/sdd:discover`) currently scan the entire ADR + spec corpus to answer any question, because they have no way to ask "which of these N artifacts are *relevant* to this target?" That works at 23 ADRs and 18 specs; it does not scale to mature projects. Authoring skills (`/sdd:adr`, `/sdd:spec`) ask the human to declare graph edges (`supersedes`, `extends`, `related`) without surfacing candidate matches, so connections are missed and the DAG ADR-0023 introduced stays sparse. Planning and implementation skills (`/sdd:plan`, `/sdd:work`) cannot retrieve "existing code that already solves part of this story", so issues get framed as greenfield and stories duplicate work.
+
+[qmd](https://github.com/tobi/qmd) is an on-device hybrid retrieval engine (BM25 + vector + LLM rerank, all local GGUF models) that the new `/sdd:index` skill (introduced alongside this ADR) wires into per-repo collections of ADRs, specs, and code. Every read-side and authoring skill could become dramatically smarter by retrieving "top-K artifacts relevant to this question" before reading anything in full — but only if it can *assume* qmd is present. The question is whether to treat qmd as an optional accelerator (with fallback paths in every skill) or a required peer of the plugin.
+
+## Decision Drivers
+
+* **Skill complexity scales with optional dependencies.** Every "if qmd available, do X; else do Y" branch is two code paths to author, test, and document. With ~11 skills slated to become qmd-aware, that is ~22 paths instead of ~11.
+* **Capability ceiling matters more than installation friction.** A skill that *might* call qmd cannot rely on its results being available, so its design ceiling is the no-qmd path. Hard dependency lets each skill design *for* hybrid retrieval rather than around it.
+* **The architectural primitive the plugin actually optimizes for.** ADR-0015 declared markdown the source of truth; ADR-0023 declared the artifact graph first-class; both decisions hinge on being able to *traverse and search* that markdown corpus efficiently. qmd is the runtime for that traversal — making it optional means the foundation is conditionally present.
+* **Onboarding is a one-time cost.** `npm install -g @tobilu/qmd` is a single command, and the GGUF models auto-download on first embed. The cost is paid once per machine; the benefit accrues across every project the user touches.
+* **Forcing function for ecosystem coherence.** A hard dependency means every SDD project has the same retrieval primitives available, so skill authors and downstream tooling (a future MCP, a CI runner, etc.) can rely on them. Optional means the lowest common denominator wins.
+* **Breaking change is the right time.** The plugin is at v4.2.0 with active users. Slipping a hard dep into a minor version would break installs silently. v5.0.0 is honest about the rupture.
+
+## Considered Options
+
+* **Option 1**: Status quo — no qmd integration. Skills continue to scan the whole corpus.
+* **Option 2**: Optional dependency — every qmd-aware skill checks for qmd at runtime and falls back to the current behavior when absent.
+* **Option 3**: Soft requirement — `/sdd:init` warns if qmd is missing and recommends installing it; skills assume qmd is present and error cleanly when it is not.
+* **Option 4**: Hard dependency — `/sdd:init` enforces qmd presence; the plugin refuses to operate without it; v5.0.0 marks the breaking change.
+* **Option 5**: Bundle qmd in the plugin manifest via npx — declare an MCP server in `.claude-plugin/.mcp.json` as `npx -y @tobilu/qmd mcp` so the plugin "ships" qmd.
+
+## Decision Outcome
+
+Chosen option: **"Option 4 — Hard dependency, v5.0.0"**, because the value of qmd-aware skills compounds across the plugin's surface and the cost of optional fallbacks would be paid in skill complexity for the lifetime of the project. The other options each fail on a specific axis:
+
+- Option 1 leaves the plugin in its current shape and forecloses the qmd-native skills capability we already see working in `/sdd:index`.
+- Option 2 doubles the surface area of every qmd-aware skill, doubles the test matrix, and constrains design to the no-qmd ceiling.
+- Option 3 has the same skill-author cost as Option 4 (skills still assume qmd) without the install-time guarantee — users hit cryptic mid-run failures instead of a clear precheck error.
+- Option 5 is unviable today because qmd's MCP surface is read-only (`query`, `get`, `multi_get`, `status`); write operations (`collection add`, `embed`, `update`, `context add`) require the CLI in PATH, so bundling the MCP does not eliminate the install precheck. (Reconsider when qmd exposes write operations as MCP tools.)
+
+### Sub-decision 1: Enforcement happens in `/sdd:init`
+
+`/sdd:init` runs `command -v qmd` as a preflight check. If qmd is missing, init refuses to write CLAUDE.md and emits the install command (`npm install -g @tobilu/qmd` or `bun install -g @tobilu/qmd`) plus a link to qmd's repository. This makes the dependency obvious at the moment a user is setting up a project — not three skills deep into a workflow.
+
+### Sub-decision 2: Other qmd-aware skills MAY assume qmd is present
+
+Skills downstream of `/sdd:init` MAY assume qmd is installed and the repo is indexed (or invite the user to run `/sdd:index` if not). They MUST NOT include conditional fallback paths. If a skill needs to handle "qmd installed but this repo not yet indexed", it does so by routing to `/sdd:index` rather than by silently degrading.
+
+### Sub-decision 3: Version bump to 5.0.0
+
+The plugin moves from v4.2.0 → v5.0.0 in `.claude-plugin/plugin.json`. The CHANGELOG documents the qmd requirement under "Breaking Changes" with the install command. Existing users on v4.x continue to work without qmd; only fresh installs and explicit upgrades pick up the requirement.
+
+### Consequences
+
+* Good, because every qmd-aware skill becomes designable *for* hybrid retrieval rather than around its absence — the design ceiling of `/sdd:check`, `/sdd:audit`, `/sdd:discover`, `/sdd:adr`, `/sdd:spec`, `/sdd:plan`, `/sdd:prime`, `/sdd:work`, and `/sdd:review` rises substantially.
+* Good, because skill code stays single-path: no `if qmd available` branches to author, test, or document.
+* Good, because users receive a coherent "the plugin assumes X" promise instead of "the plugin has feature parity with and without X."
+* Good, because forcing qmd installation creates the surface area for future plugin features (RAG over the artifact corpus, semantic graph queries, cross-repo search) without re-litigating the dependency model.
+* Bad, because new users must install qmd before `/sdd:init` succeeds — a friction point that did not previously exist.
+* Bad, because qmd's GGUF models (~2GB total: EmbeddingGemma 300M, Qwen3-Reranker 0.6B, qmd-query-expansion 1.7B) auto-download on first embed, which surprises bandwidth-constrained users.
+* Bad, because CPU-only machines pay a real time cost on initial embed (mitigated by `/sdd:index`'s background-mode prompt) and a smaller cost on every subsequent query (mitigated by qmd's HTTP daemon, which keeps models loaded between requests).
+* Bad, because v5.0.0 is a breaking release — any tooling, marketplace listing, or downstream automation that pinned to v4 needs an update.
+
+### Confirmation
+
+Compliance is confirmed by:
+
+1. `/sdd:init` exits non-zero with the install command when qmd is absent. Verified by an integration test that runs `init` in a sandbox without qmd in PATH.
+2. No qmd-aware skill contains a `command -v qmd || fallback` branch. Verified by a `grep -r "command -v qmd" skills/` lint check; only `/sdd:init` may match.
+3. The plugin's `README.md` and `.claude-plugin/plugin.json` description list qmd as a runtime requirement, not a recommendation.
+4. CHANGELOG entry for v5.0.0 enumerates the breaking change and the install command.
+
+## Pros and Cons of the Options
+
+### Option 1: Status quo (no qmd)
+
+The current shape of the plugin — read-side skills scan the full corpus; authoring skills ask humans to declare edges manually; planning skills greenfield every story.
+
+* Good, because zero install friction — anyone with the plugin can use it immediately.
+* Good, because no breaking change required.
+* Neutral, because the existing skills work fine at small corpus sizes (today's claude-plugin-sdd repo is the proof).
+* Bad, because the design ceiling of every read-side skill is "load everything into context", which fails as repos mature.
+* Bad, because authoring skills cannot suggest graph edges, leaving the DAG ADR-0023 introduced sparse.
+* Bad, because planning skills cannot retrieve existing code, so stories are sized as if from scratch.
+
+### Option 2: Optional dependency (with fallback)
+
+Every qmd-aware skill detects qmd at runtime and branches: smart path if present, current path if absent.
+
+* Good, because no install friction for users who do not want qmd.
+* Good, because no breaking change.
+* Bad, because every qmd-aware skill is two code paths — roughly double the SKILL.md authoring effort and test coverage.
+* Bad, because the design ceiling of each skill is constrained by the no-qmd path; the qmd path is at most a faster version of the same behavior, never genuinely smarter.
+* Bad, because users on the fallback path receive a strictly worse experience while reading the same documentation.
+* Bad, because skill authors must reason about both paths simultaneously, which leaks complexity into every PR.
+
+### Option 3: Soft requirement (warn at init, assume in skills)
+
+`/sdd:init` warns about missing qmd but proceeds. Skills assume qmd is present and error out when it is not.
+
+* Good, because no breaking change at the install layer.
+* Good, because skill code stays single-path (same as Option 4).
+* Neutral, because the user-facing failure mode shifts from "init refuses" to "skills crash" — same outcome, later in the workflow.
+* Bad, because users discover the dependency mid-task instead of at setup, which is the worst possible time to learn it.
+* Bad, because warnings are routinely ignored — the soft signal does nothing the hard precheck would not do better.
+
+### Option 4: Hard dependency (chosen)
+
+`/sdd:init` enforces qmd presence; v5.0.0 marks the breaking change; downstream skills MAY assume qmd is available.
+
+* Good, because skill code stays single-path.
+* Good, because the dependency is discovered at the right moment (init), not mid-workflow.
+* Good, because the v5.0.0 bump is honest about the rupture and gives existing users a clear upgrade signal.
+* Good, because future plugin capabilities (semantic graph, RAG, cross-repo search) can rely on qmd as primitive.
+* Bad, because new users hit an install step before the plugin works.
+* Bad, because qmd's GGUF models auto-download (~2GB) on first embed.
+* Bad, because the v5.0.0 release requires CHANGELOG, README, and marketplace updates.
+
+### Option 5: Bundle qmd in plugin manifest via npx
+
+Declare an MCP server in `.claude-plugin/.mcp.json` as `npx -y @tobilu/qmd mcp` so the plugin auto-spawns qmd's MCP. The skills shell out to `npx -y @tobilu/qmd ...` for write operations.
+
+* Good, because zero-install for users — `/plugin install` fetches qmd transitively.
+* Neutral, because this option does not eliminate the requirement on the qmd CLI being callable; it only reframes how it is invoked.
+* Bad, because qmd's MCP is read-only today (`query`, `get`, `multi_get`, `status`). Write operations (`collection add`, `embed`, `update`, `context add`) are CLI-only, so the plugin still needs a CLI path. Bundling the MCP eliminates only the *search* install friction, not the *index* friction.
+* Bad, because every `npx -y` invocation does a dependency-resolve check (~1-3s overhead) on top of any user-installed qmd, doubling the latency on indexing operations.
+* Bad, because users who already have the standalone `qmd@qmd` plugin installed (a separate marketplace entry) end up with two MCP servers backed by the same `~/.cache/qmd/index.sqlite` file — reads are fine, but writes can race.
+* Bad, because the plugin would silently re-implement what an upstream-maintained marketplace plugin already provides, creating version-drift risk between the bundled qmd and the standalone plugin.
+* Reconsider, when qmd exposes write operations as MCP tools — at that point, bundling the MCP becomes a genuine alternative to a CLI dependency.
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+  User([User]) -->|1. /sdd:init| Init[/sdd:init]
+  Init -->|preflight: command -v qmd| QmdCheck{qmd in PATH?}
+  QmdCheck -->|no| Refuse[Refuse with install command:<br/>npm install -g @tobilu/qmd]
+  QmdCheck -->|yes| WriteClaude[Write CLAUDE.md<br/>+ suggest /sdd:index]
+  WriteClaude -->|2. /sdd:index| Index[/sdd:index]
+  Index -->|qmd collection add x3| QmdIndex[(qmd index<br/>~/.cache/qmd/index.sqlite)]
+
+  WriteClaude -.->|3+. all qmd-aware skills MAY assume qmd is present| Skills
+
+  subgraph Skills [qmd-aware skills v5+]
+    Prime[/sdd:prime]
+    Check[/sdd:check]
+    Audit[/sdd:audit]
+    Discover[/sdd:discover]
+    AdrSk[/sdd:adr]
+    SpecSk[/sdd:spec]
+    Plan[/sdd:plan]
+    Work[/sdd:work]
+    Review[/sdd:review]
+  end
+
+  Skills -->|qmd MCP query<br/>or qmd CLI| QmdIndex
+
+  classDef refuse fill:#fbb,stroke:#900
+  classDef ok fill:#bfb,stroke:#090
+  class Refuse refuse
+  class WriteClaude,QmdIndex ok
+```
+
+## More Information
+
+* `/sdd:index` (introduced alongside this ADR) is the only skill that *creates* qmd state. All other qmd-aware skills are consumers.
+* ADR-0025 (paired with this one) extends the per-repo collection set with a fourth `{repo}-issues` collection by syncing tracker issues to `.sdd/issues/`. That decision assumes the dependency model established here.
+* The forthcoming `qmd-native-skills` spec enumerates the per-skill requirements that consume this dependency.
+* qmd's HTTP daemon mode (`qmd mcp --http --daemon`) is the recommended runtime for CPU-only users — it keeps models loaded across requests, eliminating cold-start latency on every query. Future plugin work may auto-start the daemon on `/sdd:init`.
+* This ADR does *not* require users to install the standalone `qmd@qmd` Claude Code plugin (which exposes the qmd MCP to all sessions). The SDD plugin's skills work with either the qmd CLI directly or the qmd MCP if present; both surfaces talk to the same underlying index.

--- a/docs/adrs/ADR-0025-tracker-issues-as-fourth-qmd-collection.md
+++ b/docs/adrs/ADR-0025-tracker-issues-as-fourth-qmd-collection.md
@@ -1,0 +1,239 @@
+---
+status: proposed
+date: 2026-05-03
+decision-makers: Joe Stump
+related: [ADR-0007, ADR-0009, ADR-0011, ADR-0017]
+extends: [ADR-0024]
+---
+
+# ADR-0025: Tracker Issues as a Fourth Per-Repo qmd Collection
+
+## Context and Problem Statement
+
+ADR-0024 establishes qmd as a hard dependency and `/sdd:index` as the canonical way to index per-repo content into three collections: `{repo}-adrs`, `{repo}-specs`, and `{repo}-code`. The unit of work in this plugin's lifecycle, however, is not the ADR or the spec — it is the **tracker issue**: stories produced by `/sdd:plan`, claimed by `/sdd:work`, reviewed by `/sdd:review`. Issues encode current state of work in a way that ADRs and specs do not: who owns what, what is in flight, what just merged, what got duplicated last sprint. Without this corpus indexed, the qmd-native versions of `/sdd:plan`, `/sdd:work`, and `/sdd:review` are blind to half the context that actually matters during sprint execution.
+
+The tracker abstraction adds a complication: SDD supports seven backends (GitHub, Gitea, GitLab, Jira, Linear, Beads, and the `tasks.md` fallback from ADR-0007). Each has a different API, authentication model, and shape. Whatever indexing approach we choose has to absorb that variety without leaking it into every consumer skill. How should the plugin make tracker issues hybrid-searchable alongside ADRs, specs, and code, while keeping the seven-tracker abstraction in one place?
+
+## Decision Drivers
+
+* **qmd is a markdown indexer.** Every other collection (`-adrs`, `-specs`, `-code`) is a directory of files on disk that qmd scans. Anything we add should fit that model rather than asking qmd to do something new.
+* **One abstraction, seven trackers.** The plugin already has tracker-detection and per-tracker skills (Try-Then-Create labels, PR Search by Spec). The issue-sync layer should reuse that abstraction, not re-implement it inside qmd's collection-update mechanism.
+* **Debuggability of indexed content.** When a query returns an unexpected match, the user should be able to `cat` the matched file. Indexes that pull directly from a remote API at scan time make this opaque.
+* **Incremental sync matters at scale.** A repo with 5,000 issues should not re-fetch and re-embed the entire corpus on every `/sdd:index update`. The sync layer needs an "updated since" cursor.
+* **Issue privacy is real.** Issue bodies routinely contain customer data, internal URLs, and partial credentials. Whatever local representation we create must be `.gitignore`d by default and surfaced to the user as "do not commit this directory."
+* **Existing PR/issue awareness already needs this.** ADR-0017's "Pre-Flight PR Awareness" pattern and the Sibling PR Manifest already query the tracker live. Centralizing on a synced corpus lets that pattern read from the index instead of paginating remote APIs on every dispatch.
+
+## Considered Options
+
+* **Option 1**: Don't index issues — keep fetching live from the tracker on demand inside each consumer skill.
+* **Option 2**: Use qmd's per-collection `update:` shell command to call `gh issue list` (etc.) directly, with qmd parsing the JSON output.
+* **Option 3**: Sync tracker issues to `.sdd/issues/{number}.md` markdown files via a tracker-aware sync layer in `/sdd:index`, then add `{repo}-issues` as a normal markdown collection in qmd.
+* **Option 4**: Build (or commission upstream) a qmd plugin that exposes a tracker source as a first-class collection type.
+
+## Decision Outcome
+
+Chosen option: **"Option 3 — sync to `.sdd/issues/`, index as normal markdown collection"**, because it keeps the multi-tracker abstraction in our skill (where it already lives) and lets qmd do exactly what it is designed to do (index local markdown). The synced files are debuggable, survive qmd reinstall, give qmd structured frontmatter to weight on, and let consumer skills retrieve issues through the same `qmd query -c {repo}-issues` interface they already use for ADRs/specs/code. Three sub-decisions are bundled below because they shape the disk layout and would otherwise re-emerge the next time someone touches the sync.
+
+### Sub-decision 1: On-disk layout
+
+```
+.sdd/
+  issues/
+    {number}.md            # one file per issue, named by tracker-native ID
+    _meta.json             # last-sync cursor (per-tracker) and counts
+```
+
+`.sdd/` is added to `.gitignore` by `/sdd:init` (component-level convergence; existing gitignore is appended, never replaced). For trackers that use composite IDs (Jira's `PROJ-123`, Linear's `TEAM-45`), the filename uses the full ID with the dash preserved: `.sdd/issues/PROJ-123.md`.
+
+### Sub-decision 2: Frontmatter schema (what qmd sees)
+
+Every synced file has this frontmatter:
+
+```yaml
+---
+id: 142                        # tracker-native ID (number for GH/Gitea/GitLab/Beads, key for Jira/Linear)
+title: "Add JWT validation to auth middleware"
+status: open                   # normalized: open | closed | merged | draft
+labels: [story, auth, sprint-3]
+assignees: [joestump]
+author: alice
+created: 2026-04-12T10:30:00Z
+updated: 2026-05-01T14:22:00Z
+closed: null                   # ISO timestamp or null
+url: https://github.com/owner/repo/issues/142
+tracker: github                # github | gitea | gitlab | jira | linear | beads | tasks-md
+references:
+  specs: [SPEC-0010]           # parsed from title + body
+  adrs: [ADR-0011]             # parsed from title + body
+  blocks: [#138, #140]         # parsed from "Blocks:" lines or tracker-native dependency edges
+  blocked_by: [#135]
+---
+
+# {title}
+
+{verbatim issue body}
+
+{optional appended sections from PR data: Files Modified, Sibling PRs, Merge Status — only when an issue has an associated PR}
+```
+
+The `references` block parses `SPEC-XXXX` and `ADR-XXXX` mentions from title and body, and dependency edges from "Blocks:"/"Blocked by:" lines (or the tracker's native dependency fields where they exist). This gives qmd's reranker structured fields to weight on without forcing every consumer skill to re-parse.
+
+### Sub-decision 3: Sync mechanism per tracker
+
+| Tracker | Sync command | Incremental cursor |
+|---------|--------------|-------------------|
+| GitHub | `gh issue list --state all --json number,title,body,state,labels,assignees,createdAt,updatedAt,url --search "updated:>{cursor}" --limit 1000` | `updated:>YYYY-MM-DD` in search |
+| Gitea | MCP tools (`mcp__gitea__issue_list` or equivalent), filtered by `since` | `since` parameter |
+| GitLab | `glab issue list --all --updated-after {cursor}` | `--updated-after` |
+| Jira | MCP tools with JQL `updated >= "{cursor}"` | JQL clause |
+| Linear | MCP tools with `filter: { updatedAt: { gte: cursor } }` | GraphQL filter |
+| Beads | `bd list --json` (full corpus — small enough; no cursor needed) | none |
+| tasks.md | Parse `docs/openspec/specs/*/tasks.md` files directly | file mtime |
+
+The sync layer normalizes all responses into the frontmatter schema above before writing to disk. Per-tracker logic lives in `references/tracker-sync.md` so consumer skills never see the API shape.
+
+### Sub-decision 4: Sync trigger points
+
+`/sdd:index update` syncs the issues collection as part of its normal pass — same UX as ADR/spec updates. Consumer skills MAY trigger an opportunistic sync at start-of-run when their work depends on fresh issue state:
+
+| Skill | Trigger |
+|-------|---------|
+| `/sdd:plan` | Sync before grouping requirements (avoids creating duplicate stories of recently-closed issues) |
+| `/sdd:work` | Sync before building the Sibling PR Manifest (ADR-0017) |
+| `/sdd:review` | Sync before building the Topological Merge Order (shared-patterns.md) |
+| `/sdd:enrich`, `/sdd:organize` | Sync before iterating issues to enrich/group |
+
+Skills MUST NOT sync silently — they print a one-line note ("Syncing N issues from {tracker}…") and proceed. If the sync fails, they fall back to live tracker queries (the pre-qmd path) and continue, not block.
+
+### Consequences
+
+* Good, because consumer skills (`/sdd:plan`, `/sdd:work`, `/sdd:review`, `/sdd:enrich`) gain hybrid search over the entire issue corpus through the same `-c {repo}-issues` interface they already use for ADRs/specs/code.
+* Good, because the multi-tracker abstraction stays in the SDD plugin, where the existing tracker-detection and per-tracker logic already lives. qmd remains tracker-agnostic.
+* Good, because synced files are inspectable, greppable, and survive qmd reinstall.
+* Good, because frontmatter `references` lets qmd's reranker boost matches that mention the spec/ADR a consumer is asking about — concrete reranker fuel, the way ADR-0024 already established for collection-level context.
+* Good, because the Sibling PR Manifest pattern (ADR-0017) becomes a qmd query rather than a paginated remote API call on every dispatch.
+* Bad, because issue bodies contain sensitive content; `.gitignore`d cache mitigates but cannot fully eliminate the risk that a user `tar`s their working directory and shares it.
+* Bad, because the sync layer must implement seven tracker integrations, each with its own auth, pagination, and rate-limit story.
+* Bad, because trackers can rewrite history (issue titles edit, comments delete, status flips) in ways the cursor-based incremental sync may miss until the next full re-sync.
+* Bad, because `tasks.md` (ADR-0007) does not have stable issue IDs the way trackers do; the tasks.md sync is a special case that uses a content-derived hash as the file name.
+* Bad, because `.sdd/issues/` adds a new on-disk artifact category users have to learn about; documented prominently in `/sdd:init`'s output and in CLAUDE.md.
+
+### Confirmation
+
+Compliance is confirmed by:
+
+1. `/sdd:index add` creates the `{repo}-issues` collection alongside the existing three (or skips with a clear warning if no tracker is configured). Verified by integration tests against each supported tracker (mocked APIs OK).
+2. The frontmatter of every synced file conforms to the schema in Sub-decision 2. Verified by a script in the test suite that parses every `.sdd/issues/*.md` and validates required fields.
+3. `.sdd/` appears in `.gitignore` after `/sdd:init` runs (idempotent; existing entries preserved).
+4. `tracker-sync.md` is the sole location of per-tracker API shape — verified by a `grep -r "gh issue list\|glab issue list\|bd list" skills/` lint that should match only inside that reference file.
+5. Consumer skills emit the "Syncing N issues from {tracker}…" line before invoking sync.
+6. Sync failures fall back to live tracker queries with a warning, never silently block.
+
+## Pros and Cons of the Options
+
+### Option 1: Don't index issues; fetch live on demand
+
+The current shape — `/sdd:plan`, `/sdd:work`, `/sdd:review` paginate the tracker API every time they need issue context.
+
+* Good, because no on-disk artifact to manage; no privacy-vs-cache trade-off.
+* Good, because data is always fresh.
+* Bad, because consumer skills cannot run hybrid retrieval over issues — they can only filter by title or label.
+* Bad, because every dispatch repeats the same API calls (Pre-Flight PR Awareness in ADR-0017 already feels this pain).
+* Bad, because rate limits and auth errors block consumer skills from finishing, even when the data they need was retrieved minutes ago by a sibling skill.
+
+### Option 2: qmd per-collection `update:` shell command
+
+qmd supports custom update commands per collection (see `getCollectionFromYaml(col.name)?.update` in qmd's source). We could give the issues collection a YAML config with `update: gh issue list --json ... | jq ... > /tmp/issues.json` and have qmd parse the JSON.
+
+* Good, because no separate sync layer in our skill — qmd handles the lifecycle.
+* Good, because update timing piggybacks on `qmd update`.
+* Bad, because qmd is a markdown indexer, not a JSON indexer — the parsed output would still need to be markdown-shaped before qmd can BM25/vector-search it.
+* Bad, because the multi-tracker abstraction now lives in qmd's YAML config rather than in our skill, fragmenting the tracker-handling code.
+* Bad, because users debugging an issue match cannot `cat` a file — they would have to re-run the update command and parse the intermediate JSON.
+* Bad, because per-collection update commands are a qmd feature, not a stable API contract — relying on them couples us to qmd internals.
+
+### Option 3: Sync to `.sdd/issues/`, index as markdown (chosen)
+
+`/sdd:index` calls a tracker-aware sync layer that writes one markdown file per issue to `.sdd/issues/`. qmd then indexes it as a normal markdown collection.
+
+* Good, because the multi-tracker abstraction stays in our skill where it already lives.
+* Good, because synced files are debuggable, greppable, and inspectable.
+* Good, because frontmatter is reranker-friendly.
+* Good, because `.gitignore` keeps the cache local without imposing structure on the user's repo.
+* Good, because incremental sync via per-tracker cursors keeps the cost proportional to changed issues.
+* Bad, because we own the sync code (seven tracker integrations).
+* Bad, because the user has to learn that `.sdd/` exists.
+
+### Option 4: qmd plugin that adds a tracker source
+
+Build a qmd extension (or commission one upstream) that lets qmd treat a tracker as a first-class collection source.
+
+* Good, because clean separation: SDD plugin is tracker-agnostic; qmd extension is tracker-specific.
+* Good, because reusable beyond SDD — anyone using qmd could add their tracker.
+* Bad, because qmd does not currently expose a plugin API for collection sources.
+* Bad, because pushing this upstream is a months-long effort with no guarantee of acceptance.
+* Bad, because we would still need to implement the seven tracker integrations — they would just live in qmd's repo instead of ours.
+* Reconsider, when qmd ships a stable extension API for collection sources.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+  subgraph Trackers
+    GH[GitHub]
+    Gitea[Gitea]
+    GL[GitLab]
+    Jira[Jira]
+    Linear[Linear]
+    Beads[Beads]
+    TasksMD[tasks.md]
+  end
+
+  subgraph SddPlugin [SDD plugin]
+    IndexSk[/sdd:index update]
+    SyncLayer[references/tracker-sync.md<br/>per-tracker fetch + normalize]
+    Cursor[(.sdd/issues/_meta.json<br/>per-tracker cursors)]
+  end
+
+  Cache[(.sdd/issues/<br/>{number}.md per issue<br/>frontmatter + body)]
+
+  Qmd[(qmd index<br/>{repo}-issues collection)]
+
+  GH -->|gh issue list --search updated:&gt;cursor| SyncLayer
+  Gitea -->|MCP issue list since cursor| SyncLayer
+  GL -->|glab issue list --updated-after| SyncLayer
+  Jira -->|JQL updated &gt;= cursor| SyncLayer
+  Linear -->|GraphQL filter updatedAt| SyncLayer
+  Beads -->|bd list --json| SyncLayer
+  TasksMD -->|parse files by mtime| SyncLayer
+
+  IndexSk -->|trigger sync| SyncLayer
+  SyncLayer -->|read cursor| Cursor
+  SyncLayer -->|write {number}.md| Cache
+  SyncLayer -->|update cursor| Cursor
+
+  Cache -->|qmd collection add /<br/>qmd update| Qmd
+
+  subgraph Consumers [qmd-aware consumers]
+    Plan[/sdd:plan]
+    Work[/sdd:work]
+    Review[/sdd:review]
+    Enrich[/sdd:enrich]
+  end
+
+  Consumers -->|qmd query -c {repo}-issues| Qmd
+  Consumers -.->|opportunistic sync at start| IndexSk
+
+  classDef store fill:#e8f4ff,stroke:#0366d6
+  classDef ext fill:#fff4e8,stroke:#bf8700
+  class Cache,Cursor,Qmd store
+  class GH,Gitea,GL,Jira,Linear,Beads,TasksMD ext
+```
+
+## More Information
+
+* This ADR extends ADR-0024. Without qmd as a hard dependency, the consumer skills could not assume the issues collection is searchable and the sync investment would not pay off.
+* The forthcoming `qmd-native-skills` spec lists the per-skill requirements for issue-aware behavior (e.g., `/sdd:plan` MUST sync before requirement grouping; `/sdd:work` MUST query for sibling PR awareness from the issues collection).
+* `tracker-sync.md` (a new shared reference file) absorbs the per-tracker logic. Consumer skills never see API shapes; they only see normalized markdown files.
+* The Sibling PR Manifest pattern (ADR-0017, SPEC-0015 REQ "Pre-Flight PR Awareness") gets reframed as a qmd query against the synced corpus rather than a live API call. The same data, but cached, indexed, and rerankable.
+* Future: a notion of issue *projections* — generated views like "all open stories blocked by foundation PRs" — could live in `.sdd/issues/_views/` as derived markdown so qmd can search them too. Out of scope for this ADR.

--- a/docs/adrs/ADR-0026-tiered-index-freshness-strategy.md
+++ b/docs/adrs/ADR-0026-tiered-index-freshness-strategy.md
@@ -1,0 +1,239 @@
+---
+status: proposed
+date: 2026-05-03
+decision-makers: Joe Stump
+extends: [ADR-0024]
+related: [ADR-0025, ADR-0017]
+---
+
+# ADR-0026: Tiered Index Freshness Strategy
+
+## Context and Problem Statement
+
+ADR-0024 makes qmd a hard dependency, so every qmd-aware skill assumes the index exists. ADR-0025 adds a tracker-issues collection that can change between every skill invocation. Neither ADR addresses *when* the indexes get refreshed, and a wrong answer here will silently degrade every consumer skill: stale code-collection results lead `/sdd:work` to recreate types that already exist; stale issue results lead `/sdd:plan` to schedule work that was just closed; stale ADR/spec results lead `/sdd:check` to miss governing artifacts written that morning.
+
+A single-trigger answer ("always update on prime", "always update on every skill call") fails on cost-vs-freshness in opposite directions. The correct shape acknowledges that different content categories change at different rates, that `qmd update` (file scan) and `qmd embed` (vector generation) have wildly different costs, and that the most precise refresh signal is *which skill just finished mutating which collection*. The decision is how to compose those signals into a coherent, opinionated default behavior that consumer skills can rely on without having to think about freshness themselves.
+
+## Decision Drivers
+
+* **Cost asymmetry between update and embed.** `qmd update` is a file-mtime scan — cheap, sub-second on typical repos. `qmd embed` runs ~1s per chunk on CPU and ~10× faster on GPU. Conflating them produces either a sluggish UX (embed every time) or a stale index (update never).
+* **Mutation precision beats periodic polling.** When `/sdd:adr` writes a new ADR, the *most* precise update signal is "this skill just wrote this file" — not a 5-minute timer. Mutation-aware updates eliminate staleness for the most common cause of staleness (the user's own work).
+* **Session start is a natural sync moment.** `/sdd:prime` is when the user signals "I'm about to do work in this repo" — exactly when external changes (other devs, CI, branch switches) should land in the index.
+* **Issues change faster than artifacts.** Tracker issues are edited in browsers, labelled by bots, closed by CI. The cadence is qualitatively different from ADRs/specs/code, which only change when *someone* in this repo writes code.
+* **Embed prompts are friction.** Asking the user "embed now? y/n" every time a CPU-only machine has unembedded chunks is a tax on every workflow. Defaulting to background mode preserves the user's flow.
+* **Auto mode discipline.** The plugin already operates in auto mode by default. Freshness behavior should also default to "do the cheap right thing silently and only escalate to a prompt when the right thing isn't obvious."
+
+## Considered Options
+
+* **Option 1**: Manual only — user runs `/sdd:index update` when they remember.
+* **Option 2**: Single trigger via `/sdd:prime` — every session start runs full update + embed.
+* **Option 3**: On every consumer skill call — each skill runs `qmd update` first.
+* **Option 4**: Time-based staleness threshold — skills check timestamp, update only if older than threshold.
+* **Option 5**: File-watching daemon — background process listens for fs events.
+* **Option 6**: Tiered hybrid — mutation-aware (Tier 1) + session-start (Tier 2) + threshold (Tier 3) + per-collection cadence (Tier 4), with embed treated separately from update.
+
+## Decision Outcome
+
+Chosen option: **"Option 6 — Tiered hybrid"**, because each tier picks the cheapest mechanism for the staleness it actually addresses. The other options each fail on a specific axis: Option 1 leaks staleness into every skill; Option 2 makes every prime slow and still misses mid-session changes; Option 3 makes every consumer skill slow and embeds redundantly; Option 4 alone misses the high-fidelity mutation signals that Tier 1 captures for free; Option 5 requires an OS-level daemon that the plugin has no clean way to install or manage.
+
+The strategy has four tiers and one cross-cutting embed policy, each with a clear owner skill and a clear trigger.
+
+### Tier 1 — Mutation-aware updates (most precise, owned by mutating skills)
+
+Skills that *write* indexed content trigger a narrow `qmd update` for the affected collection when they finish. No staleness ever for the most common case (the user's own work).
+
+| Skill | Trigger | Affected collection |
+|-------|---------|---------------------|
+| `/sdd:adr` | After writing ADR file | `{repo}-adrs` |
+| `/sdd:spec` | After writing spec.md or design.md | `{repo}-specs` |
+| `/sdd:status` | After flipping status | The collection whose artifact changed |
+| `/sdd:work` | After merging a PR | `{repo}-code` (for the changed paths) |
+| `/sdd:plan`, `/sdd:enrich`, `/sdd:organize` | After mutating tracker issues | `{repo}-issues` (via sync layer from ADR-0025) |
+| `/sdd:review` | After merging a PR | `{repo}-code` AND `{repo}-issues` |
+
+Mutation updates run synchronously, before the skill returns its report. They are silent unless they fail (in which case a one-line warning lands in the report).
+
+### Tier 2 — Session-start update via `/sdd:prime`
+
+`/sdd:prime` runs `qmd update` (cheap file-mtime scan) on entry to catch changes from outside the current Claude session: other developers, CI bots, branch switches, manually edited files. Specifically:
+
+1. If the qmd index was touched within the last 60 seconds, skip — back-to-back primes are common enough to optimize for.
+2. Otherwise, run `qmd update` silently. Print one line in the report header: "Refreshed index ({N} added, {M} updated, {R} removed across all collections)" only when there were changes; print nothing when the index was already current.
+3. After the update, count unembedded chunks across this repo's collections via `qmd status`. If non-zero, surface a one-line note in the prime output: "{N} chunks unembedded — run `/sdd:index embed` (≈{seconds}s on this machine, foreground; or wait for the next mutation skill to backfill)." Do NOT prompt.
+
+`/sdd:prime` does not trigger embed — that is opt-in via `/sdd:index embed` or piggybacks on Tier 1 mutations. Embedding on session start would slow every prime and surprise users on CPU.
+
+### Tier 3 — Staleness-threshold opportunistic updates inside consumer skills
+
+Read-only consumer skills (`/sdd:check`, `/sdd:audit`, `/sdd:plan`, `/sdd:work`, `/sdd:review`, `/sdd:discover`) check the qmd index timestamp on entry. If older than the staleness threshold, run a silent `qmd update` first. Print a one-line note in the report: "Index was {age} stale — refreshed before running."
+
+The threshold default is **120 minutes (2 hours)** and is configurable in CLAUDE.md `### SDD Configuration`:
+
+```markdown
+### SDD Configuration
+
+#### Index Freshness
+- **Staleness Threshold**: 120m
+```
+
+Two hours strikes the right balance for the typical workflow: short enough that index never lags a half-day of work, long enough that back-to-back skill calls within a focused work session do not trigger redundant updates. Users with high tracker churn or large teams can shorten it (e.g., `30m`); users on slow disks or huge repos can lengthen it (e.g., `4h`).
+
+### Tier 4 — Issues collection always syncs at consumer entry
+
+Tracker issues change qualitatively faster than ADRs/specs/code (browser edits, bot labels, CI status flips). Skills whose correctness depends on fresh issue state ALWAYS sync the issues collection on entry, regardless of staleness threshold:
+
+| Skill | Sync requirement |
+|-------|------------------|
+| `/sdd:plan` | Sync before requirement grouping (avoid duplicating recently-closed issues) |
+| `/sdd:work` | Sync before building Sibling PR Manifest (ADR-0017) |
+| `/sdd:review` | Sync before computing Topological Merge Order |
+| `/sdd:enrich`, `/sdd:organize` | Sync before iterating issues |
+
+Tier 4 overrides Tier 3 for the issues collection only — other collections still respect the threshold. The override is justified by the cadence asymmetry; treating issues like ADRs would let stale work-state silently corrupt sprint planning.
+
+### Embed Policy: CPU-only defaults to background, no prompt
+
+`/sdd:index embed` (and any internal call to qmd embed from another skill) follows this policy:
+
+1. Detect GPU via `qmd status`. If GPU is present, run synchronously — embedding is fast enough that asking would be friction.
+2. If CPU-only, default to **background mode** without prompting. Run as a backgrounded Bash command, log to `/tmp/qmd-embed-{repo}.log`, return the report immediately. The harness emits a completion notification when the backgrounded command exits.
+3. The user MAY override with explicit subcommand args:
+   - `/sdd:index embed --foreground` — block the session (right when the user wants to verify chunk counts inline)
+   - `/sdd:index embed --skip` — no-op (right when the user is about to run an expensive multi-step that should not race with embed)
+
+This replaces the AskUserQuestion-based three-way prompt in the original `/sdd:index` design. Prompting CPU users every time was a tax that produced the same answer 95% of the time. Background-by-default is the right default; explicit flags handle the long tail.
+
+### Consequences
+
+* Good, because mutation-aware updates eliminate staleness for the most common case (the user's own work) at zero perceptible cost.
+* Good, because consumer skills get fresh data on entry without per-call user friction.
+* Good, because the embed/update split prevents the slow-step from coupling to the cheap-step.
+* Good, because issues stay fresh under high tracker churn without burdening ADR/spec/code consumers with the same cadence.
+* Good, because CPU-only users get embeddings done in the background without recurring prompts.
+* Good, because the staleness threshold is a single configuration knob users can tune to their workflow.
+* Bad, because four tiers is more behavior to document and reason about than a single trigger.
+* Bad, because the staleness check adds a small (~50ms) overhead to every consumer skill entry.
+* Bad, because background embeds can be killed mid-flight (machine sleep, terminal close), leaving a partial index. Mitigated by the log file location and the fact that re-running embed picks up where the previous run left off.
+* Bad, because Tier 4's "always sync issues" can be slow on huge backlogs (5,000+ issues). Mitigated by the incremental cursor in ADR-0025 sub-decision 3.
+
+### Confirmation
+
+Compliance is confirmed by:
+
+1. Each mutating skill (`/sdd:adr`, `/sdd:spec`, `/sdd:status`, `/sdd:work`, `/sdd:plan`, `/sdd:enrich`, `/sdd:organize`, `/sdd:review`) calls `qmd update` after writing files but before returning. Verified by reading each SKILL.md and grepping for the `qmd update` invocation in the appropriate step.
+2. `/sdd:prime` calls `qmd update` (or skips with the 60-second short-circuit) and surfaces the unembedded-chunk count when non-zero. Verified by an integration test that adds a file, runs prime, and asserts the chunk delta is reflected.
+3. Read-only consumer skills check the index timestamp and trigger `qmd update` when staleness exceeds the configured threshold. Verified by integration tests that artificially set the index timestamp to "stale" and assert the update runs.
+4. The `Staleness Threshold` configuration key is documented in `references/shared-patterns.md` § "Config Resolution" and accepted by `/sdd:init` Step 3.
+5. `/sdd:index embed` on a CPU-only machine defaults to background without prompting. Verified by a sandbox test that mocks `qmd status` to report no GPU and asserts no AskUserQuestion call.
+6. The four-tier model is documented in `references/shared-patterns.md` as the canonical "Index Freshness" pattern that consumer skills reference rather than re-implement.
+
+## Pros and Cons of the Options
+
+### Option 1: Manual only
+
+User runs `/sdd:index update` when they remember to.
+
+* Good, because zero implicit behavior — every refresh is explicit.
+* Good, because predictable performance for every other skill call.
+* Bad, because real users routinely forget. Stale indexes silently degrade every retrieval-based skill.
+* Bad, because no good signal exists to remind the user (we have no daemon, no cron).
+
+### Option 2: Single trigger via `/sdd:prime`
+
+Every session start runs `qmd update` and `qmd embed`.
+
+* Good, because one trigger to remember.
+* Good, because aligns with "I'm starting work" intent.
+* Bad, because not all sessions begin with prime — many start with `/sdd:check` or `/sdd:work` directly.
+* Bad, because embed is slow; conflating it with prime makes session start unbearable on CPU.
+* Bad, because mid-session changes (a CI bot closing an issue, a teammate pushing) go stale until the next prime.
+
+### Option 3: Update on every consumer skill call
+
+Each consumer skill runs `qmd update` first.
+
+* Good, because freshness is automatic.
+* Bad, because every skill becomes 50–500ms slower on entry, even when it does not need fresh data.
+* Bad, because back-to-back skill calls re-update redundantly.
+* Bad, because still does not address embed cost.
+
+### Option 4: Time-based staleness threshold alone
+
+Skills check timestamp; update only if older than threshold.
+
+* Good, because amortizes update cost across multiple skill calls.
+* Good, because configurable per workflow.
+* Bad, because misses Tier-1 mutation signals — when the user just wrote an ADR, the index could be updated for ~free, but a threshold-only model waits for the next staleness check.
+* Bad, because the threshold is an arbitrary number that will never be right for everyone.
+
+### Option 5: File-watching daemon
+
+Background process listens for fs events and runs `qmd update` on changes.
+
+* Good, because freshness is continuous and automatic.
+* Bad, because requires installing and managing a daemon — outside the plugin's clean install model.
+* Bad, because OS-specific (inotify on Linux, fsevents on Mac, polling on Windows) — adds platform complexity.
+* Bad, because does not address tracker issues, which change in remote APIs the daemon cannot watch.
+* Reconsider, when Claude Code itself ships a fs-watch primitive plugins can hook into.
+
+### Option 6: Tiered hybrid (chosen)
+
+Mutation-aware (T1) + session-start (T2) + threshold (T3) + per-collection cadence (T4) + embed policy.
+
+* Good, because each tier picks the cheapest mechanism for the staleness it addresses.
+* Good, because T1 captures the highest-fidelity signal (skills mutating their own collections) at zero cost.
+* Good, because T4 handles the cadence asymmetry of issues without affecting ADRs/specs/code.
+* Good, because the embed policy removes a recurring prompt for CPU users.
+* Bad, because four tiers is more to document and reason about than a single trigger.
+* Bad, because the staleness threshold is still arbitrary (mitigated by being configurable).
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+  Start([Skill invoked]) --> SkillType{Skill type?}
+
+  SkillType -->|Mutating skill| Mutate[Skill writes content]
+  Mutate --> T1[Tier 1: qmd update<br/>narrow to changed collection]
+  T1 --> Report[Skill returns report]
+
+  SkillType -->|/sdd:prime| PrimeCheck{Last update<br/>&lt; 60s?}
+  PrimeCheck -->|yes| LoadCtx[Load ADR/spec context]
+  PrimeCheck -->|no| T2[Tier 2: qmd update silently]
+  T2 --> EmbedCheck{Unembedded<br/>chunks?}
+  EmbedCheck -->|yes| Surface[Surface 1-line note:<br/>'N chunks unembedded']
+  EmbedCheck -->|no| LoadCtx
+  Surface --> LoadCtx
+  LoadCtx --> Report
+
+  SkillType -->|Consumer skill| ConsumerType{Needs issues?}
+  ConsumerType -->|yes: plan/work/review/enrich/organize| T4[Tier 4: always sync issues]
+  ConsumerType -->|no: check/audit/discover| T3Check{Index age &gt;<br/>staleness threshold?}
+  T4 --> T3Check
+  T3Check -->|yes| T3[Tier 3: qmd update silently]
+  T3Check -->|no| RunSkill[Run skill body]
+  T3 --> RunSkill
+  RunSkill --> Report
+
+  SkillType -->|/sdd:index embed| GPUCheck{GPU available?}
+  GPUCheck -->|yes| EmbedFG[qmd embed foreground<br/>fast]
+  GPUCheck -->|no| EmbedBG[qmd embed background<br/>silent default]
+  EmbedFG --> Report
+  EmbedBG --> Report
+
+  classDef cheap fill:#bfb,stroke:#090
+  classDef expensive fill:#fbb,stroke:#900
+  classDef neutral fill:#e8f4ff,stroke:#0366d6
+  class T1,T2,T3,T4 cheap
+  class EmbedFG,EmbedBG expensive
+  class Report,LoadCtx,Mutate,RunSkill neutral
+```
+
+## More Information
+
+* This ADR extends ADR-0024 by specifying *when* qmd is invoked, complementing ADR-0024's *whether* qmd is required.
+* This ADR works with ADR-0025 by treating issues as a special-cadence collection (Tier 4) — issues sync at consumer entry while other collections respect the staleness threshold.
+* The tiered model is documented in `references/shared-patterns.md` as the canonical "Index Freshness" pattern. Consumer skills reference this pattern by section name rather than reimplementing the logic per skill.
+* The 60-second prime short-circuit and the 120-minute default threshold are tuning constants chosen for the typical claude-plugin-sdd workflow. Both are configurable; both should be reviewed after the qmd-native skills land and produce real telemetry.
+* Tier 5 (scheduled background sync via Claude Code's `schedule` skill) is deliberately out of scope for v5. It will be reconsidered in a follow-up ADR after V1 ships and the Tier 1–4 baseline produces evidence about the long-tail staleness cases that scheduling would address.
+* Background embed jobs can be interrupted (machine sleep, terminal close). The recovery story is "re-run `/sdd:index embed` and it picks up where it left off" — qmd already handles this by tracking unembedded chunks at the database level. No special recovery logic is needed in the plugin.


### PR DESCRIPTION
## Summary

Three proposed ADRs documenting the v5.0.0 direction. They land as `proposed` status — actual implementation work follows in a separate spec + sprint.

- **ADR-0024**: Make qmd a hard dependency of the SDD plugin starting with v5.0.0. Eliminates fallback paths in qmd-aware skills; lets every skill design *for* hybrid retrieval rather than around its absence; v5.0.0 marks the breaking change.
- **ADR-0025**: Tracker issues as a fourth per-repo qmd collection. `/sdd:index update` syncs from the configured tracker (gh / glab / tea / Jira / Linear / Beads / tasks.md) to `.sdd/issues/{number}.md`, then qmd indexes that directory like any other markdown collection. Multi-tracker abstraction stays in the SDD plugin; qmd remains tracker-agnostic.
- **ADR-0026**: Tiered index freshness strategy. Mutation-aware updates (Tier 1, owned by mutating skills) + session-start update via `/sdd:prime` (Tier 2) + 120-min staleness threshold for consumer skills (Tier 3) + always-sync issues collection at consumer entry for plan/work/review/enrich (Tier 4). Plus an embed policy: GPU defaults to foreground, CPU defaults to silent background — no AskUserQuestion every time.

## Why these are landing as a PR (not just sitting on a wip branch)

So the spec work that follows can reference them by accepted artifact ID and the artifact graph (ADR-0023) tracks them. They're `proposed` status — the user marks them `accepted` when the implementation lands.

## Files changed

- `docs/adrs/ADR-0024-qmd-as-hard-dependency.md` — new
- `docs/adrs/ADR-0025-tracker-issues-as-fourth-qmd-collection.md` — new
- `docs/adrs/ADR-0026-tiered-index-freshness-strategy.md` — new

## What's NOT in this PR

- The `qmd-native-skills` spec (separate PR after these land)
- Implementation of any of the three ADRs (separate sprint via `/sdd:plan` after the spec)
- `/sdd:init` enforcement of qmd presence (per ADR-0024 sub-decision 1; lands in the implementation sprint)
- `.sdd/issues/` sync logic (per ADR-0025; lands in implementation sprint)
- The four-tier freshness implementation (per ADR-0026; lands in implementation sprint)

## No version bump in this PR

Proposed ADRs don't change behavior. v5.0.0 ships when the implementation lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)