### PR TITLE
feat(prime): filter non-authoritative artifacts (ADR-0027)

### DIFF
--- a/docs/adrs/ADR-0027-non-authoritative-artifact-filtering-in-prime.md
+++ b/docs/adrs/ADR-0027-non-authoritative-artifact-filtering-in-prime.md
@@ -1,0 +1,115 @@
+---
+status: proposed
+date: 2026-05-09
+decision-makers: joestump
+---
+
+# ADR-0027: Non-Authoritative Artifact Filtering in `/sdd:prime`
+
+## Context and Problem Statement
+
+`/sdd:prime` loads all ADRs and specs into the session context regardless of their status. As the project grows, artifacts accumulate statuses like `superseded`, `deprecated`, and `rejected` — these represent decisions that are no longer authoritative. Loading them alongside active artifacts creates two problems:
+
+1. **Context pollution**: Non-authoritative artifacts consume context window space that could be used for actual implementation work. A session primed with 30 ADRs where 10 are superseded wastes a third of the architecture context on outdated decisions.
+2. **Decision confusion**: An agent (or human) scanning the primed context may follow a superseded decision instead of its replacement. Nothing in the current output distinguishes "this is the current truth" from "this was replaced six months ago." The flat table treats all statuses equally.
+
+MADR frontmatter already tracks `status` (accepted, proposed, superseded, deprecated, rejected) and the `superseded-by` field links old decisions to their replacements. `/sdd:prime` should leverage these fields to present only authoritative artifacts by default while preserving discoverability of historical decisions.
+
+## Decision Drivers
+
+* **Context window efficiency** — primed context should maximize the ratio of actionable architecture information to total tokens consumed
+* **Decision clarity** — agents and humans should be able to trust that primed artifacts represent current architectural truth
+* **Historical discoverability** — superseded and deprecated artifacts still have value for understanding why decisions changed; they should not be invisible
+* **Transition traceability** — when an artifact is superseded, the user should see what replaced it without having to hunt through files
+* **Consistency with topic filtering** — the existing topic filter already has a "Skipped" section pattern; non-authoritative filtering should follow the same UX
+
+## Considered Options
+
+* **Option 1**: Filter non-authoritative statuses from main tables with a callout footer showing excluded artifacts and their transitions
+* **Option 2**: Keep all artifacts in the main table but add a status badge/icon to distinguish non-authoritative ones
+* **Option 3**: Add an `--all` flag to include non-authoritative artifacts, exclude them silently by default
+
+## Decision Outcome
+
+Chosen option: "Option 1 — Filter with callout footer", because it removes non-authoritative artifacts from the active context while preserving full visibility of what was excluded and why. The footer pattern is consistent with the existing "Skipped" section in topic-filtered mode and provides transition links (superseded-by) so users can trace decision evolution without opening files.
+
+The set of non-authoritative statuses is: `superseded`, `deprecated`, `rejected`. All other statuses (`accepted`, `proposed`, `draft`, or missing) are considered authoritative and remain in the main tables.
+
+### Consequences
+
+* Good, because primed context only contains actionable, current architectural decisions — agents won't follow outdated guidance
+* Good, because the footer section preserves discoverability without polluting the main tables
+* Good, because `superseded-by` transitions in the footer let users trace decision evolution at a glance
+* Good, because the pattern is consistent with the existing "Skipped" section in topic-filtered output
+* Good, because context window usage improves as non-authoritative artifacts are summarized in one-liners rather than full table rows
+* Bad, because `/sdd:status` must enforce `superseded-by` links when marking an artifact superseded — an incomplete transition leaves a dead-end in the footer (out of scope for this ADR; tracked separately)
+* Neutral, because topic-filtered mode still surfaces non-authoritative artifacts when relevant to the topic, but flags them with a warning — this is a deliberate trade-off favoring historical context over strict filtering
+
+### Confirmation
+
+Implementation will be confirmed by:
+
+1. Running `/sdd:prime` on a project with superseded/deprecated/rejected ADRs excludes them from the main ADR table
+2. Excluded artifacts appear in a "Non-Authoritative (excluded)" footer section with one-liner summaries
+3. Superseded artifacts in the footer show `→ superseded by ADR-XXXX` transition links
+4. The header count reflects only authoritative artifacts (e.g., "Primed session with 15 ADRs and 10 specs" excludes the 3 superseded ones)
+5. Running `/sdd:prime {topic}` where the topic matches a superseded artifact still surfaces it in the results but with a `⚠ superseded` badge
+6. Running `/sdd:prime` with zero non-authoritative artifacts produces no footer section
+7. Same filtering logic applies to specs with non-authoritative statuses
+8. Workspace aggregate mode renders the footer with module-prefixed artifact references (e.g., `[api] ADR-0007: ...`)
+
+## Pros and Cons of the Options
+
+### Option 1: Filter with Callout Footer
+
+Filter `superseded`, `deprecated`, and `rejected` artifacts from the main tables. Add a "Non-Authoritative (excluded)" section at the bottom listing each excluded artifact as a one-liner with its status and transition target (if superseded).
+
+* Good, because the main tables only contain current, actionable decisions
+* Good, because the footer preserves discoverability — nothing is silently hidden
+* Good, because transition links (`→ superseded by ADR-XXXX`) provide immediate traceability
+* Good, because it follows the established "Skipped" section pattern from topic filtering
+* Neutral, because the footer adds a small amount of output, but one-liners are minimal
+* Bad, because it requires `superseded-by` metadata to be consistently maintained
+
+### Option 2: Keep All with Status Badges
+
+Show all artifacts in the main table but prepend a badge (e.g., `~~strikethrough~~` or `⚠`) to non-authoritative entries.
+
+* Good, because all artifacts remain visible in one place
+* Good, because no information is hidden or moved
+* Bad, because non-authoritative artifacts still consume context window space as full table rows
+* Bad, because agents may still process strikethrough text as valid guidance — visual badges don't reliably signal "ignore this" to an LLM
+* Bad, because the table becomes cluttered as more artifacts are superseded over time
+
+### Option 3: Silent Exclusion with `--all` Flag
+
+Exclude non-authoritative artifacts by default with no indication they exist. Add `--all` flag to include them.
+
+* Good, because the output is maximally clean — only current decisions shown
+* Bad, because users have no indication that artifacts were excluded — they may not know to use `--all`
+* Bad, because superseded decision chains are invisible without explicitly requesting them
+* Bad, because it breaks the principle of least surprise — artifacts appear to vanish
+
+## Non-Authoritative Status Definitions
+
+| Status | Meaning | Footer Display |
+|--------|---------|---------------|
+| `superseded` | Replaced by a newer decision | `ADR-XXXX: {title} → superseded by ADR-YYYY` |
+| `deprecated` | No longer recommended but not formally replaced | `ADR-XXXX: {title} (deprecated)` |
+| `rejected` | Considered but not adopted | `ADR-XXXX: {title} (rejected)` |
+
+## Impact on Topic-Filtered Mode
+
+When `/sdd:prime {topic}` is used, non-authoritative artifacts that match the topic are **included** in the results but flagged:
+
+- Table rows show status as `⚠ superseded`, `⚠ deprecated`, or `⚠ rejected`
+- The summary section includes a note: "This artifact is superseded by ADR-XXXX — see the replacement for current guidance"
+- Non-matching non-authoritative artifacts appear in the "Skipped" section as usual
+
+This ensures that someone investigating a topic's history can see the full decision chain, while being clearly warned that certain artifacts are no longer authoritative.
+
+## More Information
+
+- This ADR modifies the output behavior of `/sdd:prime` (ADR-0002, SPEC-0002). The scanning and topic-matching logic remains unchanged; only the presentation layer filters and sections the results.
+- The `superseded-by` field is part of the MADR format already used by `/sdd:adr` (ADR-0003). A follow-up should update `/sdd:status` to enforce that marking an artifact as `superseded` requires a `superseded-by` value.
+- Related: ADR-0002 (init and context priming), ADR-0003 (foundational artifact formats), ADR-0022 (rename to sdd namespace), SPEC-0002 (initialization and context priming).

