### PR TITLE
spec(0020): amend with post-PR chain pattern (ADR-0030)

### DIFF
--- a/docs/openspec/specs/loop-autonomous-mode/design.md
+++ b/docs/openspec/specs/loop-autonomous-mode/design.md
@@ -152,7 +152,7 @@ The line schema is enumerated normatively in spec.md ("Telemetry Schema"). Beyon
 
 - `tracked_prs[]` — one entry per PR the iteration interacted with, capturing `number`, `branch`, `head_sha_at_iteration_start`, `head_sha_at_iteration_end`, and `state_at_end`. These fields exist precisely so the resume contract can reconcile open PRs by SHA equality without external probing, and so `/sdd:review --loop`'s "no new commits since prior iteration" check has typed inputs rather than out-of-band signals.
 - `active_worktrees[]` — one entry per worktree left on disk (successful or failed), capturing `path`, `branch`, and `head_sha`. Failed-issue worktrees are preserved per `skills/work/SKILL.md` Rules; recording them in history lets resume report them without scanning the filesystem.
-- `chain_invoked` (bool), `review_outcome` (one of `"approve"`, `"changes-requested"`, `"needs-human"`), and `autofix_pr_invoked` (bool) — typed inputs for the post-PR chain pattern (per spec.md "Chain Outcome Telemetry"). When `--no-chain` is set, only `chain_invoked: false` is recorded; the other two fields are omitted. These fields let post-mortems correlate cost spikes with chain invocations and confirm that ADR-0010's one-round invariant held across the chain.
+- `chain_invoked` (bool), `review_outcome` (one of `"approve"`, `"changes-requested"`, `"needs-human"`, `"errored"`), `autofix_pr_invoked` (bool), and `autofix_pr_invocation_status` (one of `"accepted"`, `"unavailable"`, `"errored"`) — typed inputs for the post-PR chain pattern (per spec.md "Chain Outcome Telemetry"). When `--no-chain` is set, only `chain_invoked: false` is recorded; the other three fields are omitted. These fields let post-mortems correlate cost spikes with chain invocations, distinguish a `/autofix-pr` invocation that the Claude Code build accepted from one that was unavailable or errored, and confirm that ADR-0010's one-round invariant held across the chain.
 
 `comments_pushed` counts BOTH top-level review comments AND reply-to-comment messages — both consume tracker API rate limits and represent loop-driven activity, so a single counter that conflates the two is the faithful spend proxy in single-PR review mode (where `prs_touched` is informational and `comments_pushed`/`merges_attempted` carry the meaningful signal).
 
@@ -174,6 +174,7 @@ A canonical example line:
   "chain_invoked": true,
   "review_outcome": "approve",
   "autofix_pr_invoked": true,
+  "autofix_pr_invocation_status": "accepted",
   "gates": [],
   "stop_conditions_fired": []
 }

--- a/docs/openspec/specs/loop-autonomous-mode/design.md
+++ b/docs/openspec/specs/loop-autonomous-mode/design.md
@@ -152,6 +152,7 @@ The line schema is enumerated normatively in spec.md ("Telemetry Schema"). Beyon
 
 - `tracked_prs[]` — one entry per PR the iteration interacted with, capturing `number`, `branch`, `head_sha_at_iteration_start`, `head_sha_at_iteration_end`, and `state_at_end`. These fields exist precisely so the resume contract can reconcile open PRs by SHA equality without external probing, and so `/sdd:review --loop`'s "no new commits since prior iteration" check has typed inputs rather than out-of-band signals.
 - `active_worktrees[]` — one entry per worktree left on disk (successful or failed), capturing `path`, `branch`, and `head_sha`. Failed-issue worktrees are preserved per `skills/work/SKILL.md` Rules; recording them in history lets resume report them without scanning the filesystem.
+- `chain_invoked` (bool), `review_outcome` (one of `"approve"`, `"changes-requested"`, `"needs-human"`), and `autofix_pr_invoked` (bool) — typed inputs for the post-PR chain pattern (per spec.md "Chain Outcome Telemetry"). When `--no-chain` is set, only `chain_invoked: false` is recorded; the other two fields are omitted. These fields let post-mortems correlate cost spikes with chain invocations and confirm that ADR-0010's one-round invariant held across the chain.
 
 `comments_pushed` counts BOTH top-level review comments AND reply-to-comment messages — both consume tracker API rate limits and represent loop-driven activity, so a single counter that conflates the two is the faithful spend proxy in single-PR review mode (where `prs_touched` is informational and `comments_pushed`/`merges_attempted` carry the meaningful signal).
 
