### PR TITLE
docs(v5): qmd prerequisite, /sdd:prime guide update, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to the SDD plugin (`claude-plugin-sdd`) are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/) and the project follows [Semantic Versioning](https://semver.org/).
+
+## [5.0.0] — Unreleased
+
+### Breaking Changes
+
+- **qmd is now a hard runtime dependency.** The plugin's read-side and authoring skills assume [qmd](https://github.com/tobi/qmd) is installed. `/sdd:init` performs a `command -v qmd` preflight check and refuses to set up a project if qmd is absent. Install with `npm install -g @tobilu/qmd` (or `bun install -g @tobilu/qmd`) before upgrading. See [ADR-0024](https://joestump.github.io/claude-plugin-sdd/decisions/0024-qmd-as-hard-dependency) for the full rationale.
+- **Optional/fallback paths removed.** Skills no longer detect qmd at runtime and degrade — they assume qmd is present. Users on v4.x who do not want qmd should pin to the latest v4 release.
+- **First-time embed downloads ~2&nbsp;GB of GGUF models** (EmbeddingGemma 300M, Qwen3-Reranker 0.6B, qmd-query-expansion 1.7B) into `~/.cache/qmd/`. Subsequent runs reuse the cache.
+
+### Added
+
+- **`/sdd:index`**: new skill that creates and maintains per-repo qmd collections (`{repo}-adrs`, `{repo}-specs`, `{repo}-code`, `{repo}-issues`). Runs on demand and is invoked by upgrade flows.
+- **Tracker issues as a fourth qmd collection** ([ADR-0025](https://joestump.github.io/claude-plugin-sdd/decisions/0025-tracker-issues-as-fourth-qmd-collection)): tracker issues sync to `.sdd/issues/` and are indexed alongside ADRs, specs, and code so planning and review skills can find prior work.
+- **Tiered index freshness** ([ADR-0026](https://joestump.github.io/claude-plugin-sdd/decisions/0026-tiered-index-freshness-strategy)): each skill belongs to one of four freshness tiers and refreshes the qmd index accordingly — Tier 1 (post-mutation), Tier 2 (session-start, in `/sdd:prime`), Tier 3 (drift skills), Tier 4 (sprint skills always sync issues on entry, subject to a 5-minute dedup window).
+- **`/sdd:prime` non-authoritative artifact filtering** ([ADR-0027](https://joestump.github.io/claude-plugin-sdd/decisions/0027-non-authoritative-artifact-filtering-in-prime)): ADRs and specs with status `superseded`, `deprecated`, or `rejected` are excluded from the primed context and listed in a footer with `superseded-by` transition links. Topic mode still surfaces them with a `⚠` badge.
+- **qmd-aware authoring skills**: `/sdd:adr`, `/sdd:spec`, and `/sdd:status` now pre-search the artifact corpus before mutating, so users see candidate edges (supersedes, related, extends) and prior decisions on the same topic instead of guessing.
+- **qmd-aware drift skills**: `/sdd:check` and `/sdd:audit` use top-K retrieval per target file/scope, replacing the corpus-wide scan path for substantially better signal on mature repos.
+- **qmd-aware planning and implementation**: `/sdd:plan` and `/sdd:work` retrieve relevant existing code and prior issues before sizing stories or writing implementations, so duplicate work surfaces early.
+- **`/sdd:discover` pre-search**: rules out duplicate decisions before drafting ADR candidates from existing code.
+
+### Changed
+
+- `/sdd:prime` topic mode (`/sdd:prime <topic>`) uses qmd hybrid retrieval rather than reading every artifact and filtering semantically.
+- `/sdd:prime` runs a Tier 2 `qmd update` on entry (cheap mtime scan); skipped if the index was touched within 60 seconds.
+
+### Documentation
+
+- New "Prerequisites" section in [Getting Started](./guides/getting-started) covering qmd installation.
+- `/sdd:prime` command reference updated for v5 behavior. Other skill entries in [Commands](./guides/commands) describe v4 behavior and will be updated in a follow-up doc PR.
+
+### Notes for upgrading
+
+1. Install qmd: `npm install -g @tobilu/qmd`.
+2. Run `/sdd:init` to confirm the preflight passes; CLAUDE.md is rewritten only if needed.
+3. Run `/sdd:index` to build the per-repo collections (this is when the GGUF models download).
+4. Resume normal workflow — every qmd-aware skill now uses retrieval transparently.
+
+If you cannot install qmd, stay on v4.x.
+
+---
+
+## [4.4.1] — 2026-04-30
+
+See git history for v4.x and earlier releases. (CHANGELOG was introduced in v5.0.0.)

--- a/docs-site/content/guides/commands.mdx
+++ b/docs-site/content/guides/commands.mdx
@@ -425,20 +425,23 @@ responses. Run at the start of each session.
 
 **Usage:**
 ```
-/sdd:prime [topic]
+/sdd:prime [topic] [--module <name>]
 ```
 
 **What it does:**
-- Reads all ADRs and specs, summarizes each, and presents them in structured tables
-- With a topic argument, uses semantic matching to load only relevant artifacts
-  (e.g., `/sdd:prime security` loads auth, encryption, and access control ADRs)
-- Read-only — never modifies files
+- **Untargeted mode** (`/sdd:prime`): reads every ADR and spec in the corpus, summarizes each, and presents them in structured tables for a full architecture overview.
+- **Topic mode** (`/sdd:prime <topic>`): uses qmd hybrid retrieval (BM25 + vector + LLM rerank) to fetch the top-K artifacts most relevant to the topic and deep-reads only those candidates. Replaces the v4 "load everything, then filter semantically" path.
+- **Tier 2 session-start refresh** (v5.0.0+): on entry, runs a cheap `qmd update` to catch artifacts changed outside the current session (other developers, CI, branch switches). Skipped if the index was touched within the last 60 seconds. Surfaces a one-line refresh diff in the report header when something changed.
+- **Non-authoritative filtering** (v5.0.0+, ADR-0027): ADRs and specs with status `superseded`, `deprecated`, or `rejected` are excluded from the main tables and listed in a "Non-Authoritative (excluded)" footer with `superseded-by` transition links. The header counts reflect only authoritative artifacts. In topic mode, non-authoritative matches are still surfaced but flagged with a `⚠` badge so historical investigation works.
+- **Workspace mode**: with `--module <name>`, scopes to a single module; otherwise aggregates across all modules in a workspace and prefixes artifact IDs with `[module]` brackets.
+- Read-only — never modifies files (apart from the qmd index refresh in Tier 2).
 
 **Examples:**
 ```
 /sdd:prime
 /sdd:prime authentication
 /sdd:prime deployment
+/sdd:prime --module api
 ```
 
 ---

--- a/docs-site/content/guides/getting-started.mdx
+++ b/docs-site/content/guides/getting-started.mdx
@@ -8,6 +8,22 @@ sidebar_position: 0
 
 The SDD plugin brings architecture governance to Claude Code. It lets you record decisions as ADRs, formalize them into specifications, plan sprints, implement issues in parallel, and validate that your code stays aligned with your architecture -- all without leaving the CLI.
 
+## Prerequisites
+
+Starting with **v5.0.0**, the plugin has a hard runtime dependency on [qmd](https://github.com/tobi/qmd), an on-device hybrid retrieval engine (BM25 + vector + LLM rerank). qmd powers the plugin's smart-context features: topic-filtered priming, drift detection on changed files, and pre-search of related decisions when authoring ADRs and specs.
+
+Install qmd globally before running `/sdd:init`:
+
+```bash
+npm install -g @tobilu/qmd
+# or
+bun install -g @tobilu/qmd
+```
+
+`/sdd:init` runs `command -v qmd` as a preflight check and refuses to set up the project if qmd is missing. The first time qmd embeds a corpus, it auto-downloads its GGUF models (~2&nbsp;GB total) and caches them in `~/.cache/qmd/`. Subsequent embeds and queries reuse the cached models.
+
+If you previously used the plugin at v4.x, qmd was not required — see the [CHANGELOG](https://github.com/joestump/claude-plugin-sdd/blob/main/CHANGELOG.md) for the v5 upgrade notes.
+
 ## Installation
 
 Add the plugin to your project's `.claude/settings.json`:


### PR DESCRIPTION
## Summary

User-facing documentation catching up to the v5 behavior that just landed via SPEC-0019 (and PR #130 once it merges):

- **`docs-site/content/guides/getting-started.mdx`** — new **Prerequisites** section above Installation explaining qmd as a hard runtime dependency, with install commands and a note on the GGUF model auto-download.
- **`docs-site/content/guides/commands.mdx`** — updated `/sdd:prime` entry to describe v5 behavior: qmd-driven topic mode, Tier 2 session-start refresh (ADR-0026), non-authoritative artifact filtering (ADR-0027), and the `--module` flag.
- **`CHANGELOG.md`** — new file with a v5.0.0 (Unreleased) entry enumerating the breaking change, every new qmd-aware skill capability, and step-by-step upgrade notes.

## Why now

SPEC-0019 (qmd-Native Skills) merged earlier today, making qmd a hard runtime dependency. Without these doc updates, anyone upgrading or reading the guides hits stale information: `/sdd:prime` is described as "uses semantic matching to load only relevant artifacts," which is the v4 path; `getting-started.mdx` tells you to install the plugin and immediately run `/sdd:init`, which will now fail without qmd.

## Out of Scope (follow-up)

- Other skill entries in `commands.mdx` (`/sdd:plan`, `/sdd:work`, `/sdd:review`, `/sdd:check`, `/sdd:audit`, `/sdd:discover`, `/sdd:adr`, `/sdd:spec`, `/sdd:status`, `/sdd:enrich`, `/sdd:organize`) still describe v4 behavior. Their qmd-aware updates are tracked separately.
- `workflow.mdx`, `best-practices.mdx`, `plugin-architecture.mdx`, `sprint-planning.mdx` reference the pre-v3 `.claude-plugin-design.json` config name (now `.sdd-docs.json`). Pre-existing staleness, not v5-related — leaving for a doc-cleanup pass.
- `.claude-plugin/plugin.json` version bump to `5.0.0` (the CHANGELOG entry is "Unreleased" until that bump and the release tag).

## Test Plan

- [ ] Build the docs site locally: `cd docs-site && npm run build && npm run serve` — confirm getting-started renders the new Prerequisites section above Installation.
- [ ] Confirm `/sdd:prime` entry in Commands renders the new v5 bullet list correctly (no MDX parse errors on the `&nbsp;` entity).
- [ ] Visit the rendered CHANGELOG link from the Prerequisites section after merge — the link points to `main/CHANGELOG.md` so it'll resolve once this PR lands.
- [ ] Spot-check that no stale "uses semantic matching" copy remains in the `/sdd:prime` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)