### PR TITLE
feat(enrich,organize): Tier 4 issues sync on entry + Tier 1 mutation update

### DIFF
--- a/skills/enrich/SKILL.md
+++ b/skills/enrich/SKILL.md
@@ -113,6 +113,26 @@ You are retroactively adding `### Branch` and `### PR Convention` sections to ex
    - Any failures encountered (with issue numbers and error details)
    - Breakdown: how many got `### Branch`, how many got `### PR Convention`
 
+### Step 0a: Tier 4 issues sync (v5.0.0+)
+
+<!-- Governing: ADR-0026 (Tiered Index Freshness), SPEC-0019 REQ "Tier 4 Always-Sync Issues for Sprint Skills" -->
+
+Before iterating issues, sync the `{repo}-issues` qmd collection from the tracker so the local cache reflects current issue state. This is Tier 4 of the freshness model: always sync at consumer entry, subject to a 5-minute deduplication window.
+
+1. Read `.sdd/issues/_meta.json` (per `references/tracker-sync.md` § "Cursor Management"). If `last_sync` is within the last 5 minutes, skip the sync and proceed silently.
+2. Otherwise, invoke the per-tracker fetch+normalize per `references/tracker-sync.md` § "Per-Tracker Sync" with the `cursor.{tracker}` from `_meta.json` for incremental fetch. Print a one-line note: "Syncing N issues from {tracker}…".
+3. On sync failure (rate limit, auth, network), surface the failure per `references/tracker-sync.md` § "Failure Modes and Degradation" — emit a one-line warning and proceed with live tracker queries (the pre-v5 path) for this run. Do NOT block; enrichment is the user's primary intent.
+
+### Step 10: Tier 1 mutation update (v5.0.0+)
+
+<!-- Governing: ADR-0026 (Tiered Index Freshness), SPEC-0019 REQ "Tier 1 Mutation-Aware Updates" -->
+
+After all issue body updates complete (step 7.i), trigger a narrow re-sync of the `{repo}-issues` collection so the qmd index reflects the appended `### Branch` and `### PR Convention` sections. Use the canonical update pattern from `references/qmd-helpers.md` § "Update Patterns" → "Narrow update".
+
+1. Re-fetch the affected issues via the per-tracker fetch+normalize (only the issues that were modified — most trackers expose a list-by-IDs endpoint that's cheaper than a full re-sync).
+2. Run `qmd update` per the qmd-helpers pattern.
+3. The update is best-effort and silent on success. On failure, append a one-line warning to the report ("Index refresh failed for `{repo}-issues` — run `/sdd:index update` manually") but report the enrichment itself as successful.
+
 ## Config Reference
 
 This skill reads the `Branch Conventions` and `PR Conventions` subsections of the `### SDD Configuration` section in CLAUDE.md. See the plugin's `references/shared-patterns.md` § "Config Resolution" for the canonical format and defaults, and § "Branch Naming Conventions" and "PR Close Keywords" for conventions.
@@ -127,3 +147,5 @@ This skill reads the `Branch Conventions` and `PR Conventions` subsections of th
 - MUST follow the Config Resolution pattern from `references/shared-patterns.md` to read configuration from CLAUDE.md
 - MUST use the try-then-create pattern (see `references/shared-patterns.md`) for all label applications — never fail on missing labels (Governing: SPEC-0011 REQ "Auto-Create Labels")
 - No `--review` support (utility skill)
+- **v5.0.0+**: MUST trigger Tier 4 issues sync on entry per Step 0a — sync from the configured tracker into `.sdd/issues/` before iterating issues, subject to the 5-minute dedup window. On sync failure, fall back to live tracker queries with a one-line warning (NEVER block) (Governing: ADR-0026, SPEC-0019 REQ "Tier 4 Always-Sync Issues for Sprint Skills")
+- **v5.0.0+**: MUST trigger Tier 1 mutation update of `{repo}-issues` after enrichment per Step 10 — best-effort, silent on success, one-line warning on failure (Governing: ADR-0026, SPEC-0019 REQ "Tier 1 Mutation-Aware Updates")

--- a/skills/organize/SKILL.md
+++ b/skills/organize/SKILL.md
@@ -102,6 +102,28 @@ You are retroactively grouping existing tracker issues into tracker-native proje
     - Any failures encountered (with issue numbers)
     - Whether CLAUDE.md `Projects` section was updated with project IDs
 
+### Step 0a: Tier 4 issues sync (v5.0.0+)
+
+<!-- Governing: ADR-0026 (Tiered Index Freshness), SPEC-0019 REQ "Tier 4 Always-Sync Issues for Sprint Skills" -->
+
+Before discovering existing issues (Step 5), sync the `{repo}-issues` qmd collection from the tracker so the local cache reflects current issue state. This is Tier 4 of the freshness model: always sync at consumer entry, subject to a 5-minute deduplication window.
+
+1. Read `.sdd/issues/_meta.json` (per `references/tracker-sync.md` § "Cursor Management"). If `last_sync` is within the last 5 minutes, skip the sync and proceed silently.
+2. Otherwise, invoke the per-tracker fetch+normalize per `references/tracker-sync.md` with the cursor for incremental fetch. Print: "Syncing N issues from {tracker}…".
+3. On sync failure, surface a one-line warning per `references/tracker-sync.md` § "Failure Modes and Degradation" and proceed with live tracker queries (the pre-v5 path) for this run. Do NOT block; organize is the user's primary intent.
+
+### Step 12: Tier 1 mutation update (v5.0.0+)
+
+<!-- Governing: ADR-0026 (Tiered Index Freshness), SPEC-0019 REQ "Tier 1 Mutation-Aware Updates" -->
+
+After tier (c) interventions modify issue bodies (labels, project links surfaced in body, etc.), trigger a narrow re-sync of `{repo}-issues` so the qmd index reflects the changes. Use the canonical update pattern from `references/qmd-helpers.md` § "Update Patterns".
+
+1. Re-fetch the modified issues via per-tracker fetch+normalize (only those touched in tier (c)).
+2. Run `qmd update`.
+3. Best-effort and silent on success. On failure, append a one-line warning ("Index refresh failed for `{repo}-issues` — run `/sdd:index update` manually") and report the organize step itself as successful.
+
+If tier (a) (report-only) or tier (b) (project-level only, no issue-content changes) was selected, skip Step 12 — there's nothing to re-index for `{repo}-issues`.
+
 ## Config Reference
 
 This skill reads and writes the `Projects` subsection of the `### SDD Configuration` section in CLAUDE.md. See the plugin's `references/shared-patterns.md` § "Config Resolution" for the canonical format and defaults. All keys are optional with sensible defaults. When writing, merge — do not overwrite.
@@ -122,3 +144,5 @@ This skill reads and writes the `Projects` subsection of the `### SDD Configurat
 - MUST use the try-then-create pattern (see `references/shared-patterns.md`) for all label applications in tier (c) (Governing: SPEC-0011 REQ "Auto-Create Labels")
 - MUST degrade gracefully when tracker features are unavailable — skip and report, never fail (Governing: SPEC-0011 REQ "Graceful Degradation")
 - No `--review` support (utility skill)
+- **v5.0.0+**: MUST trigger Tier 4 issues sync on entry per Step 0a — sync from tracker before discovering issues, subject to 5-min dedup. On failure, fall back to live queries with a warning (Governing: ADR-0026, SPEC-0019 REQ "Tier 4 Always-Sync Issues for Sprint Skills")
+- **v5.0.0+**: MUST trigger Tier 1 update of `{repo}-issues` after tier (c) interventions per Step 12 — best-effort, silent on success (Governing: ADR-0026, SPEC-0019 REQ "Tier 1 Mutation-Aware Updates")


### PR DESCRIPTION
Closes #110. Part of #105 (SPEC-0019). Adds Tier 4 (always-sync issues at entry, 5-min dedup) and partial Tier 1 (mutation update of {repo}-issues) to /sdd:enrich and /sdd:organize. Pattern matches the canonical update flow from references/qmd-helpers.md and the per-tracker fetch from references/tracker-sync.md (both shipped in foundation PRs #118-#121).