@@ -170,6 +171,9 @@ A canonical example line:
   "active_worktrees": [
     {"path": ".sdd/worktrees/feature-123-foo", "branch": "feature/123-foo", "head_sha": "def5678"}
   ],
+  "chain_invoked": true,
+  "review_outcome": "approve",
+  "autofix_pr_invoked": true,
   "gates": [],
   "stop_conditions_fired": []
 }
@@ -281,6 +285,46 @@ State machine: `qmd_failures_consecutive` is incremented when a tick exits with 
 
 All six gates are re-evaluated on every tick. There is no debounce.
 
+## Post-PR Chain Pattern
+
+After `/sdd:work` opens a PR, the loop hands the PR off through a two-stage chain: a *bounded* architectural review pass (`/sdd:review`, exactly one round per ADR-0010), followed by an *open-ended* CI/maintenance monitoring pass (`/autofix-pr`, the Claude Code built-in that watches CI and applies straightforward fixes over time). The chain is unconditional within the iteration unless the user passes `--no-chain`. ADR-0030 is the governing decision; the spec.md requirements "Post-PR Chain Invocation" and "Chain Outcome Telemetry" are its normative form.
+
+### Sequence
+
+```mermaid
+sequenceDiagram
+  participant W as /sdd:work
+  participant GH as Tracker / GitHub
+  participant R as /sdd:review
+  participant A as /autofix-pr
+
+  W->>GH: Open PR #X
+  alt --no-chain
+    W-->>W: record chain_invoked=false; exit
+  else chain enabled (default)
+    alt /autofix-pr available
+      W->>R: invoke /sdd:review X (one round per ADR-0010)
+      R-->>W: review_outcome ∈ {approve, changes-requested, needs-human}
+      W->>A: invoke /autofix-pr X
+      A-->>W: handed off (continues monitoring CI)
+      W-->>W: record chain_invoked=true, review_outcome=…, autofix_pr_invoked=true; exit
+    else /autofix-pr unavailable
+      W->>GH: open tracker issue tagged claude-code-version-required
+      W-->>W: log warning; record chain_invoked=true, autofix_pr_invoked=false; exit cleanly
+    end
+  end
+```
+
+The diagram captures the two failure-mode branches: `--no-chain` (skip both follow-ups) and `/autofix-pr` unavailability (record the version requirement as a tracker issue, keep the PR, exit cleanly). PR creation itself is never blocked by chain failures.
+
+### Cost accounting
+
+Each chain invocation is metered by its own tool's cost surface. `/sdd:work` does NOT double-count `/sdd:review`'s tokens or `/autofix-pr`'s tokens against its own budget; those costs accrue under the invoked command's accounting. What `/sdd:work` does record in `history.jsonl` is the *event* of invocation (`chain_invoked`, `review_outcome`, `autofix_pr_invoked`) so users correlating cost spikes after the fact can map them back to the iteration that opened the PR. The chain is therefore visible in telemetry as an event but not as a token line item — consistent with how nested skill invocations are billed elsewhere in the plugin.
+
+### Interaction with --loop
+
+Each loop iteration runs a self-contained chain per PR. ADR-0028's gates (backlog drift, ambiguous criteria, budget escalation, post-feedback merge, force-unlock, repeated failure) fire BEFORE the chain — they decide whether to start a new iteration at all. Once an iteration begins and opens a PR, the chain is unconditional within that iteration unless `--no-chain` is set. There is no per-PR gate that interposes between PR creation and `/sdd:review`; the architectural review is the bounded round (ADR-0010), and the post-feedback-merge gate is the only human-mediated checkpoint that can pause the chain's eventual merge path. This preserves ADR-0028's iteration mechanics (gates as iteration-entry decisions) while keeping ADR-0010's one-round invariant intact across the chain.
+
 ## Tradeoffs
 
 - **Chattiness vs. autonomy.** Six gates can prompt several times per long run. The deliberate stance: chatty is the conservative default. Users who want quieter autonomy lower budgets so the loop ends sooner, rather than the plugin relaxing gates. Debouncing gates across iterations would be the obvious "less chatty" lever; the explicit choice not to debounce is documented here so a future contributor doesn't quietly add it.