--- a/skills/prime/SKILL.md
+++ b/skills/prime/SKILL.md
@@ -29,6 +29,7 @@ Load existing ADRs and specs into the session so Claude can give architecture-aw
 
 2. **Scan for ADRs**: Glob for `{adr-dir}/ADR-*.md` files (in aggregate mode, glob per-module). For each file:
    - Extract `status` and `date` per the **Status Field Extraction** algorithm below
+   - Extract `superseded-by` from YAML frontmatter if present (used by Step 4 footer rendering)
    - Extract the title from the first `# ` heading
    - Read the `## Context and Problem Statement` section
    - Read the `## Decision Outcome` section to extract the key decision
@@ -36,6 +37,7 @@ Load existing ADRs and specs into the session so Claude can give architecture-aw
 
 3. **Scan for specs**: Glob for `{spec-dir}/*/spec.md` files (in aggregate mode, glob per-module). Validate spec pairing per `references/shared-patterns.md` § "Spec Pairing Validation". For each file:
    - Extract `status` per the **Status Field Extraction** algorithm below
+   - Extract `superseded-by` from YAML frontmatter if present (used by Step 4 footer rendering)
    - Extract the title from the first `# ` heading (e.g., `SPEC-0001: Web Dashboard`)
    - Read the `## Overview` section
    - Count the number of `### Requirement:` headings
