### PR TITLE
feat(adr,spec,status): qmd-aware edge pre-search + Tier 1 mutation updates

### DIFF
--- a/skills/adr/SKILL.md
+++ b/skills/adr/SKILL.md
@@ -17,6 +17,30 @@ You are creating a new ADR using the MADR (Markdown Architectural Decision Recor
 
 1. **Determine the next ADR number**: Scan `{adr-dir}` for existing `ADR-XXXX-*.md` files and increment to the next number. Start at ADR-0001 if none exist. Create `{adr-dir}` if it does not exist. If `$ARGUMENTS` is empty (ignoring flags like `--review` and `--module`), use `AskUserQuestion` to ask the user what decision they want to document.
 
+1a. **qmd-aware edge pre-search** (v5.0.0+):
+
+   <!-- Governing: ADR-0024 (qmd as hard dependency), SPEC-0019 REQ "qmd-Smart Authoring Skills" -->
+
+   Before drafting, qmd-search the existing ADR corpus to find related prior decisions whose IDs SHOULD appear in the new ADR's frontmatter as `supersedes`, `extends`, or `related` edges (per ADR-0023 / SPEC-0018 frontmatter DAG).
+
+   1. Construct a hybrid query per `references/qmd-helpers.md` § "Hybrid Retrieval":
+      - `lex`: the user's description from `$ARGUMENTS` (key technologies, named systems, decision verbs)
+      - `vec`: a one-sentence framing of the decision the new ADR will make
+      - `intent: "/sdd:adr — find related prior ADRs to suggest as frontmatter edges"`
+      - `collections: ["{repo}-adrs"]` (or per-module variant in workspace mode per `qmd-helpers.md` § "This-Repo Collection Identification")
+      - `limit: 6`, `minScore: 0.3`
+
+   2. For each result above the threshold, classify the candidate edge:
+      - **supersedes**: the new ADR's description includes "replace", "deprecate", "stop using", "switch from X to Y" and the matched ADR documents X
+      - **extends**: the new ADR builds on the matched ADR's foundation without replacing it
+      - **related**: weak association — same domain, named technology, or shared concern
+
+   3. Surface the candidate edges to the user via `AskUserQuestion` BEFORE writing the file. Show each candidate with the matched ADR's ID, title, and proposed edge classification. Options for each candidate: "Include as `{edge}`", "Include as `related` instead", "Skip". The user can override the classification if the agent's guess is wrong.
+
+   4. If qmd returns zero results above the threshold, proceed without surfacing edge suggestions and emit a one-line note: "No related ADRs found — drafting from scratch."
+
+   5. On qmd unreachable / timeout per `qmd-helpers.md` § "Error Handling", surface the error and stop. Per ADR-0024, fallback paths were eliminated in v5; the failure mode is "fix qmd, retry."
+
 2. **Choose drafting mode**: Check if `$ARGUMENTS` contains `--review`.
 
    **Default (no `--review`)**: Single-agent mode. Research the codebase (read relevant files, understand the current architecture), draft the ADR directly, self-review against the architect's checklist in the Rules section, then write the file.
@@ -30,7 +54,13 @@ You are creating a new ADR using the MADR (Markdown Architectural Decision Recor
      - The drafter should research the codebase (read relevant files, understand the current architecture) before writing
      - If `TeamCreate` fails, fall back to single-agent mode: draft the ADR directly, then self-review against the architect's checklist in the Rules section before writing.
 
-3. **Write the ADR** to `{adr-dir}/ADR-XXXX-short-title.md`
+3. **Write the ADR** to `{adr-dir}/ADR-XXXX-short-title.md`. Include the user-confirmed frontmatter edges from Step 1a in the YAML frontmatter (per the canonical edge schema in `references/shared-patterns.md` § "Graph Edge Resolution").
+
+3a. **Tier 1 mutation update** (v5.0.0+):
+
+   <!-- Governing: ADR-0026 (Tiered Index Freshness), SPEC-0019 REQ "Tier 1 Mutation-Aware Updates" -->
+
+   After writing the new ADR file, trigger a narrow re-sync of `{repo}-adrs` so the qmd index reflects the new artifact. Use the canonical update pattern from `references/qmd-helpers.md` § "Update Patterns" → "Narrow update". The update is synchronous and silent on success. On failure, append a one-line warning to the report ("Index refresh failed for `{repo}-adrs` — run `/sdd:index update` manually") but report the ADR creation itself as successful.
 
 4. **Clean up** the team when done (if `--review` was used).
 
@@ -143,6 +173,9 @@ Use flowchart, sequence, or C4 diagrams as appropriate.}
 - Focus on the "why" -- what problem does this solve and why this solution?
 - Reference existing ADRs if this supersedes or relates to them
 - Every ADR SHOULD include at least one Mermaid diagram illustrating the architecture or decision flow. Use flowchart, sequence, or C4 diagrams as appropriate.
+- **v5.0.0+**: MUST run qmd-aware edge pre-search per Step 1a — surface candidate `supersedes`/`extends`/`related` edges to the user via AskUserQuestion before drafting. The user's confirmed edges land in the new ADR's frontmatter (Governing: ADR-0024, SPEC-0019 REQ "qmd-Smart Authoring Skills")
+- **v5.0.0+**: MUST trigger Tier 1 `{repo}-adrs` re-sync after writing the new file per Step 3a — best-effort, silent on success, one-line warning on failure (Governing: ADR-0026, SPEC-0019 REQ "Tier 1 Mutation-Aware Updates")
+- **v5.0.0+**: On qmd unreachable / timeout during the edge pre-search, MUST surface the error and stop — never fall back to "draft without edge suggestions" (per ADR-0024)
 
 ## Graph Edge Frontmatter (per ADR-0023 / SPEC-0018)
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -27,6 +27,31 @@ When creating a new spec from scratch, both files are created together — align
 
 3. **Determine the next SPEC number**: Scan `{spec-dir}` for existing spec.md files, find the highest SPEC number used, and increment. SPEC numbers are formatted as `SPEC-XXXX` (e.g., SPEC-0001). Start at SPEC-0001 if none exist. **IMPORTANT**: The prefix is `SPEC-`, NOT `RFC-`. Do not confuse spec numbering with RFC 2119 (which is a language standard for requirements keywords).
 
+3a. **qmd-aware edge pre-search** (v5.0.0+):
+
+   <!-- Governing: ADR-0024 (qmd as hard dependency), SPEC-0019 REQ "qmd-Smart Authoring Skills" -->
+
+   Before drafting, qmd-search the existing spec corpus to find related prior specs whose IDs SHOULD appear in the new spec's frontmatter as `requires`, `extends`, or `supersedes` edges. Also search ADRs to identify which ADRs the new spec should declare it `implements`.
+
+   1. Construct a hybrid query per `references/qmd-helpers.md` § "Hybrid Retrieval":
+      - `lex`: capability name + key technologies/concepts
+      - `vec`: a one-sentence framing of what the new spec covers
+      - `intent: "/sdd:spec — find related prior specs and governing ADRs to suggest as frontmatter edges"`
+      - `collections: ["{repo}-specs", "{repo}-adrs"]` (or per-module variants per `qmd-helpers.md` § "This-Repo Collection Identification")
+      - `limit: 8`, `minScore: 0.3`
+
+   2. Classify each result above the threshold:
+      - **requires** (spec → spec): the new spec depends on capability the matched spec provides
+      - **extends** (spec → spec): the new spec is a behavioral extension of the matched spec
+      - **supersedes** (spec → spec): the new spec replaces the matched spec
+      - **implements** (spec → ADR): the new spec realizes the matched ADR's decision
+
+   3. Surface candidate edges via `AskUserQuestion` BEFORE writing the file. Show each with the matched artifact's ID, title, and proposed edge classification. Options for each: "Include as `{edge}`", "Include as different edge", "Skip".
+
+   4. If qmd returns zero results above the threshold, proceed without surfacing edge suggestions and emit: "No related specs or ADRs found — drafting from scratch."
+
+   5. On qmd unreachable / timeout per `qmd-helpers.md` § "Error Handling", surface the error and stop. Per ADR-0024, no fallback in v5.
+
 4. **Choose drafting mode**: Check if `$ARGUMENTS` contains `--review`.
 
    **Default (no `--review`)**: Single-agent mode. Research the codebase (read relevant files, understand the current architecture), draft both spec.md and design.md directly, self-review against the architect's checklist in the Rules section, then write both files.
@@ -41,8 +66,14 @@ When creating a new spec from scratch, both files are created together — align
      - If `TeamCreate` fails, fall back to single-agent mode: draft both files directly, then self-review against the architect's checklist in the Rules section before writing.
 
 5. **Write both files**:
-   - `{spec-dir}/{capability-name}/spec.md`
+   - `{spec-dir}/{capability-name}/spec.md` — include the user-confirmed frontmatter edges from Step 3a (per the canonical edge schema in `references/shared-patterns.md` § "Graph Edge Resolution")
    - `{spec-dir}/{capability-name}/design.md`
+
+5a. **Tier 1 mutation update** (v5.0.0+):
+
+   <!-- Governing: ADR-0026 (Tiered Index Freshness), SPEC-0019 REQ "Tier 1 Mutation-Aware Updates" -->
+
+   After writing both files, trigger a narrow re-sync of `{repo}-specs` so the qmd index reflects the new artifacts. Use the canonical update pattern from `references/qmd-helpers.md` § "Update Patterns" → "Narrow update". Synchronous and silent on success. On failure, append a one-line warning to the report ("Index refresh failed for `{repo}-specs` — run `/sdd:index update` manually") but report the spec creation itself as successful.
 
 6. **Clean up** the team when done (if `--review` was used).
 
@@ -380,6 +411,9 @@ date: {YYYY-MM-DD}
 - MUST NOT inject the Security Requirements section for non-web specs (CLI tools, libraries, batch jobs, data migrations, background workers)
 - For UI-facing specs: MUST inject the Accessibility Requirements section covering WCAG 2.1 AA, ARIA landmarks, `aria-label` on icon-only controls, `aria-live` for dynamic content, keyboard navigation, and focus management (Governing: ADR-0019, SPEC-0016 REQ "Accessibility Requirements for UI Specs")
 - MUST NOT inject the Accessibility Requirements section for non-UI specs (API-only, CLI, batch jobs, background workers, internal libraries)
+- **v5.0.0+**: MUST run qmd-aware edge pre-search per Step 3a — surface candidate `requires`/`extends`/`supersedes`/`implements` edges to the user via AskUserQuestion before drafting. The user's confirmed edges land in the new spec's frontmatter (Governing: ADR-0024, SPEC-0019 REQ "qmd-Smart Authoring Skills")
+- **v5.0.0+**: MUST trigger Tier 1 `{repo}-specs` re-sync after writing both files per Step 5a — best-effort, silent on success (Governing: ADR-0026, SPEC-0019 REQ "Tier 1 Mutation-Aware Updates")
+- **v5.0.0+**: On qmd unreachable / timeout during the edge pre-search, MUST surface the error and stop — never fall back to "draft without edge suggestions" (per ADR-0024)
 - For backend specs with error handling: MUST inject error wrapping, sentinel errors, no silent swallowing, and structured logging requirements (Governing: SPEC-0016 REQ "Go Code Quality Guidelines")
 - For backend specs with concurrency: MUST inject context propagation, worker lifecycle, race safety, and race detection CI requirements (Governing: SPEC-0016 REQ "Go Code Quality Guidelines")
 - For backend specs with database interactions: MUST inject transaction, connection lifecycle, and parameterized query requirements

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -61,6 +61,12 @@ Update the status of an ADR or spec, **preserving the file's existing status for
    - "Updated ADR-0001 status: accepted → superseded (inline-bullet, preserved format; refinement note dropped)"
    - "Added inline-bullet status to SPEC-0005: draft (file had no prior status field; inline format chosen to match sibling specs)"
 
+7. **Tier 1 mutation update** (v5.0.0+):
+
+   <!-- Governing: ADR-0026 (Tiered Index Freshness), SPEC-0019 REQ "Tier 1 Mutation-Aware Updates" -->
+
+   After updating the status field, trigger a narrow re-sync of the qmd collection containing the artifact whose status changed — `{repo}-adrs` for ADRs, `{repo}-specs` for specs (or per-module variant in workspace mode per `references/qmd-helpers.md` § "This-Repo Collection Identification"). Use the canonical update pattern from `references/qmd-helpers.md` § "Update Patterns" → "Narrow update". Synchronous and silent on success. On failure, append a one-line warning to the report ("Index refresh failed for `{collection}` — run `/sdd:index update` manually") but report the status change itself as successful.
+
 ## Rules
 
 - Valid ADR statuses: `proposed`, `accepted`, `deprecated`, `superseded`
@@ -74,3 +80,4 @@ Update the status of an ADR or spec, **preserving the file's existing status for
 - MUST report which format was preserved or added in the success message — silent mutations are how the previous bug went undetected
 - Do not modify any content outside the status field — neither YAML keys nor body content nor adjacent bullets
 - Refinement note format is preserved in source files (per the prior `/sdd:prime` and `/sdd:list` updates that strip parentheticals from the table view) — this skill's job is to update the lifecycle word, not the refinement annotation, and only on explicit user direction
+- **v5.0.0+**: MUST trigger Tier 1 update of the affected collection (`{repo}-adrs` or `{repo}-specs`) per Step 7 — best-effort, silent on success, one-line warning on failure (Governing: ADR-0026, SPEC-0019 REQ "Tier 1 Mutation-Aware Updates")


### PR DESCRIPTION
Closes #114. Part of #105 (SPEC-0019). /sdd:adr, /sdd:spec gain pre-search step that surfaces candidate frontmatter edges via AskUserQuestion before drafting (supersedes/extends/related for ADRs; requires/extends/supersedes/implements for specs). All three skills gain Tier 1 update post-write to keep qmd in sync. No fallback paths on qmd failure per ADR-0024.