@@ -320,6 +364,7 @@ These do not block this spec but should be tracked:
 ## More Information
 
 - ADR-0028 — the governing decision record this spec realizes.
+- ADR-0030 — the post-PR chain pattern (`/sdd:work` → `/sdd:review` → `/autofix-pr`) realized by this spec's "Post-PR Chain Invocation" and "Chain Outcome Telemetry" requirements.
 - ADR-0010 / SPEC-0009 — the bounded-iteration invariant per PR that this spec preserves under loop wrapping.
 - ADR-0017 / SPEC-0015 — the parallel-agent coordination semantics whose worktree and lockfile interactions this spec respects (in particular, the worktree-preservation rule that is the reason PID liveness is the sole staleness signal).
 - ADR-0024 / SPEC-0019 — the qmd hard-dependency contract that condition #11 cites for the remediation message.

--- a/docs/openspec/specs/loop-autonomous-mode/spec.md
+++ b/docs/openspec/specs/loop-autonomous-mode/spec.md
@@ -393,7 +393,7 @@ Each iteration MUST emit a stdout status block (visible in the session) summariz
 
 `active_worktrees` MUST be an array of objects, one per worktree the iteration left on disk (whether successful or failed). Each object MUST include at minimum: `path` (string, absolute or repo-relative path to the worktree), `branch` (string, the branch checked out in the worktree), and `head_sha` (string, the worktree branch's HEAD SHA at iteration exit). The array MUST include failed-issue worktrees so the resume contract can re-attach or report them without external probing.
 
-The line schema MUST also include the post-PR chain fields defined under "Chain Outcome Telemetry" (`chain_invoked`, `review_outcome`, `autofix_pr_invoked`), with the values and conditional-presence rules specified there.
+The line schema MUST also include the post-PR chain fields defined under "Chain Outcome Telemetry" (`chain_invoked`, `review_outcome`, `autofix_pr_invoked`, `autofix_pr_invocation_status`), with the values and conditional-presence rules specified there.
 
 The `history.jsonl` file MUST be treated as containing potentially-sensitive content. It is written under `.sdd/loop/` (covered by the `.sdd/` gitignore entry from SPEC-0019). The file MUST NOT be uploaded to telemetry without explicit user opt-in. Where a project declares a `### Loop Logging` block in CLAUDE.md with redaction patterns, the skill SHOULD apply those patterns before writing. Where no such block exists, the file MUST be documented as treat-as-secret in the same class as `.env` and tracker tokens.
 
@@ -476,7 +476,9 @@ Governing: ADR-0030.
 
 WHEN `/sdd:work` opens a PR for an issue THEN `/sdd:work` MUST invoke `/sdd:review` on that PR before exiting, unless the user passed `--no-chain`.
 
-WHEN `/sdd:review` exits (regardless of approval state) THEN `/sdd:work` MUST invoke `/autofix-pr` on the same PR before exiting, unless the user passed `--no-chain`.
+WHEN `/sdd:review` exits with `review_outcome: "errored"` (qmd unreachable or other infrastructure failure) THEN `/sdd:work` MUST NOT invoke `/autofix-pr`, MUST add the `chain-failed-pre-autofix` label to the PR, and MUST emit telemetry with `autofix_pr_invoked: false` and `autofix_pr_invocation_status` absent.
+
+WHEN `/sdd:review` exits with any healthy outcome (`"approve"`, `"changes-requested"`, `"needs-human"`) THEN `/sdd:work` MUST invoke `/autofix-pr` on the same PR before exiting, unless the user passed `--no-chain`.
 
 WHEN `/autofix-pr` is unavailable (the Claude Code build does not ship the command) THEN `/sdd:work` MUST log a warning, MUST open a tracker issue tagged `claude-code-version-required` describing the version requirement, and MUST exit cleanly without blocking PR creation.
 
@@ -495,24 +497,29 @@ WHEN `/autofix-pr` is unavailable (the Claude Code build does not ship the comma
 - **WHEN** `/autofix-pr` is not available in the current Claude Code build
 - **THEN** `/sdd:work` MUST log a warning, MUST open a tracker issue with the `claude-code-version-required` label naming the missing command and required version, and MUST exit cleanly without blocking PR creation
 
+#### Scenario: /sdd:review errors on qmd unreachability
+
+- **WHEN** `/sdd:review` exits with `review_outcome: "errored"` because qmd is unreachable (or another infrastructure failure)
+- **THEN** `/sdd:work` MUST skip the `/autofix-pr` invocation, MUST add the `chain-failed-pre-autofix` label to the PR, and MUST emit telemetry with `autofix_pr_invoked: false` and `autofix_pr_invocation_status` absent per "Chain Outcome Telemetry"
+
 ### Requirement: Chain Outcome Telemetry
 
 Governing: ADR-0028, ADR-0030.
 
-WHEN `/sdd:work` invokes the post-PR chain THEN the per-iteration entry in `history.jsonl` MUST include `chain_invoked: true|false`, `review_outcome` (one of `"approve"`, `"changes-requested"`, `"needs-human"`), and `autofix_pr_invoked: true|false`.
+WHEN `/sdd:work` invokes the post-PR chain THEN the per-iteration entry in `history.jsonl` MUST include `chain_invoked: true|false`, `review_outcome` (one of `"approve"`, `"changes-requested"`, `"needs-human"`, `"errored"`), `autofix_pr_invoked: true|false`, and `autofix_pr_invocation_status` (one of `"accepted"`, `"unavailable"`, `"errored"`).
 
-WHEN `--no-chain` is set THEN the per-iteration entry MUST record `chain_invoked: false` and MUST omit the `review_outcome` and `autofix_pr_invoked` fields.
+WHEN `--no-chain` is set THEN the per-iteration entry MUST record `chain_invoked: false` and MUST omit the `review_outcome`, `autofix_pr_invoked`, and `autofix_pr_invocation_status` fields.
 
-#### Scenario: Chain runs to completion and all three fields are recorded
+#### Scenario: Chain runs to completion and all four fields are recorded
 
-- **WHEN** PR #X is created and the chain runs to completion (`/sdd:review` returns `approve` and `/autofix-pr` is invoked)
-- **THEN** the iteration's `history.jsonl` line MUST record `chain_invoked: true`, `review_outcome: "approve"`, and `autofix_pr_invoked: true`
+- **WHEN** PR #X is created and the chain runs to completion (`/sdd:review` returns `approve` and `/autofix-pr` is invoked and accepted)
+- **THEN** the iteration's `history.jsonl` line MUST record `chain_invoked: true`, `review_outcome: "approve"`, `autofix_pr_invoked: true`, and `autofix_pr_invocation_status: "accepted"`
 
 #### Scenario: --no-chain omits the per-stage fields
 
 - **WHEN** `--no-chain` is set on the iteration that opens PR #X
 - **THEN** the iteration's `history.jsonl` line MUST record `chain_invoked: false`
-- **AND** MUST NOT include `review_outcome` or `autofix_pr_invoked`
+- **AND** MUST NOT include `review_outcome`, `autofix_pr_invoked`, or `autofix_pr_invocation_status`
 
 ### Requirement: ADR-0010 Bounded-Iteration Preservation
 

--- a/docs/openspec/specs/loop-autonomous-mode/spec.md
+++ b/docs/openspec/specs/loop-autonomous-mode/spec.md
@@ -10,7 +10,7 @@ extends: [SPEC-0009]
 
 ## Overview
 
-Defines how `/sdd:work` and `/sdd:review` cooperate with the runtime `/loop` skill so users can grind a backlog (or watch a single PR) autonomously without losing the user-in-the-loop preference. The contract is opt-in via a `--loop` flag on each skill: the runtime re-invokes the skill, and the skill enforces stop conditions, concurrency, user-prompt gates, budget ceilings, and inter-iteration telemetry. `/loop` itself is unchanged.
+Defines how `/sdd:work` and `/sdd:review` cooperate with the runtime `/loop` skill so users can grind a backlog (or watch a single PR) autonomously without losing the user-in-the-loop preference. The contract is opt-in via a `--loop` flag on each skill: the runtime re-invokes the skill, and the skill enforces stop conditions, concurrency, user-prompt gates, budget ceilings, and inter-iteration telemetry. `/loop` itself is unchanged. In addition to the loop iteration mechanics, this spec governs the post-PR chain pattern that hands off PR follow-up from `/sdd:work` to `/sdd:review` (one architectural round) and then to `/autofix-pr` (Claude Code built-in for ongoing CI/maintenance), per ADR-0030.
 
 This spec realizes ADR-0028 by translating its sub-decisions into RFC 2119 requirements. It covers the CLI surface for both skills, the twelve stop conditions (iteration / PR / wall-clock / dollar budgets, repeated failure, dependency cycle, user interrupt, lockfile contention, qmd-unreachable, and prior-gate stop), the lock-and-skip concurrency model with PID liveness as the sole staleness signal, the six `AskUserQuestion` gates (backlog drift, ambiguous criteria, budget escalation, post-feedback merge, force-unlock, repeated failure), the on-disk artifacts (`.sdd/loop/{skill}.lock`, `.budget.json`, `.history.jsonl`), the resume contract for crash recovery, and the single-PR `/sdd:review --loop --pr <N>` watch mode.
 
@@ -393,6 +393,8 @@ Each iteration MUST emit a stdout status block (visible in the session) summariz
 
 `active_worktrees` MUST be an array of objects, one per worktree the iteration left on disk (whether successful or failed). Each object MUST include at minimum: `path` (string, absolute or repo-relative path to the worktree), `branch` (string, the branch checked out in the worktree), and `head_sha` (string, the worktree branch's HEAD SHA at iteration exit). The array MUST include failed-issue worktrees so the resume contract can re-attach or report them without external probing.
 
+The line schema MUST also include the post-PR chain fields defined under "Chain Outcome Telemetry" (`chain_invoked`, `review_outcome`, `autofix_pr_invoked`), with the values and conditional-presence rules specified there.
+
 The `history.jsonl` file MUST be treated as containing potentially-sensitive content. It is written under `.sdd/loop/` (covered by the `.sdd/` gitignore entry from SPEC-0019). The file MUST NOT be uploaded to telemetry without explicit user opt-in. Where a project declares a `### Loop Logging` block in CLAUDE.md with redaction patterns, the skill SHOULD apply those patterns before writing. Where no such block exists, the file MUST be documented as treat-as-secret in the same class as `.env` and tracker tokens.
 
 #### Scenario: Gate invocation is captured verbatim
@@ -467,6 +469,50 @@ For each entry in `active_worktrees`, the skill MUST verify the worktree exists 
 - **WHEN** the budget-escalation gate fires in single-PR mode and `max_iterations`, `max_minutes`, and `max_dollars` are all near 80%
 - **THEN** the gate prompt MUST list those three dimensions only
 - **AND** MUST NOT mention `prs_touched`
+
+### Requirement: Post-PR Chain Invocation
+
+Governing: ADR-0030.
+
+WHEN `/sdd:work` opens a PR for an issue THEN `/sdd:work` MUST invoke `/sdd:review` on that PR before exiting, unless the user passed `--no-chain`.
+
+WHEN `/sdd:review` exits (regardless of approval state) THEN `/sdd:work` MUST invoke `/autofix-pr` on the same PR before exiting, unless the user passed `--no-chain`.
+
+WHEN `/autofix-pr` is unavailable (the Claude Code build does not ship the command) THEN `/sdd:work` MUST log a warning, MUST open a tracker issue tagged `claude-code-version-required` describing the version requirement, and MUST exit cleanly without blocking PR creation.
+
+#### Scenario: Chain runs to completion after PR creation
+
+- **WHEN** `/sdd:work` creates PR #X
+- **THEN** it MUST invoke `/sdd:review X` and, after `/sdd:review` exits, MUST invoke `/autofix-pr X` before exiting
+
+#### Scenario: --no-chain suppresses both follow-ups
+
+- **WHEN** the user passes `--no-chain` and `/sdd:work` opens a PR
+- **THEN** `/sdd:work` MUST exit after PR creation without invoking `/sdd:review` or `/autofix-pr`
+
+#### Scenario: /autofix-pr is unavailable in this Claude Code build
+
+- **WHEN** `/autofix-pr` is not available in the current Claude Code build
+- **THEN** `/sdd:work` MUST log a warning, MUST open a tracker issue with the `claude-code-version-required` label naming the missing command and required version, and MUST exit cleanly without blocking PR creation
+
+### Requirement: Chain Outcome Telemetry
+
+Governing: ADR-0028, ADR-0030.
+
+WHEN `/sdd:work` invokes the post-PR chain THEN the per-iteration entry in `history.jsonl` MUST include `chain_invoked: true|false`, `review_outcome` (one of `"approve"`, `"changes-requested"`, `"needs-human"`), and `autofix_pr_invoked: true|false`.
+
+WHEN `--no-chain` is set THEN the per-iteration entry MUST record `chain_invoked: false` and MUST omit the `review_outcome` and `autofix_pr_invoked` fields.
+
+#### Scenario: Chain runs to completion and all three fields are recorded
+
+- **WHEN** PR #X is created and the chain runs to completion (`/sdd:review` returns `approve` and `/autofix-pr` is invoked)
+- **THEN** the iteration's `history.jsonl` line MUST record `chain_invoked: true`, `review_outcome: "approve"`, and `autofix_pr_invoked: true`
+
+#### Scenario: --no-chain omits the per-stage fields
+
+- **WHEN** `--no-chain` is set on the iteration that opens PR #X
+- **THEN** the iteration's `history.jsonl` line MUST record `chain_invoked: false`
+- **AND** MUST NOT include `review_outcome` or `autofix_pr_invoked`
 
 ### Requirement: ADR-0010 Bounded-Iteration Preservation
 


### PR DESCRIPTION
## Summary

Amends SPEC-0020 (Loop Autonomous Mode) with the post-PR chain pattern formalized in ADR-0030 (peer PR in flight):

- **2 new requirements** — \"Post-PR Chain Invocation\" (chain semantics, `--no-chain` opt-out, `/autofix-pr` unavailability fallback) and \"Chain Outcome Telemetry\" (`chain_invoked`, `review_outcome`, `autofix_pr_invoked` fields on each `history.jsonl` line).
- **5 new scenarios** across the two REQs covering the happy path, `--no-chain`, the unavailable-command fallback, the recorded telemetry, and the omitted-fields case.
- **1 new design.md section** (\"Post-PR Chain Pattern\") with a mermaid sequence diagram, cost-accounting paragraph (per-tool metering, no double-counting), and `--loop` interaction paragraph (gates fire BEFORE the chain).
- **history.jsonl schema** updated in both spec.md (Telemetry Schema REQ) and design.md (schema bullet + canonical example) to include the three new fields.
- **Overview** updated with one sentence noting that the spec now governs the chain pattern in addition to loop iteration mechanics.

## Why now

ADR-0030 is the governing decision for the chain pattern (peer agent's PR in flight). SPEC-0020 needs the normative form so implementers have RFC 2119 requirements to test against. The amendment is internal to SPEC-0020 — no new dependency edges in the spec frontmatter.

## Dependency note

This PR's body cites ADR-0030, which a peer agent is drafting in parallel. This amendment assumes ADR-0030 will land before or with this PR. Reviewers can choose merge order; the spec text references ADR-0030 by number only and does not link to specific sub-decisions, so it remains coherent regardless of merge sequencing.

## Test plan

- [ ] Review for RFC 2119 compliance on the two new REQs (MUST / MUST NOT used consistently; WHEN/THEN scenarios well-formed).
- [ ] Verify internal consistency between spec.md and design.md (schema fields match in both places; canonical example line includes the three new fields; cost-accounting and `--loop` interaction prose aligns with the REQ language).
- [ ] Confirm alignment with ADR-0030 sub-decisions (one-round invariant preserved per ADR-0010; unavailability fallback opens a tracker issue with the agreed label; `--no-chain` semantics match).
- [ ] Confirm the new section does not contradict existing requirements (\"ADR-0010 Bounded-Iteration Preservation\" still holds; existing telemetry REQ now correctly references the new fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)