@@ -47,9 +49,18 @@ Load existing ADRs and specs into the session so Claude can give architecture-aw
    1. **YAML frontmatter** (canonical, current SDD template): look for a `status:` key inside the `---` … `---` frontmatter block at the top of the file.
    2. **Inline bullet** (legacy / hand-authored): if no YAML frontmatter exists OR YAML has no `status:` field, scan the first 30 lines for a line matching `- **Status:** {value}` (case-insensitive on "Status"; tolerate `*` or `+` as the bullet marker; tolerate `Status:` without the bold).
    3. **Strip refinement notes**: the inline-bullet form sometimes carries a parenthetical refinement note: `- **Status:** accepted (refined by ADR-0010, 2026-05-03)`. Split on the first `(`, trim trailing whitespace, and use only the leading word ("accepted"). The parenthetical content is preserved in the source file but is not rendered in prime tables — it would blow out column width for a corner case better surfaced by `/sdd:graph` or by reading the artifact directly.
-   4. **No status found**: if neither form yields a value, record the artifact as having no parseable status. Render as `—` in the table when other artifacts in the same corpus have status; drop the Status column entirely when *zero* artifacts in the corpus have status (see Step 6 rendering rule).
+   4. **No status found**: if neither form yields a value, record the artifact as having no parseable status. Render as `—` in the table when other artifacts in the same corpus have status; drop the Status column entirely when *zero* artifacts in the corpus have status (see Step 7 rendering rule).
 
-4. **Apply topic filter** (if `$ARGUMENTS` is not empty):
+   <!-- Governing: ADR-0027 (Non-Authoritative Artifact Filtering in Prime) -->
+
+4. **Filter non-authoritative artifacts**: Partition all scanned ADRs and specs into two groups:
+   - **Authoritative**: status is `accepted`, `proposed`, `draft`, `review`, `approved`, `implemented`, or missing/empty — these appear in the main output tables
+   - **Non-authoritative**: status is `superseded`, `deprecated`, or `rejected` — these are excluded from the main tables and collected for the footer section
+   - For each non-authoritative artifact, record its status and `superseded-by` target (if present)
+   - The header counts (e.g., "Primed session with N ADRs and M specs") MUST reflect only authoritative artifacts
+   - In topic-filtered mode (Step 5), non-authoritative artifacts are NOT excluded by this step — they are surfaced in matching results with a `⚠` badge instead. This step's filtering applies to the unfiltered/main output paths.
+
+5. **Apply topic filter** (if `$ARGUMENTS` is not empty):
    - The topic argument is a free-text string for semantic matching
    - For each ADR, read the title, context/problem statement, and decision outcome
    - For each spec, read the title and overview
@@ -60,13 +71,13 @@ Load existing ADRs and specs into the session so Claude can give architecture-aw
      No ADRs or specs matched the topic "{topic}". Try a broader term, or run `/sdd:prime` without a topic to see all artifacts.
      ```
 
-5. **Handle edge cases**:
+6. **Handle edge cases**:
    - If `{adr-dir}` does not exist: "The `{adr-dir}` directory does not exist. Run `/sdd:adr [description]` to create your first ADR."
    - If `{spec-dir}` does not exist: "The `{spec-dir}` directory does not exist. Run `/sdd:spec [capability]` to create your first spec."
    - If neither directory has any artifacts: "No design artifacts found. Create an ADR with `/sdd:adr` or a spec with `/sdd:spec` first."
    - If ADRs exist but no specs (or vice versa), present whichever exists and note the other is empty
 
-6. **Present results** using the appropriate output format below.
+7. **Present results** using the appropriate output format below.
 
 ## Output
 
@@ -89,11 +100,18 @@ Primed session with {N} ADRs and {M} specs.
 |----|-------|--------|--------------|
 | SPEC-0001 | {title} | {status} | {N} requirements, {M} scenarios |
 
+### Non-Authoritative (excluded)
+- ADR-XXXX: {title} → superseded by ADR-YYYY
+- ADR-XXXX: {title} (deprecated)
+- SPEC-XXXX: {title} (rejected)
+
 ### Quick Reference
 - Check for drift: `/sdd:check [target]`
 - Full audit: `/sdd:audit [scope]`
 - List all artifacts: `/sdd:list`
 ```
+
+> **Note**: The "Non-Authoritative (excluded)" section MUST only appear when there are excluded artifacts. If all artifacts are authoritative, omit the section entirely.
 
 ### Workspace aggregate mode (`/sdd:prime` in a multi-module project):
 
@@ -116,6 +134,10 @@ Primed session with {N} ADRs and {M} specs across {K} modules.
 | [api] | SPEC-0001 | {title} | {status} | {N} requirements, {M} scenarios |
 | [worker] | SPEC-0001 | {title} | {status} | {N} requirements, {M} scenarios |
 
