### PR TITLE
spec(qmd-native-skills): SPEC-0019 — input to v5.0.0 sprint

### DIFF
--- a/docs/openspec/specs/qmd-native-skills/design.md
+++ b/docs/openspec/specs/qmd-native-skills/design.md
@@ -1,0 +1,208 @@
+# Design: qmd-Native Skills
+
+## Context
+
+Three ADRs landed in v4.4.0 (proposed) defining the v5.0.0 architecture: ADR-0024 (qmd as a hard dependency), ADR-0025 (tracker issues as a fourth qmd collection), and ADR-0026 (tiered index freshness strategy). Each ADR makes a single architectural commitment; this spec realizes all three by enumerating the per-skill behavioral requirements that the implementation sprint must satisfy.
+
+The current shape of the plugin treats qmd as an optional accelerator. `/sdd:index` (introduced in v4.3.0) creates per-repo collections, but every other read-side skill (`/sdd:prime`, `/sdd:check`, `/sdd:audit`, `/sdd:discover`) still scans the full ADR + spec corpus on every invocation. Authoring skills (`/sdd:adr`, `/sdd:spec`) ask the user to declare frontmatter edges (per the graph from SPEC-0018) without surfacing candidate matches. Sprint skills (`/sdd:plan`, `/sdd:work`, `/sdd:review`) are unaware of existing code patterns and unaware of recent tracker activity beyond what they explicitly query at dispatch time. Each of these is a missed opportunity to leverage hybrid retrieval; collectively they justify the v5.0.0 breaking change.
+
+This spec is the single coordination point between the three ADRs and the implementation sprint that follows. `/sdd:plan SPEC-0019` will break it into ~12-16 stories spanning two new shared references (qmd-helpers, tracker-sync), one foundation story (the issues-collection sync), one migration story (`/sdd:init` enforcement + version bump), and one feature story per refreshed skill.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Make every appropriate read-side skill use hybrid retrieval as the default retrieval primitive — not as a fallback or optional accelerator
+- Make authoring skills (`/sdd:adr`, `/sdd:spec`) suggest frontmatter graph edges (per SPEC-0018) by pre-searching the corpus
+- Make sprint skills (`/sdd:plan`, `/sdd:work`, `/sdd:review`) aware of existing code and existing issues so stories are framed accurately and duplicate-implementation drift is reduced
+- Land the four-tier freshness model (ADR-0026) so the index stays honest without per-call user friction
+- Establish two new shared references (`qmd-helpers.md`, `tracker-sync.md`) that absorb the cross-cutting concerns and prevent each consumer skill from reinventing the patterns
+- Preserve the user-explicit-action invariant: every cross-system mutation still gets either explicit user invocation or AskUserQuestion confirmation. qmd integration changes the *how*, not the consent model
+
+### Non-Goals
+
+- Tier 5 (scheduled background sync) — explicitly out of scope; deferred to v5.1+ after the V1 baseline produces evidence
+- A native qmd MCP for write operations (collection-add, embed, etc.) — that's an upstream qmd feature request, not in this spec
+- Cross-repo semantic queries — siloed per-repo today; future work
+- Modifying the qmd CLI itself — we consume its current API surface
+- Removing the optional fallback paths that previously qmd-aware skills had — there are none; the consumer skills built around qmd availability assumption (per ADR-0024) ship that way from the start in v5.0.0
+
+## Architecture
+
+### High-level dependency layout
+
+```mermaid
+flowchart TB
+  subgraph References [Shared References v5]
+    QmdH[references/qmd-helpers.md<br/>retrieval pattern, MCP-vs-CLI,<br/>error handling, this-repo identification]
+    TrkS[references/tracker-sync.md<br/>per-tracker fetch + normalize<br/>for issues collection]
+    SP[references/shared-patterns.md<br/>existing — referenced by all]
+    IA[references/issue-authoring.md<br/>v4.4.1 — referenced by issue-touching skills]
+  end
+
+  subgraph Foundation [v5 Foundation Stories]
+    Init["/sdd:init<br/>preflight enforces qmd<br/>+ .gitignore .sdd/"]
+    IdxIssues["/sdd:index<br/>issues collection + sync"]
+  end
+
+  subgraph DriftSkills [Refreshed Read-Side Skills]
+    Prime["/sdd:prime<br/>topic-filter via qmd<br/>+ Tier 2 update"]
+    Check["/sdd:check<br/>top-K retrieval<br/>+ Tier 3 staleness"]
+    Audit["/sdd:audit<br/>top-K at scale<br/>+ Tier 3 staleness"]
+    Disc["/sdd:discover<br/>rule out duplicates<br/>via pre-search"]
+  end
+
+  subgraph AuthoringSkills [Refreshed Authoring Skills]
+    Adr["/sdd:adr<br/>pre-search + edge suggestions"]
+    SpecSk["/sdd:spec<br/>pre-search + edge suggestions"]
+  end
+
+  subgraph SprintSkills [Refreshed Sprint Skills]
+    Plan["/sdd:plan<br/>code+issues retrieval<br/>+ Tier 4 issues sync"]
+    Work["/sdd:work<br/>code retrieval per worker<br/>+ Tier 4 issues sync"]
+    Review["/sdd:review<br/>ADR+issues retrieval<br/>+ Tier 4 issues sync"]
+  end
+
+  subgraph MutationSkills [Skills With Tier 1 Updates]
+    Status["/sdd:status<br/>+ Tier 1 update"]
+    Enrich["/sdd:enrich<br/>+ Tier 1 update<br/>+ Tier 4 issues sync"]
+    Org["/sdd:organize<br/>+ Tier 1 update<br/>+ Tier 4 issues sync"]
+  end
+
+  Foundation --> References
+
+  DriftSkills --> QmdH
+  AuthoringSkills --> QmdH
+  SprintSkills --> QmdH
+  SprintSkills --> TrkS
+  MutationSkills --> QmdH
+  MutationSkills --> TrkS
+
+  Adr --> IA
+  SpecSk --> IA
+  Plan --> IA
+  Enrich --> IA
+  Work --> IA
+  Review --> IA
+```
+
+### Cross-cutting components
+
+**`references/qmd-helpers.md`** — the single source of truth for how the plugin talks to qmd. Sections:
+
+- **MCP-vs-CLI** — prefer the qmd MCP `mcp__plugin_qmd_qmd__*` tools when loaded (declarative, no shell invocation cost); fall back to the `qmd` CLI when MCP is not loaded. Both surfaces talk to the same `~/.cache/qmd/index.sqlite`, so swapping is transparent for read operations. Write operations (collection-add, embed, update, context-add) are CLI-only today.
+- **Hybrid Retrieval** — canonical pattern for top-K retrieval: construct a query document with `lex` + `vec` sub-queries, send via MCP `query` tool (or CLI `qmd query --json`), parse the result format, treat results below threshold (~0.3) as non-matches.
+- **This-Repo Collection Identification** — exact-prefix match on collection names. A collection belongs to this repo iff its name equals `{slug}-adrs`, `{slug}-specs`, `{slug}-code`, `{slug}-issues`, OR `{slug}-{module}-{kind}` in workspace mode. Substring match would falsely claim sibling-repo collections.
+- **Error Handling** — qmd timeout (5s default for queries; longer for rerank), qmd-not-running (start daemon if HTTP mode configured; otherwise CLI), no-collections-for-this-repo (route to `/sdd:index`), partial-embedding (degrade to BM25-only with a one-line note).
+- **Update Patterns** — Tier 1 narrow update for mutating skills (per-collection scope where qmd supports it; full update otherwise). Tier 2/3 silent updates with timestamp checks.
+
+**`references/tracker-sync.md`** — the single source of truth for syncing tracker issues into `.sdd/issues/`. Sections:
+
+- **Per-tracker fetch and normalize** — one section per supported tracker (GitHub, Gitea, GitLab, Jira, Linear, Beads, tasks.md). Each section documents the fetch command, incremental cursor mechanism, response shape, and the normalization to the canonical frontmatter schema.
+- **Frontmatter schema** — copy of the schema defined in ADR-0025 sub-decision 2, with field-by-field requirements.
+- **Sync triggering** — when consumer skills should sync (always at entry for sprint skills, with the 5-minute dedup window).
+- **Cursor management** — `.sdd/issues/_meta.json` schema and update protocol.
+- **Failure modes and degradation** — rate-limit handling, retry/backoff, fallback to live tracker queries on persistent failure.
+
+### Per-skill refresh shape
+
+Every refreshed skill follows the same retrofit pattern:
+
+1. **Replace corpus-scanning prelude** — wherever the skill currently does "read every ADR / every spec / every issue", replace with a call into `qmd-helpers.md` § Hybrid Retrieval scoped to the skill's question.
+2. **Add freshness logic** — Tier 2 for `/sdd:prime` only; Tier 3 for `/sdd:check`, `/sdd:audit`, `/sdd:discover`; Tier 4 for sprint skills (always sync issues at entry).
+3. **Add Tier 1 mutation update** — for skills that write artifacts or merge code/issues, append a `qmd update` call (via qmd-helpers patterns) before returning.
+4. **Surface freshness state** — one-line note in the report when the index was refreshed, when chunks remain unembedded, when a sync happened.
+5. **Remove fallback** — the pre-v5 "scan everything" path is removed. If a repo isn't indexed, the skill stops and points to `/sdd:index`.
+
+This pattern is mechanical enough that the per-skill stories from `/sdd:plan SPEC-0019` should be similarly sized (medium, ~250-450 line PR each).
+
+## Key Design Decisions
+
+### Why a single spec rather than per-skill specs
+
+Each refreshed skill is small individually, but the *coordination* between them — sharing the qmd-helpers reference, agreeing on freshness tiers, agreeing on the issues-collection schema — is the load-bearing work. Splitting into per-skill specs would force each spec to re-derive the cross-cutting decisions, leading to drift. One spec per ADR (three specs) was the alternative; rejected because the implementation work crosses ADR boundaries (every refreshed skill consumes all three ADRs' decisions).
+
+### Why qmd-helpers and tracker-sync as references, not as new skills
+
+Skills are agent-invocable behaviors. qmd-helpers and tracker-sync are *patterns* consumed by skills. They have no standalone invocation use case. Treating them as references (the same pattern as `shared-patterns.md`, `issue-authoring.md`) keeps the surface area honest and prevents `/sdd:qmd-query` or `/sdd:tracker-sync` from existing as awkward partial duplicates of `qmd:qmd` (which already exposes the qmd MCP) or `gh issue list`.
+
+### Why the Tier 4 dedup window is 5 minutes (not 1 minute or 30 minutes)
+
+Sprint skills frequently run back-to-back during active development sessions. A 1-minute window would miss the common "I just ran `/sdd:plan`, now I'm running `/sdd:work`" sequence. A 30-minute window would let the issues collection drift uncomfortably during long sprints where issues are actively being closed in the GitHub UI between dispatches. 5 minutes fits the natural cadence of focused work without thrashing the tracker API.
+
+### Why CPU-default-background embeds skip the prompt
+
+Per the user's revised guidance (during the v4.4.0 polish pass): the AskUserQuestion-based three-way prompt was friction every time, and the answer was the same 95% of the time. Hardware detection is reliable; the right answer is implicit in the hardware, so don't ask. The `--foreground` and `--skip` flags handle the long tail.
+
+### Why mutation-aware updates are best-effort, not blocking
+
+A failed Tier 1 update is annoying but does not corrupt the user's actual work — the artifact (ADR, spec, code, issue) is already written/merged at the point the update would run. Blocking on the update would invert the cost: a working write blocked by an index refresh failure. Best-effort + one-line warning is the right trade.
+
+### Why `/sdd:status` updates the affected collection (not the whole index)
+
+`/sdd:status` flips status fields in either YAML frontmatter or inline bullets. The change is small and local. Touching only the affected collection (the one containing the artifact whose status changed) keeps the update cheap. The same logic applies to /sdd:adr / /sdd:spec / /sdd:work — narrow updates over wide ones whenever the change is scoped.
+
+## Migration / Rollout
+
+### v5.0.0 release shape
+
+The v5.0.0 release ships **all** requirements in this spec atomically. We do not stage v5.0.0 → v5.1.0 → v5.2.0 because the qmd-hard-dependency commitment (ADR-0024) requires every consumer skill to be ready to assume qmd availability — partial release would leave some skills in the optional-fallback state and others in the assumed-presence state, which is exactly the dual-path complexity ADR-0024 was meant to eliminate.
+
+### Upgrade path for existing v4.x users
+
+1. User installs `sdd@claude-plugin-sdd` v5.0.0 via `/plugin install` or `/plugin update`
+2. On their next `/sdd:init` invocation (in any project), the qmd preflight runs
+3. If qmd is missing, init refuses with the install command
+4. User runs `npm install -g @tobilu/qmd` (one-time, machine-global)
+5. User re-runs `/sdd:init`; preflight passes; init writes / updates CLAUDE.md and `.gitignore`
+6. User runs `/sdd:index` to populate the per-repo collections (one-time per repo; `qmd embed` runs in background on CPU machines)
+7. From this point forward, every refreshed skill works as designed
+
+The "manual install qmd once" cost is paid once per machine, not per project. The "manual run /sdd:index once" cost is paid once per project.
+
+### Backwards incompatibilities
+
+- `/sdd:init` will refuse on machines without qmd — breaking change for users who don't intend to install qmd. The CHANGELOG must call this out prominently.
+- The pre-v5 "scan everything" path in `/sdd:check`, `/sdd:audit`, `/sdd:discover` is removed. Users who liked the verbose-everything mode no longer have it; they must rely on qmd's hybrid retrieval (which is strictly better on relevance, but different on output volume).
+- `.sdd/` directory introduced in user repos. The `/sdd:init` change adds it to `.gitignore` to prevent the local cache from being committed.
+
+### Telemetry / verification
+
+After v5.0.0 ships, the plugin's CI eval suite (per ADR-0021 / SPEC-0017) gains coverage for:
+
+- Each refreshed skill's qmd-driven behavior (top-K retrieval returns the expected candidates for synthetic queries)
+- The freshness tier logic (mock the qmd index timestamp; verify the right tier triggers)
+- The CPU-default-background embed flow (mock `qmd status` to report no GPU; assert background mode)
+
+The eval framework already exercises individual skills; the new evals integrate qmd as a fixture.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Users on bandwidth-constrained networks balk at the ~2GB GGUF model download on first embed | CHANGELOG documents the size; `/sdd:init` final report previews the cost; `/sdd:index embed` is the explicit trigger |
+| Users without GPU experience slow embeds | CPU-default-background mode (per the embed policy) keeps the session unblocked; HTTP daemon mode (qmd's feature) keeps models warm across queries; `/tmp/qmd-embed-{repo}.log` lets users inspect progress |
+| Issues sync rate-limits user's GitHub account during heavy sprint work | Tier 4 dedup window prevents redundant syncs; backoff retries on 429; fallback to live tracker queries on persistent failure |
+| Users who liked seeing the full corpus output from `/sdd:prime` find the new top-K mode less helpful | `/sdd:prime` with no topic argument retains the full overview; only the topic-filtered mode uses qmd retrieval |
+| qmd CLI changes its output format and breaks the qmd-helpers parsers | Pin to a tested qmd version range in the install instructions; integration tests against the pinned version; document the supported range in qmd-helpers.md |
+| Cross-repo semantic queries arrive on user wishlists before they're scoped | Out of Scope section makes the deferral explicit; add to the v5.1 wishlist once V1 ships |
+| Workspace mode (per ADR-0016) interacts unexpectedly with the new collections | Issues collection in workspace mode follows the existing per-module naming pattern (`{repo}-{module}-issues`); tracker-sync layer scopes to the module's tracker config; tested via the existing workspace fixture in the eval suite |
+
+## Open Questions
+
+These do not block this spec but should be tracked for follow-up specs or ADRs:
+
+1. **Should `/sdd:graph` ingest the issues collection's `references` block to extend the artifact graph beyond ADRs and specs?** The synced issue files have a `references` block listing `SPEC-XXXX` and `ADR-XXXX` mentions. ADR-0023 / SPEC-0018 currently cover only ADR-to-ADR and spec-to-ADR edges. Adding issue → spec edges would extend impact analysis to "which open issues touch SPEC-X". Deferred — needs its own spec to define the edge schema and semantics.
+2. **Should the staleness threshold be auto-tuned per consumer skill?** A drift-detection skill (`/sdd:check`) probably wants tighter freshness than a stable-context skill (`/sdd:prime`). Currently one global threshold. Auto-tuning would require telemetry; revisit after V1 ships.
+3. **Should qmd-helpers.md include rate-limiting on retrievals?** A pathological case: an agent in a tight loop calls `qmd query` 100 times in a row. Currently no throttle. Probably fine because the qmd reranker is the bottleneck (multi-second per call on CPU); revisit if telemetry shows otherwise.
+4. **Should `/sdd:init` offer to start the qmd HTTP daemon for CPU users?** The HTTP daemon (`qmd mcp --http --daemon`) keeps models loaded across requests, dramatically improving CPU-only performance. Currently `/sdd:init` just verifies qmd is installed; it doesn't start the daemon. Adding daemon-start to init would be a UX win on CPU machines but adds a long-running process under init's responsibility. Revisit after V1 produces real CPU-user feedback.
+
+## More Information
+
+- ADR-0024 (qmd as hard dependency) — the dependency commitment this spec realizes
+- ADR-0025 (tracker issues as fourth qmd collection) — the issues-collection design this spec realizes
+- ADR-0026 (tiered index freshness strategy) — the freshness model this spec realizes
+- ADR-0023 / SPEC-0018 (frontmatter DAG and `/sdd:graph`) — the graph layer the authoring-skill edge suggestions populate
+- ADR-0017 / SPEC-0015 (parallel agent coordination) — the worker / sibling-PR awareness logic that `/sdd:work`'s qmd-smartness extends
+- `references/issue-authoring.md` (v4.4.1) — the issue-body conventions consumed by all issue-touching skills, including the new sprint-skill behaviors
+- `references/shared-patterns.md` — the existing umbrella reference; this spec's two new references (qmd-helpers, tracker-sync) sit alongside it

--- a/docs/openspec/specs/qmd-native-skills/spec.md
+++ b/docs/openspec/specs/qmd-native-skills/spec.md
@@ -1,0 +1,366 @@
+---
+status: draft
+date: 2026-05-03
+implements: [ADR-0024, ADR-0025, ADR-0026]
+requires: [SPEC-0014, SPEC-0018]
+---
+
+# SPEC-0019: qmd-Native Skills
+
+## Overview
+
+Realizes the v5.0.0 architecture (ADR-0024 hard qmd dependency, ADR-0025 tracker issues as a fourth qmd collection, ADR-0026 tiered freshness strategy) by making every appropriate SDD plugin skill qmd-aware. The plugin moves from "every read-side skill scans the entire ADR + spec corpus" to "every read-side skill retrieves the top-K relevant artifacts via qmd hybrid search, then reads in full only what matters." Authoring skills (`/sdd:adr`, `/sdd:spec`) gain pre-search to suggest frontmatter edges. Sprint skills (`/sdd:plan`, `/sdd:work`, `/sdd:review`) gain awareness of existing code and existing tracker issues. Mutation-aware updates and a per-tier freshness model keep the index honest without per-call user friction.
+
+This spec is the input to the v5.0.0 sprint. It defines what must be true after the implementation lands; per-skill exact algorithms live in updated SKILL.md files. Two new shared references absorb the cross-cutting concerns: `references/qmd-helpers.md` (retrieval pattern, MCP-vs-CLI, error handling) and `references/tracker-sync.md` (per-tracker fetch and normalize for the issues collection).
+
+## Requirements
+
+### Requirement: qmd Preflight Enforcement
+
+`/sdd:init` MUST refuse to operate when the `qmd` CLI is not available in `PATH`. The check happens before any CLAUDE.md write or skills-table convergence. Error output MUST include the install command (`npm install -g @tobilu/qmd` or `bun install -g @tobilu/qmd`) and a link to qmd's repository.
+
+#### Scenario: qmd missing on a fresh machine
+
+- WHEN the user runs `/sdd:init` and `command -v qmd` returns non-zero
+- THEN `/sdd:init` MUST output the canonical error message naming the install command and stop without modifying CLAUDE.md, `.gitignore`, or any other file
+- AND the exit signal MUST be visible enough that downstream tooling (CI, install scripts) can detect the missing dependency
+
+#### Scenario: qmd present but not yet authenticated to a model registry
+
+- WHEN the user runs `/sdd:init` and `command -v qmd` succeeds but `qmd status` reports the GGUF models are not yet downloaded
+- THEN `/sdd:init` MUST proceed (model download is qmd's responsibility on first embed, not an init prerequisite)
+- AND `/sdd:init`'s final report SHOULD note that the first `/sdd:index embed` will trigger a one-time ~2GB model download
+
+#### Scenario: re-running `/sdd:init` after a successful install
+
+- WHEN the user has already run `/sdd:init` successfully and re-runs it
+- THEN the qmd preflight passes (idempotent)
+- AND no spurious changes are introduced to CLAUDE.md or `.gitignore`
+
+### Requirement: qmd Assumption in Consumer Skills
+
+Every qmd-aware skill MAY assume qmd is installed and reachable on `PATH` (because `/sdd:init` enforced it per the Preflight requirement) and MUST NOT include conditional fallback paths gated on qmd availability. If a skill needs to handle "qmd installed but this repo not yet indexed", it MUST route to `/sdd:index` rather than silently degrading.
+
+#### Scenario: a consumer skill encounters an unindexed repo
+
+- WHEN `/sdd:check` runs in a repo where `qmd collection list` shows no `{repo}-*` collections
+- THEN the skill MUST output: "No qmd collections found for {repo}. Run `/sdd:index` first." and stop
+- AND MUST NOT fall back to the pre-v5 "scan the entire corpus" behavior
+
+#### Scenario: a consumer skill encounters a partially indexed repo (missing embeddings)
+
+- WHEN `/sdd:check` runs in a repo where collections exist but `qmd status` shows pending chunks for those collections
+- THEN the skill MUST proceed using BM25-only retrieval (qmd handles this gracefully by returning lex matches when vectors are missing)
+- AND MUST surface a one-line note: "{N} chunks unembedded — vector/hybrid search disabled until `/sdd:index embed` runs"
+
+### Requirement: Plugin Version Bump to v5.0.0
+
+The release that lands all requirements in this spec MUST bump `.claude-plugin/plugin.json` `version` from the current 4.x line to **5.0.0**. The CHANGELOG MUST document the qmd dependency under "Breaking Changes" with the install command.
+
+#### Scenario: v5.0.0 install on a machine without qmd
+
+- WHEN a user installs `sdd@claude-plugin-sdd` v5.0.0 and runs `/sdd:init` without qmd installed
+- THEN `/sdd:init` MUST emit the install command and stop, per the Preflight requirement
+- AND the failure mode MUST be obvious enough that a user upgrading from v4.x understands they have new install work
+
+### Requirement: Issues Collection Layout
+
+The plugin MUST sync tracker issues to `.sdd/issues/{number}.md` (or `.sdd/issues/{tracker-id}.md` for trackers using non-numeric IDs like Jira `PROJ-123`). Each synced file MUST carry the canonical frontmatter schema and the issue body verbatim. Synced files MUST be under `.sdd/issues/`, never directly under `.sdd/` or elsewhere.
+
+The frontmatter schema MUST include: `id`, `title`, `status` (normalized: `open` / `closed` / `merged` / `draft`), `labels`, `assignees`, `author`, `created`, `updated`, `closed`, `url`, `tracker`, and a `references` block parsing `SPEC-XXXX` and `ADR-XXXX` mentions plus `Blocks:` / `Blocked by:` dependency edges from the issue body.
+
+#### Scenario: syncing a GitHub issue with full metadata
+
+- WHEN `/sdd:index update` runs against a repo configured for GitHub and an issue exists at `https://github.com/owner/repo/issues/142` with title, body, labels, assignees, and timestamps
+- THEN a file `.sdd/issues/142.md` MUST be written with the canonical frontmatter populated from the GitHub API response
+- AND the body MUST be the verbatim issue body
+- AND the `tracker` frontmatter field MUST equal `github`
+
+#### Scenario: syncing a Jira issue with composite ID
+
+- WHEN `/sdd:index update` runs against a repo configured for Jira and an issue exists with key `PROJ-123`
+- THEN a file `.sdd/issues/PROJ-123.md` MUST be written (preserving the dash in the filename)
+- AND the `id` frontmatter field MUST equal `PROJ-123`
+
+#### Scenario: re-syncing an issue whose body changed
+
+- WHEN `/sdd:index update` runs and an issue's body has changed since the last sync
+- THEN the existing `.sdd/issues/{id}.md` MUST be overwritten with the current body and updated `updated` timestamp
+- AND no merge or diff MUST be attempted (the tracker is the source of truth; the local cache is replaceable)
+
+### Requirement: Tracker Sync Layer
+
+The per-tracker fetch and normalize logic MUST live in a single `references/tracker-sync.md` reference file. Consumer skills (`/sdd:index`, `/sdd:plan`, `/sdd:work`, `/sdd:review`, `/sdd:enrich`, `/sdd:organize`) MUST consume it by section name and MUST NOT inline tracker-specific API calls in their own SKILL.md files. The reference MUST cover all seven supported trackers: GitHub, Gitea, GitLab, Jira, Linear, Beads, and `tasks.md` fallback.
+
+#### Scenario: a new tracker is added in the future
+
+- WHEN a new tracker (e.g., `Bitbucket`) is added to the supported set
+- THEN the only file requiring substantive edits MUST be `references/tracker-sync.md` (plus minimal entries in `references/shared-patterns.md` § Tracker Detection)
+- AND no consumer skill SKILL.md MUST need to learn the new tracker's API shape
+
+#### Scenario: a tracker API rate-limits or returns an error during sync
+
+- WHEN the tracker-sync layer encounters a 429 or 5xx response
+- THEN it MUST retry with exponential backoff up to 3 times before reporting a sync failure
+- AND a sync failure MUST surface a clear error to the consumer skill that triggered it, not a silent partial sync
+
+### Requirement: Issues Collection Sync via /sdd:index
+
+`/sdd:index update` MUST sync the `{repo}-issues` (or `{repo}-{module}-issues` in workspace mode) collection as part of its normal pass. Consumer skills (`/sdd:plan`, `/sdd:work`, `/sdd:review`, `/sdd:enrich`, `/sdd:organize`) MUST trigger an opportunistic sync at start-of-run if the issues collection has not been synced within the last 5 minutes.
+
+#### Scenario: /sdd:plan starts after an idle session
+
+- WHEN `/sdd:plan SPEC-0019` runs and the last issues sync was >5 minutes ago
+- THEN the skill MUST trigger an issues-only sync via the tracker-sync layer before grouping requirements into stories
+- AND MUST output a one-line note: "Syncing N issues from {tracker}…"
+
+#### Scenario: /sdd:work starts immediately after /sdd:plan
+
+- WHEN `/sdd:work` runs within 5 minutes of a `/sdd:plan` invocation that already synced issues
+- THEN the skill MUST skip the redundant sync and proceed
+- AND MUST silently note (in trace output, not user-facing) that the sync was skipped due to recency
+
+### Requirement: .sdd Gitignore Enforcement
+
+`/sdd:init` MUST add `.sdd/` to the project's `.gitignore` (creating `.gitignore` if absent). The entry MUST be appended exactly once; running `/sdd:init` repeatedly MUST NOT produce duplicate `.sdd/` lines. Other entries in `.gitignore` MUST be preserved exactly.
+
+#### Scenario: fresh project with no .gitignore
+
+- WHEN `/sdd:init` runs in a project that has no `.gitignore`
+- THEN `/sdd:init` MUST create `.gitignore` containing `.sdd/`
+- AND MUST NOT create or modify any other entry
+
+#### Scenario: project with existing .gitignore that includes .sdd/
+
+- WHEN `/sdd:init` runs and `.gitignore` already contains `.sdd/` (anywhere in the file)
+- THEN `/sdd:init` MUST leave the file unchanged
+- AND MUST NOT append a duplicate
+
+#### Scenario: project with .gitignore that does NOT include .sdd/
+
+- WHEN `/sdd:init` runs and `.gitignore` exists but does not contain `.sdd/`
+- THEN `/sdd:init` MUST append `.sdd/` to the end of the file (preceded by a single newline if the file does not end with one)
+- AND all existing entries MUST remain in their original positions
+
+### Requirement: qmd-helpers Reference
+
+The plugin MUST provide a `references/qmd-helpers.md` shared reference covering: how to call qmd (prefer the qmd MCP `mcp__plugin_qmd_qmd__*` tools when loaded; fall back to the `qmd` CLI otherwise), how to format result candidates for downstream consumption, how to handle qmd errors (timeout, no-collections, partial-embedding), and how skills should detect "this repo's collections" via exact-prefix match on collection names. Every qmd-aware consumer skill MUST consume this reference by section name.
+
+#### Scenario: a skill needs to retrieve top-K candidates
+
+- WHEN `/sdd:check` needs to find the ADRs and specs governing a target file
+- THEN the skill MUST use the canonical retrieval pattern from `references/qmd-helpers.md` § Hybrid Retrieval
+- AND MUST NOT inline its own qmd CLI invocation
+
+#### Scenario: a skill needs to identify this-repo collections
+
+- WHEN any skill needs to filter to "collections belonging to this repo"
+- THEN the skill MUST use the exact-prefix match pattern documented in `references/qmd-helpers.md` § This-Repo Collection Identification
+- AND MUST NOT use substring match (which would spuriously claim e.g., `not-myrepo-adrs` for slug `myrepo`)
+
+### Requirement: Tier 1 Mutation-Aware Updates
+
+Every skill that writes to indexed content MUST trigger a narrow `qmd update` for the affected collection(s) before returning. The update is synchronous and silent unless it fails. Failures MUST surface as a one-line warning in the skill's normal report output.
+
+| Skill | Writes to | Affected collection |
+|-------|-----------|---------------------|
+| `/sdd:adr` | new ADR file | `{repo}-adrs` |
+| `/sdd:spec` | new spec.md / design.md | `{repo}-specs` |
+| `/sdd:status` | YAML or inline status field | The collection containing the artifact whose status changed |
+| `/sdd:work` | merged PR (changed code) | `{repo}-code` |
+| `/sdd:plan`, `/sdd:enrich`, `/sdd:organize` | tracker issues | `{repo}-issues` |
+| `/sdd:review` | merged PR (changed code AND closed issues) | `{repo}-code` AND `{repo}-issues` |
+
+#### Scenario: /sdd:adr finishes writing a new ADR
+
+- WHEN `/sdd:adr` completes and writes `docs/adrs/ADR-NNNN-foo.md`
+- THEN before returning, the skill MUST invoke the canonical update pattern from `references/qmd-helpers.md` to refresh the `{repo}-adrs` collection
+- AND the skill's success report MUST not mention the update (silent on success)
+
+#### Scenario: a Tier 1 update fails
+
+- WHEN `/sdd:adr` finishes writing the file but the qmd update fails (e.g., qmd daemon crashed)
+- THEN the skill's report MUST include a one-line warning: "Index refresh failed for {repo}-adrs — run `/sdd:index update` manually"
+- AND the artifact MUST still be reported as successfully written (the update is best-effort, not blocking)
+
+### Requirement: Tier 2 Session-Start Update via /sdd:prime
+
+`/sdd:prime` MUST run `qmd update` (cheap file-mtime scan) on entry to catch changes from outside the current session. The update MUST be skipped when the qmd index was touched within the last 60 seconds (back-to-back primes are common). The update MUST be silent on success unless the diff is non-zero. After the update, `/sdd:prime` MUST surface the count of unembedded chunks for this repo's collections via a one-line note (no AskUserQuestion).
+
+#### Scenario: /sdd:prime runs at the start of a fresh session
+
+- WHEN `/sdd:prime` runs and the qmd index was last touched >60s ago
+- THEN the skill MUST invoke `qmd update` silently
+- AND MUST print a one-line note in the report header IF the update added/modified/removed any documents (otherwise omit the line entirely)
+
+#### Scenario: /sdd:prime runs back-to-back
+
+- WHEN `/sdd:prime` runs and the qmd index was last touched <60s ago
+- THEN the skill MUST skip the update
+- AND MUST NOT emit any update-related output
+
+#### Scenario: /sdd:prime sees unembedded chunks for this repo
+
+- WHEN `/sdd:prime` finishes loading context and `qmd status` reports unembedded chunks belonging to this repo's collections
+- THEN the report MUST surface a one-line note: "{N} chunks unembedded — run `/sdd:index embed` (≈{seconds}s on this machine, foreground; or wait for the next mutation skill to backfill)"
+- AND MUST NOT prompt the user via AskUserQuestion
+
+### Requirement: Tier 3 Staleness Threshold for Consumer Skills
+
+Read-only consumer skills (`/sdd:check`, `/sdd:audit`, `/sdd:discover`) MUST check the qmd index's last-modified timestamp on entry. If older than the configured staleness threshold, the skill MUST run a silent `qmd update` first and print a one-line note: "Index was {age} stale — refreshed before running."
+
+The threshold default MUST be **120 minutes** (2 hours), configurable in CLAUDE.md `### SDD Configuration` `#### Index Freshness` `**Staleness Threshold**` (e.g., `30m`, `4h`).
+
+#### Scenario: /sdd:check runs after a long idle period
+
+- WHEN `/sdd:check` runs and the qmd index's last-modified timestamp is >120 minutes ago
+- THEN the skill MUST trigger `qmd update` silently before performing retrieval
+- AND MUST emit the staleness note in its report header
+
+#### Scenario: user has configured a shorter threshold
+
+- WHEN CLAUDE.md `### SDD Configuration` `#### Index Freshness` `**Staleness Threshold**` is `30m` and `/sdd:check` runs 31 minutes after the last update
+- THEN the skill MUST honor the configured threshold and trigger the update
+
+#### Scenario: index is fresh
+
+- WHEN `/sdd:check` runs and the qmd index was updated within the configured threshold
+- THEN the skill MUST NOT trigger an update
+- AND MUST proceed silently (no staleness note in the report)
+
+### Requirement: Tier 4 Always-Sync Issues for Sprint Skills
+
+`/sdd:plan`, `/sdd:work`, `/sdd:review`, `/sdd:enrich`, and `/sdd:organize` MUST sync the issues collection on entry, regardless of staleness threshold, subject to the 5-minute deduplication window from the Issues Collection Sync requirement.
+
+#### Scenario: /sdd:work runs after a teammate closes an issue in the browser
+
+- WHEN `/sdd:work` runs and an issue was closed in the GitHub UI 30 seconds before
+- THEN the issues sync MUST run (assuming the >5min dedup window has elapsed since the last sync, which it has not in this case — but if it had been >5min)
+- AND the closed issue MUST appear with `status: closed` in `.sdd/issues/{N}.md` after the sync
+
+#### Scenario: a Tier 4 sync fails mid-sprint
+
+- WHEN the issues sync fails for `/sdd:plan` (e.g., GitHub rate limit)
+- THEN the skill MUST fall back to live tracker queries (the pre-qmd path) for issue context within this run
+- AND MUST emit a one-line warning: "Issues sync failed — degrading to live tracker queries for this run"
+- AND MUST NOT block on the failure
+
+### Requirement: CPU-Default-Background Embed Policy
+
+`/sdd:index embed` (and any internal qmd-embed call from another skill) MUST detect GPU availability via `qmd status` and apply this policy:
+
+- GPU present → run synchronously (foreground)
+- CPU only → run as a backgrounded Bash command, log to `/tmp/qmd-embed-{repo}.log`, return the report immediately
+
+The skill MUST accept `--foreground` and `--skip` flags as overrides. The skill MUST NOT prompt the user via AskUserQuestion to choose between modes — the hardware-aware default is the right behavior.
+
+#### Scenario: CPU-only embed defaults to background
+
+- WHEN `/sdd:index embed` runs on a machine where `qmd status` reports "running on CPU"
+- THEN the embed command MUST be launched in the background with stdout/stderr redirected to `/tmp/qmd-embed-{repo}.log`
+- AND the report MUST surface the log path and indicate that completion will be signaled by the harness's background-task notification
+
+#### Scenario: GPU present runs synchronously
+
+- WHEN `/sdd:index embed` runs on a GPU-enabled machine
+- THEN the embed MUST run synchronously
+- AND the report MUST include the embedded chunk count and elapsed time
+
+#### Scenario: explicit foreground override on CPU machine
+
+- WHEN `/sdd:index embed --foreground` runs on a CPU-only machine
+- THEN the skill MUST honor the override and run synchronously
+- AND MUST NOT background despite the CPU detection
+
+### Requirement: qmd-Smart Drift Skills
+
+`/sdd:check`, `/sdd:audit`, and `/sdd:discover` MUST use qmd hybrid retrieval to identify the top-K candidate ADRs, specs, and (for /sdd:discover) existing decisions before reading any artifact in full. The pre-v5 "read the entire corpus" path MUST be removed from these skills (it remains in older plugin versions, not in v5.0.0+).
+
+For `/sdd:check {target}` and `/sdd:audit {target}`, the retrieval query MUST be derived from the target's content (file path, governing comment block, code summary). For `/sdd:discover`, the retrieval query MUST be the candidate decision the agent is about to suggest, used to rule out duplicates.
+
+#### Scenario: /sdd:check identifies governing artifacts via qmd
+
+- WHEN `/sdd:check src/auth/login.go` runs
+- THEN the skill MUST construct a hybrid query from the file's path, the governing comment block (if present), and a summary of the file's exported symbols
+- AND MUST retrieve the top-8 candidates from `{repo}-adrs` and `{repo}-specs` via qmd
+- AND MUST read those candidates in full before evaluating drift
+
+#### Scenario: /sdd:discover rules out duplicate decisions
+
+- WHEN `/sdd:discover` is about to suggest "Use JWT for session tokens" as an implicit decision
+- THEN the skill MUST first run a qmd query against `{repo}-adrs` for that suggestion
+- AND IF a top result has cosine similarity ≥0.7 to the suggestion, the skill MUST NOT include the suggestion (an ADR likely already covers it)
+- AND MUST log the suppressed suggestion + the matched ADR in the report's "Skipped" section
+
+### Requirement: qmd-Smart Authoring Skills
+
+`/sdd:adr` and `/sdd:spec` MUST pre-search the corresponding collection before writing the new artifact. The search query MUST be the user's description (from `$ARGUMENTS`) plus any context the agent has gathered. Top-K results MUST be surfaced to the user via AskUserQuestion as candidate frontmatter edges (`supersedes`, `extends`, `related` for ADRs; `requires`, `extends` for specs).
+
+#### Scenario: /sdd:adr finds a related prior decision
+
+- WHEN `/sdd:adr "Switch from REST to gRPC"` runs and the corpus contains ADR-0008 ("Use REST for the API")
+- THEN the skill MUST surface ADR-0008 to the user via AskUserQuestion
+- AND MUST offer "supersedes ADR-0008" as one of the candidate edges to include in the new ADR's frontmatter
+- AND the user MUST be able to accept, reject, or modify each suggested edge
+
+#### Scenario: /sdd:spec finds a prerequisite spec
+
+- WHEN `/sdd:spec "Authentication"` runs and the corpus contains SPEC-0014 ("Token Validation")
+- THEN the skill MUST surface SPEC-0014 to the user via AskUserQuestion
+- AND MUST offer "requires SPEC-0014" as a candidate edge
+
+#### Scenario: pre-search returns nothing relevant
+
+- WHEN `/sdd:adr "Pick a CSV parsing library"` runs and qmd returns no results above the relevance threshold
+- THEN the skill MUST proceed without surfacing edge suggestions
+- AND MUST emit a one-line note: "No related artifacts found — drafting from scratch"
+
+### Requirement: qmd-Smart Sprint Skills
+
+`/sdd:plan`, `/sdd:work`, and `/sdd:review` MUST use qmd retrieval to inform their sprint-level decisions:
+
+- `/sdd:plan` MUST search `{repo}-code` and `{repo}-issues` to size and frame stories accurately. Stories that touch existing code MUST be framed as "extend X in path/to/file" rather than "implement from scratch".
+- `/sdd:work` workers MUST search `{repo}-code` for existing patterns (helpers, conventions, sibling implementations) before writing new code. This mitigates the duplicate-implementation drift the Foundation Story Detection pattern (per ADR-0017) was designed to catch.
+- `/sdd:review` reviewers MUST search `{repo}-adrs` and `{repo}-issues` to identify ADRs the PR should reference and prior issues the PR touches.
+
+#### Scenario: /sdd:plan recognizes existing code that solves part of a story
+
+- WHEN `/sdd:plan SPEC-0019` runs and one requirement involves "user session management" while `{repo}-code` already contains a `internal/session/store.go` with relevant functions
+- THEN the corresponding story body MUST reference the existing file ("extend `internal/session/store.go`")
+- AND MUST size the story accordingly (smaller than greenfield)
+
+#### Scenario: /sdd:work avoids re-creating an existing helper
+
+- WHEN a `/sdd:work` worker is about to write a `parseUserID` helper and qmd retrieval surfaces an existing `internal/auth/parse.go:parseUserID` in `{repo}-code`
+- THEN the worker MUST import the existing helper rather than create a duplicate
+- AND MUST broadcast `TYPE_IMPORTED` per ADR-0017's Worker Communication Protocol
+
+#### Scenario: /sdd:review surfaces a missing ADR reference
+
+- WHEN `/sdd:review` is reviewing a PR that modifies authentication code and qmd retrieval against `{repo}-adrs` returns ADR-0011 (which governs auth) but the PR does not reference ADR-0011 in its body or governing comments
+- THEN the reviewer MUST raise this as a finding ("Should this PR reference ADR-0011?")
+- AND MUST cite the relevant ADR section that suggests the connection
+
+### Requirement: qmd-Smart Context Loading
+
+`/sdd:prime {topic}` MUST use qmd hybrid retrieval to identify the top-K most relevant ADRs and specs to the topic, then read those in full and present them. This replaces the pre-v5 "read every ADR + every spec, then filter" path. Untargeted `/sdd:prime` (no topic) MUST still load all artifacts, since the user has explicitly asked for a corpus overview.
+
+#### Scenario: /sdd:prime with a topic argument
+
+- WHEN `/sdd:prime auth` runs against a corpus of 23 ADRs and 18 specs
+- THEN the skill MUST construct a qmd query from the topic and retrieve the top-K candidates from `{repo}-adrs` and `{repo}-specs`
+- AND MUST read only those candidates in full before producing the prime report
+- AND MUST NOT read every artifact in the corpus
+
+#### Scenario: /sdd:prime with no topic
+
+- WHEN `/sdd:prime` runs with no topic argument
+- THEN the skill MUST behave as today: load all ADR / spec metadata for the overview table
+- AND MUST NOT use qmd retrieval (no topic = no query to construct)
+
+## Out of Scope (deferred to future specs)
+
+- Tier 5 scheduled background sync (per ADR-0026 § "Tier 5") — deferred to v5.1 or later, after V1 ships and produces evidence about long-tail staleness cases
+- A native qmd MCP extension exposing collection-add / context-add / update / embed as MCP tools — would let `/sdd:index` operate via MCP only and remove the CLI dependency. Tracked as an upstream qmd feature request.
+- Cross-repo semantic queries — currently each repo's collections are siloed. A future spec might define a "this repo + my other indexed repos" mode for `/sdd:check` and similar.
+- Issue-level frontmatter graph integration — the `references` block in synced issue files lists `SPEC-XXXX` and `ADR-XXXX` mentions, but these are NOT yet consumed by `/sdd:graph`. Integrating issues into the artifact graph (so an issue can be a node) is a separate spec.


### PR DESCRIPTION
## Summary

SPEC-0019 — the qmd-native-skills spec. Realizes the three v5 ADRs (0024 hard qmd dep, 0025 issues collection, 0026 freshness) by enumerating per-skill behavioral requirements. Input to the v5.0.0 sprint that follows.

- **17 requirements** spanning hard-dependency enforcement, issues-collection layout/sync, qmd-helpers reference, four freshness tiers, embed policy, and per-skill smartness (drift / authoring / sprint).
- **41 WHEN/THEN scenarios** — every requirement has 2-3 scenarios covering the happy path, the failure mode, and an edge case.
- **Two new shared references** scoped: `references/qmd-helpers.md` (retrieval pattern, MCP-vs-CLI, error handling, this-repo identification, update patterns) and `references/tracker-sync.md` (per-tracker fetch/normalize for the issues collection).

## Why this is a single spec, not three

Each ADR makes a single architectural commitment but the implementation work crosses ADR boundaries — every refreshed skill consumes decisions from all three ADRs. Splitting into per-ADR specs would force each spec to re-derive the cross-cutting decisions and create drift. One spec keeps the coordination point honest.

## Scope of the v5.0.0 sprint that this spec inputs

`/sdd:plan SPEC-0019` will produce ~12-16 stories. Anticipated decomposition:

**Foundation (merge first):**
- `references/qmd-helpers.md`
- `references/tracker-sync.md`
- `/sdd:index` issues-collection support (new `{repo}-issues` collection + sync layer wiring)

**Migration (also early):**
- `/sdd:init` preflight + .gitignore + version bump to v5.0.0

**Per-refreshed-skill stories (parallelizable after foundations):**
- `/sdd:prime` Tier 2 + topic-filter via qmd
- `/sdd:check` Tier 3 + top-K retrieval
- `/sdd:audit` Tier 3 + top-K retrieval at scale
- `/sdd:discover` rule-out-duplicates pre-search
- `/sdd:adr` and `/sdd:spec` pre-search + edge-suggestions (could be one bundled story since they share the pattern)
- `/sdd:plan` Tier 4 + code+issues retrieval for story sizing
- `/sdd:work` Tier 4 + code retrieval per worker
- `/sdd:review` Tier 4 + ADR+issues retrieval for missing references
- `/sdd:status`, `/sdd:enrich`, `/sdd:organize` Tier 1 mutation updates

## Files changed

- `docs/openspec/specs/qmd-native-skills/spec.md` — new (366 lines, 17 REQs)
- `docs/openspec/specs/qmd-native-skills/design.md` — new (208 lines)

Status: `draft`. Marked `accepted` after the v5.0.0 sprint lands.

## Test plan

- [ ] `/sdd:graph validate` should accept the new `implements: [ADR-0024, ADR-0025, ADR-0026]` and `requires: [SPEC-0014, SPEC-0018]` frontmatter without errors.
- [ ] `/sdd:graph` should derive the inverse edges: ADR-0024/0025/0026 each get `governed-by: [SPEC-0019]`; SPEC-0014 and SPEC-0018 each get `depended-on-by: [SPEC-0019]`.
- [ ] Re-run `/sdd:list spec` and verify SPEC-0019 appears with status `draft` (testing the v4.4.1 status parser handles draft-status YAML).
- [ ] Re-run `/sdd:prime` and verify the spec table includes SPEC-0019 with the correct requirement and scenario counts (17 / 41).

## Adversarial review checklist

- [ ] **Requirement granularity** — 17 requirements with 41 scenarios is at the high end. Are any requirements decomposable into smaller units that would parallelize better in `/sdd:plan`? My judgment: keep as-is. Smaller requirements would just mean more stories with thinner acceptance criteria. The current shape supports the planned ~12-16 story breakdown without forcing 17+ tiny PRs.
- [ ] **Tier 4 dedup window of 5 minutes** — design.md justifies as fitting natural sprint cadence. Reviewer: any reason this should be configurable (alongside the 120m staleness threshold)? My lean: leave hardcoded for V1; if real workflows surface a misfit, expose as `### Index Freshness` `**Issues Sync Dedup Window**` in v5.x.
- [ ] **Tier 1 best-effort updates** — design.md argues these should not block when they fail. Reviewer: any failure mode where best-effort silently corrupts the index? Counter-argument: a failed update means the index is stale until the next mutation or Tier 2/3 trigger; user-visible damage is minimal because the artifact itself is correctly written. Conclusion: best-effort is the right call.
- [ ] **Removal of pre-v5 corpus-scan fallback in /sdd:check / /sdd:audit / /sdd:discover** — this is the spec's most aggressive simplification. Reviewer: are there any user workflows that genuinely need the full-corpus behavior? Counter: `/sdd:audit` with `--full` flag could optionally bypass qmd and scan everything. Out of scope for this spec; could ship as a v5.1 follow-up if real demand surfaces.
- [ ] **CHANGELOG promise** — Migration / Rollout section commits to documenting the qmd dependency under "Breaking Changes" with the install command. Verify the CHANGELOG actually exists and has a v5.0.0 entry by the end of the sprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)