### PR TITLE
feat(index): add {repo}-issues collection sourced from .sdd/issues/ tracker sync

### DIFF
--- a/skills/index/SKILL.md
+++ b/skills/index/SKILL.md
@@ -5,11 +5,11 @@ allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
 argument-hint: [add|update|embed|status|remove] [--module <name>] [--foreground|--skip]
 ---
 
-<!-- Governing: ADR-0015 (Markdown-Native Configuration), ADR-0016 (Workspace Mode), ADR-0024 (qmd hard dependency), ADR-0026 (Tiered Index Freshness) -->
+<!-- Governing: ADR-0015 (Markdown-Native Configuration), ADR-0016 (Workspace Mode), ADR-0024 (qmd hard dependency), ADR-0025 (Tracker Issues as Fourth qmd Collection), ADR-0026 (Tiered Index Freshness), SPEC-0019 REQ "Issues Collection Layout", SPEC-0019 REQ "Issues Collection Sync via /sdd:index" -->
 
 # Index Repository into QMD
 
-Create per-repository [qmd](https://github.com/tobi/qmd) collections so agents and humans can run hybrid search across a repo's ADRs, OpenSpec specs, and source code from a single query plane. Each repository owns three collections (`{repo}-adrs`, `{repo}-specs`, `{repo}-code`) so searches can be filtered cleanly with `qmd query "..." -c {repo}-adrs`. Workspace projects (ADR-0016) get one set of collections per module: `{repo}-{module}-{kind}`.
+Create per-repository [qmd](https://github.com/tobi/qmd) collections so agents and humans can run hybrid search across a repo's ADRs, OpenSpec specs, source code, and tracker issues from a single query plane. Each repository owns four collections (`{repo}-adrs`, `{repo}-specs`, `{repo}-code`, `{repo}-issues`) so searches can be filtered cleanly with `qmd query "..." -c {repo}-adrs`. The issues collection is populated by syncing the configured tracker into `.sdd/issues/{id}.md` files (per ADR-0025 and `references/tracker-sync.md`). Workspace projects (ADR-0016) get one set of collections per module: `{repo}-{module}-{kind}`.
 
 ## Process
 
@@ -58,14 +58,15 @@ Before doing anything else, verify the environment. Each check has its own short
    git rev-parse --show-toplevel | xargs basename | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g'
    ```
 
-2. Build the collection name set:
-   - **Single-module project** (no workspace, or `--module` provided): `{repo}-adrs`, `{repo}-specs`, `{repo}-code`. Where `{repo}` is the slug from step 3.1, plus the module name when `--module` is provided (e.g., `stumpcloud-infra-adrs`).
-   - **Workspace aggregate mode** (no `--module`, multiple modules detected): one triple per module — `{repo}-{module}-adrs`, `{repo}-{module}-specs`, `{repo}-{module}-code`. The skill iterates Steps 4–7 once per module.
+2. Build the collection name set (per ADR-0025 / SPEC-0019, the issues collection is the fourth per-repo collection alongside adrs, specs, and code):
+   - **Single-module project** (no workspace, or `--module` provided): `{repo}-adrs`, `{repo}-specs`, `{repo}-code`, `{repo}-issues`. Where `{repo}` is the slug from step 3.1, plus the module name when `--module` is provided (e.g., `stumpcloud-infra-adrs`).
+   - **Workspace aggregate mode** (no `--module`, multiple modules detected): one quadruple per module — `{repo}-{module}-adrs`, `{repo}-{module}-specs`, `{repo}-{module}-code`, `{repo}-{module}-issues`. The skill iterates Steps 4–7 once per module.
 
 3. Resolve absolute paths for each collection's source directory:
    - `*-adrs` → `{module-root}/{adr-dir}` (from Step 0)
    - `*-specs` → `{module-root}/{spec-dir}` (from Step 0)
    - `*-code` → `{module-root}` (the entire repo or module root)
+   - `*-issues` → `{module-root}/.sdd/issues/` (the local sync cache populated from the configured tracker — see Step 4 `add` operation sub-step 6 and the `update` operation issues sync)
 
 ### Step 4: Dispatch to the Operation
 
@@ -82,6 +83,7 @@ For each collection in the name set:
 3. **Build the file mask**. The qmd CLI takes only `--name` and `--mask` (no `--ignore` flag). qmd already auto-excludes `node_modules/`, `.git/`, `.cache/`, `vendor/`, `dist/`, and `build/` at the indexer level (see `store.js` `excludeDirs`), so the mask only needs to set what to *include*:
    - ADR collection: `--mask "ADR-*.md"` (matches the MADR filename convention from ADR-0003)
    - Spec collection: `--mask "**/*.md"` (catches both `spec.md` and `design.md`)
+   - Issues collection: `--mask "*.md"` (the synced issue files are flat under `.sdd/issues/`, one per issue, named `{id}.md` per ADR-0025 sub-decision 1)
    - Code collection: derive the mask from what is actually in the repo. Rank tracked extensions:
 
      ```bash
@@ -129,12 +131,23 @@ For each collection in the name set:
 
    If CLAUDE.md is too thin to derive a domain description (or the repo lacks one entirely), use `AskUserQuestion` to ask the user for a one-line project description, then synthesize the rest from `git ls-files` extension counts and from scanning ADR/spec titles. Don't ship a vague summary just because CLAUDE.md was thin — the reranker quality cost is real.
 
+6. **Issues collection initial sync** (per ADR-0025 / SPEC-0019 REQ "Issues Collection Sync via /sdd:index"). The `*-issues` collection is unique among the four — its source directory `.sdd/issues/` is initially empty (no synced issue files exist until the first sync). Before running `qmd collection add` for the issues collection, run an initial sync via the tracker-sync layer to populate `.sdd/issues/`:
+
+   1. Detect the configured tracker per the **Tracker Detection** flow in `references/shared-patterns.md`. If no tracker is detected, skip the issues collection entirely with a one-line warning ("No tracker configured — skipping `{repo}-issues` collection. Run `/sdd:init` to configure a tracker, or use the tasks.md fallback per ADR-0007."). Continue with the other three collections.
+   2. If a tracker is detected, invoke the per-tracker fetch+normalize per `references/tracker-sync.md` § "Per-Tracker Sync" → relevant tracker section. The sync writes one `.sdd/issues/{id}.md` file per open and recently-closed issue, using the canonical frontmatter schema documented in `tracker-sync.md` § "Canonical Frontmatter Schema".
+   3. After the sync completes, write the cursor to `.sdd/issues/_meta.json` per `tracker-sync.md` § "Cursor Management".
+   4. Then proceed with `qmd collection add` for the `*-issues` collection per the steps above.
+   5. The context summary for the issues collection (sub-step 5) SHOULD describe the tracker source and the issue scope, e.g.: *"Tracker issues for the {repo} project — synced from {tracker} ({owner}/{repo}). Each file under `.sdd/issues/` is one issue with frontmatter (id, status, labels, assignees, created/updated, references to specs/ADRs and dependencies) and the verbatim issue body. Open and recently-closed issues both appear; closed issues retain `status: closed` and `closed: {timestamp}` fields."*
+
+   On sync failure (rate limit, auth, network), surface the error per `tracker-sync.md` § "Failure Modes and Degradation" and skip the issues collection — the other three collections still get created.
+
 #### Operation: update
 
 1. Verify this repo's collections exist in `qmd collection list`. If none exist, output: "No qmd collections found for {repo}. Run `/sdd:index add` first." and stop.
 2. Note the global scope to the user before invoking: `qmd update` re-scans **every** collection in the user's index. qmd does not currently expose per-collection filtering on `update` and there is no shell-level workaround — a per-repo update would have to come from upstream qmd. If `qmd collection list` shows collections that do not belong to this repo, surface their count so the user understands what is about to happen.
-3. Run `qmd update`.
-4. After the update, prompt the user via `AskUserQuestion` whether to re-embed now (the embed operation below). New documents are not searchable via vector/hybrid search until they are embedded.
+3. **Issues collection re-sync first** (per SPEC-0019 REQ "Issues Collection Sync via /sdd:index"). Before running `qmd update`, re-fetch tracker issues into `.sdd/issues/` so the qmd file scan picks up new and changed issues. Use the per-tracker fetch+normalize per `references/tracker-sync.md`, with the cursor from `.sdd/issues/_meta.json` for incremental sync. Print a one-line note: "Syncing N issues from {tracker}…". On sync failure, surface the error and continue with the existing local cache (per `tracker-sync.md` § "Failure Modes and Degradation").
+4. Run `qmd update`.
+5. After the update, prompt the user via `AskUserQuestion` whether to re-embed now (the embed operation below). New documents are not searchable via vector/hybrid search until they are embedded.
 
 #### Operation: embed
 
@@ -154,7 +167,7 @@ Per ADR-0026's embed policy, this operation runs silently with a hardware-aware 
 3. **Pre-embed scope disclosure** (concrete cross-repo accounting). `qmd embed` operates on the entire qmd index — it generates embeddings for any unembedded chunks across all collections, not just this repo's. Before invoking it, call `qmd status` (or the qmd MCP `status` tool) to get the authoritative scope:
 
    - **Total pending across the index**: the `needsEmbedding` field
-   - **Pending attributable to this repo**: identify this-repo collections via **exact prefix match** on the collection name — a collection belongs to this repo if and only if its name equals `{slug}-adrs`, `{slug}-specs`, or `{slug}-code` (or `{slug}-{module}-{kind}` in workspace mode). **Do NOT use substring match**: a slug like `myrepo` would otherwise spuriously claim collections like `not-myrepo-adrs` belonging to a sibling repo. Match against the full collection name from `collections[]`. To estimate this-repo-pending, sum `(documents - embedded)` across the matched collections (per-collection embedded count comes from `qmd ls {collection}` or by tracking the diff before/after the most recent `qmd update`).
+   - **Pending attributable to this repo**: identify this-repo collections via **exact prefix match** on the collection name — a collection belongs to this repo if and only if its name equals `{slug}-adrs`, `{slug}-specs`, `{slug}-code`, or `{slug}-issues` (or `{slug}-{module}-{kind}` in workspace mode, where `{kind}` is one of `adrs`/`specs`/`code`/`issues`). **Do NOT use substring match**: a slug like `myrepo` would otherwise spuriously claim collections like `not-myrepo-adrs` belonging to a sibling repo. Match against the full collection name from `collections[]`. To estimate this-repo-pending, sum `(documents - embedded)` across the matched collections (per-collection embedded count comes from `qmd ls {collection}` or by tracking the diff before/after the most recent `qmd update`).
    - **Pending attributable to other repos**: total minus this-repo's share. Sample 2-3 of the other repo names from the unmatched collections (strip the trailing `-{kind}` segment to recover the slug) so the user sees concretely *whose* chunks they are about to embed.
 
    Surface this in the report concretely:
@@ -217,12 +230,14 @@ Auto-routed: collections did not exist → ran `add` then started `embed` ({fore
 | {repo}-adrs | {abs path to ADR dir} | {N} | {yes/no/in-progress} |
 | {repo}-specs | {abs path to spec dir} | {N} | {yes/no/in-progress} |
 | {repo}-code | {abs path to module root} | {N} | {yes/no/in-progress} |
+| {repo}-issues | `.sdd/issues/` (synced from {tracker}) | {N} | {yes/no/in-progress} |
 
 {Optional one-line note: total unique chunks queued for embedding, and a reminder that qmd auto-excludes node_modules/.git/.cache/vendor/dist/build.}
 
 ### Search Examples
 - ADRs only: `qmd query "{topic from a recent ADR title}" -c {repo}-adrs`
 - Code only: `qmd query "{a function or pattern likely in the codebase}" -c {repo}-code`
+- Issues only: `qmd query "{topic from an open issue}" -c {repo}-issues`
 - Across architecture: `qmd query "..." -c {repo}-adrs -c {repo}-specs`
 - Via the qmd MCP server: call its `query` tool with `collections: ["{repo}-adrs"]`
 
@@ -245,6 +260,7 @@ Auto-routed: collections did not exist → ran `add` then started `embed` ({fore
 | {repo}-adrs | {a} | {m} | {r} |
 | {repo}-specs | {a} | {m} | {r} |
 | {repo}-code | {a} | {m} | {r} |
+| {repo}-issues | {a} | {m} | {r} |
 
 {N} documents need re-embedding to become searchable via vector/hybrid query.
 
@@ -265,6 +281,7 @@ Embedded {N} chunks across {M} collections in {duration}.
 | {repo}-adrs | {N} | {C} |
 | {repo}-specs | {N} | {C} |
 | {repo}-code | {N} | {C} |
+| {repo}-issues | {N} | {C} |
 
 Hybrid search (`qmd query`) and vector search (`qmd vsearch`) are now available.
 ```
@@ -290,6 +307,7 @@ While it runs, BM25 keyword search via `qmd search -c {repo}-{...}` is already a
 | {repo}-adrs | {N} | {V} | {timestamp} | {abs path} |
 | {repo}-specs | {N} | {V} | {timestamp} | {abs path} |
 | {repo}-code | {N} | {V} | {timestamp} | {abs path} |
+| {repo}-issues | {N} | {V} | {timestamp} | `.sdd/issues/` (last sync: {iso-timestamp}) |
 
 ### Health
 - Index: {path to sqlite} ({size})
@@ -306,6 +324,7 @@ While it runs, BM25 keyword search via `qmd search -c {repo}-{...}` is already a
 |------|--------|
 | {repo}-adrs | removed ({N} documents dropped) |
 | {repo}-specs | removed ({N} documents dropped) |
+| {repo}-issues | removed ({N} documents dropped); `.sdd/issues/` cache preserved (gitignored) |
 | {repo}-code | removed ({N} documents dropped) |
 
 To rebuild the index later, run `/sdd:index`.
@@ -344,7 +363,9 @@ In aggregate mode, render one section per module before the report's shared sect
 - MUST run preflight checks (qmd installed, in git repo, CLAUDE.md present) before any side-effecting `qmd` command — partial failures are confusing and hard to undo
 - MUST derive the repo name from `git rev-parse --show-toplevel` rather than the current working directory; users may invoke from a subdirectory
 - MUST use the **Artifact Path Resolution** pattern from `references/shared-patterns.md` instead of hardcoding `docs/adrs/` or `docs/openspec/specs/` — repos can override these paths in CLAUDE.md (Governing: ADR-0015)
-- MUST create three collections per repo (or per module in workspace mode), not one — collection-level filtering (`-c <name>`) is the primary mechanism users will use to keep ADR/spec/code searches separate
+- MUST create four collections per repo (or per module in workspace mode): `-adrs`, `-specs`, `-code`, and `-issues` — collection-level filtering (`-c <name>`) is the primary mechanism users will use to keep different content types separate. The issues collection MAY be skipped (with a warning) when no tracker is configured per ADR-0007 (Governing: ADR-0025, SPEC-0019 REQ "Issues Collection Layout")
+- MUST run an issues sync via `references/tracker-sync.md` BEFORE running `qmd collection add` for the issues collection in the `add` operation — the source directory `.sdd/issues/` is initially empty, so the collection has nothing to scan until the first sync writes the markdown files (Governing: SPEC-0019 REQ "Issues Collection Sync via /sdd:index")
+- MUST run an issues sync via `references/tracker-sync.md` BEFORE `qmd update` in the `update` operation — fresh issue state must land in `.sdd/issues/` before the file scan picks up the changes
 - MUST attach a `qmd context add` summary to every collection — qmd's reranker uses context strings to disambiguate results, and uncontextualized collections produce noisier hybrid scores
 - MUST use `--chunk-strategy auto` when embedding so code files chunk on AST boundaries (function, class, import) instead of arbitrary character offsets — produces dramatically better code search recall
 - MUST detect existing collections via `qmd collection list` before re-creating; re-running `add` on an existing collection is a no-op in qmd but will not refresh path or mask, so a stale config can persist silently


### PR DESCRIPTION
Closes #108. Part of #105 (SPEC-0019). Implements REQ Issues Collection Layout and REQ Issues Collection Sync via /sdd:index. Adds the fourth per-repo collection populated by syncing the configured tracker into .sdd/issues/{id}.md via references/tracker-sync.md (#107). Updates Step 3 (collection name set), Step 4 add (initial sync sub-step), Step 4 update (re-sync first sub-step), all report templates, and the exact-prefix-match list. Three new MUST rules. See commit message for full detail.