+### Non-Authoritative (excluded)
+- [api] ADR-XXXX: {title} → superseded by ADR-YYYY
+- [worker] SPEC-XXXX: {title} (deprecated)
+
 ### Quick Reference
 - Check for drift: `/sdd:check [target]`
 - Check single module: `/sdd:check --module api [target]`
@@ -135,6 +157,7 @@ Primed session with {N} ADRs and {M} specs matching "{topic}".
 | ID | Title | Status | Relevance |
 |----|-------|--------|-----------|
 | ADR-XXXX | {title} | {status} | {why this matched the topic} |
+| ADR-XXXX | {title} | ⚠ superseded | {why this matched the topic} |
 
 ### Matching Specs
 
@@ -146,6 +169,9 @@ Primed session with {N} ADRs and {M} specs matching "{topic}".
 
 **ADR-XXXX: {title}**
 {2-3 sentence summary of context, decision, and rationale.}
+
+**ADR-XXXX: {title}** ⚠ superseded by ADR-YYYY
+{2-3 sentence summary. Final sentence notes: "This decision was superseded by ADR-YYYY — see the replacement for current guidance."}
 
 **SPEC-XXXX: {title}**
 {2-3 sentence summary of what the spec covers and key requirements.}
@@ -172,3 +198,9 @@ Primed session with {N} ADRs and {M} specs matching "{topic}".
 - In workspace aggregate mode, MUST include the Module column in output tables
 - In workspace aggregate mode, sort by module name first, then by artifact number within each module
 - When `--module` is provided, do NOT prefix artifacts — behave as single-module
+- MUST partition artifacts into authoritative vs non-authoritative per Step 4 — `superseded`, `deprecated`, and `rejected` are non-authoritative; everything else (including missing/empty status) is authoritative
+- MUST exclude non-authoritative artifacts from main tables and the header counts in the unfiltered output paths — they appear only in the "Non-Authoritative (excluded)" footer
+- MUST omit the "Non-Authoritative (excluded)" footer entirely when there are zero excluded artifacts — never render an empty section
+- MUST render superseded artifacts in the footer with a transition link: `ADR-XXXX: {title} → superseded by ADR-YYYY`. If `superseded-by` metadata is missing, render as `ADR-XXXX: {title} (superseded — no replacement recorded)` so the dead-end is visible
+- In topic-filtered mode, MUST surface non-authoritative artifacts that match the topic with a `⚠ {status}` badge in the table and a "superseded by" note in the summary — do NOT silently exclude them, since topic filtering is for historical/investigative use
+- In workspace aggregate mode, MUST prefix non-authoritative footer entries with the module bracket (e.g., `[api] ADR-XXXX: ...`) consistent with main-table prefixing


### PR DESCRIPTION
## Summary

- New ADR-0027 (proposed) — "Non-Authoritative Artifact Filtering in `/sdd:prime`" — explains the problem, options, and decision (filter with callout footer)
- `skills/prime/SKILL.md` partitions scanned ADRs/specs into authoritative vs non-authoritative; `superseded`, `deprecated`, and `rejected` move to a footer section with `superseded-by` transition links
- Topic-filtered mode keeps non-authoritative matches but flags them with a `⚠ {status}` badge so historical investigation still works
- Workspace aggregate mode prefixes footer entries with module brackets to stay consistent with the main tables

## Why

`/sdd:prime` currently treats every ADR and spec equally regardless of status. As a project accumulates superseded decisions, the primed context wastes window space on outdated artifacts and can mislead agents into following replaced guidance. ADR-0027 closes the gap by promoting MADR's existing `status` and `superseded-by` fields into first-class output behavior.

## Out of Scope

- Enforcing `superseded-by` in `/sdd:status` when status changes to `superseded`. ADR-0027 calls this out as follow-up; without it, the footer can render `(superseded — no replacement recorded)` for legacy artifacts.

## Test Plan

- [ ] Run `/sdd:prime` on this repo (which has only authoritative ADRs) — no footer should render
- [ ] Manually flip an ADR to `status: superseded` with `superseded-by: ADR-XXXX`, run `/sdd:prime` — verify it moves to footer with the transition link, header count drops by one
- [ ] Run `/sdd:prime <topic>` on a topic that matches the superseded artifact — verify it appears in matching results with the `⚠ superseded` badge and the summary "superseded by" note
- [ ] Run `/sdd:prime` in workspace aggregate mode with a non-authoritative artifact in one module — verify the module-prefixed footer entry
- [ ] Spot-check that an ADR with `status: deprecated` and no `superseded-by` renders as `(deprecated)` (not as a broken transition link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)