### PR TITLE
feat(work): wire /sdd:work --loop with stop conditions, gates, qmd-unreachable detection

### DIFF
--- a/evals/triggers/work.json
+++ b/evals/triggers/work.json
@@ -9,6 +9,11 @@
   {"query": "implement the highest-priority issue and open a PR when done", "should_trigger": true},
   {"query": "pick up the next planned story and code it up", "should_trigger": true},
   {"query": "fan out work across multiple SPEC-0017 stories using worktrees", "should_trigger": true},
+  {"query": "/loop /sdd:work --loop", "should_trigger": true},
+  {"query": "grind down the backlog autonomously", "should_trigger": true},
+  {"query": "/sdd:work --loop --max-iterations 10 --max-prs 5", "should_trigger": true},
+  {"query": "resume the loop after the crash with --resume", "should_trigger": true},
+  {"query": "open the PR and run /sdd:review then /autofix-pr automatically", "should_trigger": true},
 
   {"query": "what's a git worktree?", "should_trigger": false},
   {"query": "review the existing PRs", "should_trigger": false},
@@ -19,5 +24,7 @@
   {"query": "list the open issues on this repo", "should_trigger": false},
   {"query": "audit the codebase against our specs", "should_trigger": false},
   {"query": "let's work on the design before coding anything", "should_trigger": false},
-  {"query": "make this code work — it's throwing an error", "should_trigger": false}
+  {"query": "make this code work — it's throwing an error", "should_trigger": false},
+  {"query": "what is /loop?", "should_trigger": false},
+  {"query": "explain how /sdd:work --loop differs from /sdd:work", "should_trigger": false}
 ]

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -4,7 +4,7 @@
 name: work
 description: Pick up tracker issues and implement them in parallel using git worktrees. Use when the user says "work on issues", "implement the spec", "start coding", or wants agents to build from planned issues.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, WebFetch, WebSearch, TeamCreate, TeamDelete, TaskCreate, TaskUpdate, TaskList, TaskGet, SendMessage, AskUserQuestion, ToolSearch, EnterWorktree
-argument-hint: [SPEC-XXXX | issue numbers | (empty = propose from backlog)] [--max-agents N] [--draft] [--dry-run] [--no-tests] [--module <name>]
+argument-hint: [SPEC-XXXX | issue numbers | (empty = propose from backlog)] [--max-agents N] [--draft] [--dry-run] [--no-tests] [--module <name>] [--loop [--max-iterations N] [--max-prs N] [--max-minutes N] [--max-dollars N] [--lock={skip|wait|force}] [--resume] [--budget-file PATH]] [--no-chain]
 ---
 
 <!-- Governing: ADR-0015 (Markdown-Native Configuration), SPEC-0014 REQ "Config Resolution Pattern" -->
@@ -597,3 +597,143 @@ You are picking up tracker issues and implementing them in parallel using git wo
 - **v5.0.0+**: MUST trigger Tier 4 issues sync on entry per Step 3c — sync from tracker before Step 4 issue discovery, subject to 5-min dedup. On failure, fall back to live queries with a warning, never block (Governing: ADR-0026, SPEC-0019 REQ "Tier 4 Always-Sync Issues for Sprint Skills")
 - **v5.0.0+**: Workers MUST run qmd-aware code pre-search per worker Step 3a before writing any new helper/type/struct/interface — qmd-search `{repo}-code` for matches; if found above threshold (minScore 0.4), MUST import the existing implementation and broadcast `TYPE_IMPORTED` rather than recreate (Governing: ADR-0024, SPEC-0019 REQ "qmd-Smart Sprint Skills")
 - **v5.0.0+**: Lead MUST trigger Tier 1 update of `{repo}-code` after detecting a PR merge per Step 11 — best-effort, silent on success, one-line warning on failure (Governing: ADR-0026, SPEC-0019 REQ "Tier 1 Mutation-Aware Updates")
+
+## Loop Mode (autonomous)
+
+<!-- Governing: ADR-0028 (/loop Autonomous Mode for /sdd:work and /sdd:review), SPEC-0020 REQ "Loop Mode Opt-In", REQ "CLI Surface for Loop Controls", REQ "Backlog-Empty Stop", REQ "Iteration Budget Stop", REQ "PR-Touch Budget Stop", REQ "Wall-Clock Budget Stop", REQ "Repeated-Failure Stop", REQ "Dependency-Cycle Stop", REQ "User Interrupt Stop", REQ "Lockfile Contention Skip", REQ "Prior-Gate-Stop Honor", REQ "qmd-Unreachable Stop", REQ "Cost Budget Stop", REQ "Concurrency Invariants for /sdd:work", REQ "Backlog-Drift Gate", REQ "Ambiguous-Acceptance-Criteria Gate", REQ "Budget-Escalation Gate", REQ "Force-Unlock Gate", REQ "Repeated-Failure Gate", REQ "Gates Are Not Debounced Across Iterations", REQ "Final Report on Stop" -->
+
+When `/sdd:work` is invoked under `/loop` with the `--loop` flag (e.g. `/loop /sdd:work --loop`), the skill enters autonomous-mode and follows the contract below on every tick. Without `--loop`, the skill behaves exactly as the rest of this document specifies and creates **no** `.sdd/loop/` artifacts (per SPEC-0020 REQ "Loop Mode Opt-In").
+
+The runtime `/loop` skill is unchanged. `--loop` is a skill-side opt-in. `/loop` schedules ticks; everything inside a tick is the wrapped skill's concern.
+
+### CLI surface
+
+When `--loop` is set, `/sdd:work` accepts the following additional flags. All are optional with the documented conservative defaults (per SPEC-0020 REQ "CLI Surface for Loop Controls"). Budgets are inclusive **across the entire loop run**, not per-iteration.
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--loop` | off | Opt into autonomous-mode |
+| `--max-iterations N` | 5 | Iteration ceiling across the run |
+| `--max-prs N` | 20 | Distinct-PR ceiling across the run |
+| `--max-minutes N` | 60 | Wall-clock ceiling across the run |
+| `--max-dollars N` | 25 | Dollar-cost ceiling; `0` disables condition #12 (estimate still tracked) |
+| `--lock={skip\|wait\|force}` | `skip` | Concurrency mode on lockfile contention |
+| `--resume` | off | Recover state from the most recent `history.jsonl` line |
+| `--budget-file PATH` | `.sdd/loop/work.budget.json` | Override the budget-file location |
+| `--no-chain` | off | Skip the post-PR chain (`/sdd:review` + `/autofix-pr`); restores legacy "open PR, stop" behavior. See "Post-PR Chain" below. |
+
+The first write of `budget.json` records the active ceilings (per `references/loop-primitives.md` § First-write rule) so a later `--resume` cannot silently widen them.
+
+### Per-tick flow
+
+Each tick follows this canonical flow (control flow diagram in `docs/openspec/specs/loop-autonomous-mode/design.md`):
+
+1. **Acquire lockfile** at `.sdd/loop/work.lock` per `references/loop-primitives.md` § Acquisition flow (skip / wait / force per `--lock`).
+2. **Read budget** from `.sdd/loop/work.budget.json`; on first write, initialize ceilings, `started_at`, and `rate_table_source` (per `references/loop-primitives.md` § First-write rule).
+3. **Evaluate stop conditions on entry** (see "Stop conditions" below). Any matching condition halts the loop, emits the final report, and releases the lockfile.
+4. **Run the gate block** (see "AskUserQuestion Gates" below). Any gate answered `stop` halts the loop.
+5. **Run the iteration body** — discover workable issues per Step 4 of the main flow above (skipping issues labeled `in-progress` per "Concurrency invariants"), dispatch workers, open PRs.
+6. **For each PR opened in this iteration**, invoke the post-PR chain per "Post-PR Chain" below (unless `--no-chain` or `--dry-run`).
+7. **Update budget** — increment `iterations_used`, union `prs_touched`, accumulate `tokens_in`/`tokens_out`/`agents_dispatched`, recompute `dollars_estimate`, evaluate exit-time stop conditions 3 / 4 / 5 / 12.
+8. **Emit telemetry** — append a line to `.sdd/loop/work.history.jsonl` (per `references/loop-telemetry.md`) and emit the stdout status block.
+9. **Release lockfile** and let `/loop` schedule the next tick.
+
+### Stop conditions
+
+The loop halts on any matching condition. The cause is recorded in `stop_conditions_fired[]` of the final history line.
+
+| # | Condition | Behavior |
+|---|-----------|----------|
+| 1 | Backlog empty (no unblocked, unworked, in-scope issues on entry) | Final report names empty queue; release lock; do NOT signal another tick (SPEC-0020 REQ "Backlog-Empty Stop") |
+| 3 | `iterations_used >= max_iterations` (entry-time check) | `stop_conditions_fired: ["iteration_budget"]` (SPEC-0020 REQ "Iteration Budget Stop") |
+| 4 | `len(prs_touched) >= max_prs` (deduplicated set; entry-time + after each PR open) | `stop_conditions_fired: ["prs_touched_budget"]` (SPEC-0020 REQ "PR-Touch Budget Stop") |
+| 5 | `minutes_elapsed >= max_minutes` (clock anchored at `started_at`, persists across `--resume`) | `stop_conditions_fired: ["wall_clock_budget"]` (SPEC-0020 REQ "Wall-Clock Budget Stop") |
+| 6 | Same issue/PR failed twice consecutively with the same root cause | Fire the **Repeated-Failure** gate (does NOT silently halt) (SPEC-0020 REQ "Repeated-Failure Stop") |
+| 7 | Issue-dependency analysis (per SPEC-0015 Layer 2) detects a cycle | Halt and surface the cycle's edges; do NOT attempt automatic break (SPEC-0020 REQ "Dependency-Cycle Stop") |
+| 8 | User interrupt (Ctrl-C / session close / explicit `/loop stop`) | Drain in-flight workers (no new dispatch), release lock, emit final report, no half-states (SPEC-0020 REQ "User Interrupt Stop") |
+| 9 | Lockfile holds a live PID under `--lock=skip` | Emit one-line skip note; do NOT increment counters (SPEC-0020 REQ "Lockfile Contention Skip"). `--lock=wait` blocks bounded by `max_minutes`; `--lock=force` fires the Force-Unlock gate. |
+| 10 | Any prior `gates[]` entry recorded `answer == "stop"` | "Loop already stopped at gate {name} in iteration {N}"; release lock; do NOT increment counters (SPEC-0020 REQ "Prior-Gate-Stop Honor") |
+| 11 | qmd unreachable for **2 consecutive** iterations | Halt with the ADR-0024 remediation message; the wrapped skill signals via stderr token `qmd-unreachable` OR exit code `EX_QMD_UNREACHABLE=78`; any successful iteration resets `qmd_failures_consecutive` to 0 (SPEC-0020 REQ "qmd-Unreachable Stop") |
+| 12 | `dollars_estimate >= max_dollars` (and `max_dollars > 0`) | "Cost budget reached: $X / $Y"; `--max-dollars 0` disables the stop but `dollars_estimate` is still tracked (SPEC-0020 REQ "Cost Budget Stop") |
+
+Condition #2 (terminal PR state) does NOT apply to `/sdd:work` — it is a `/sdd:review --loop --pr <N>` condition.
+
+### qmd-unreachable detection protocol
+
+The wrapped skill signals qmd-unreachable using either of these signals (per SPEC-0020 REQ "qmd-Unreachable Stop"):
+
+1. **Stderr sentinel**: a line on stderr containing the literal token `qmd-unreachable` (per `references/qmd-helpers.md` § "Error Handling")
+2. **Reserved exit code**: `EX_QMD_UNREACHABLE = 78` (matches BSD `sysexits.h` `EX_CONFIG`)
+
+The loop reads exit status first; on non-zero, scans stderr for the sentinel as a fallback. Either signal is sufficient. On detection, increment `qmd_failures_consecutive`. On any successful iteration, reset to 0. On increment to 2, condition #11 trips.
+
+### AskUserQuestion gates
+
+All gates are re-evaluated **on every tick** (per SPEC-0020 REQ "Gates Are Not Debounced Across Iterations") — the skill MUST NOT cache or reuse a prior iteration's answer to suppress a current iteration's gate. Each invocation is captured verbatim in the iteration's `gates[]` array per `references/loop-telemetry.md`.
+
+| Gate | Trigger | Prompt template | Options |
+|------|---------|-----------------|---------|
+| **Backlog Drift** | Unblocked-issue snapshot differs from the prior iteration's recorded snapshot | "Backlog changed since last iteration. Re-propose the next batch?" | `re-propose`, `continue`, `stop` |
+| **Ambiguous Criteria** | Issue lacks `### Acceptance Criteria` OR section contains TBD/TODO markers | "Issue #{N} has ambiguous criteria. Skip, escalate, or proceed with my best interpretation?" | `skip`, `escalate`, `proceed`, `stop` |
+| **Budget Escalation (80%)** | One or more active budgets cross 80% on this tick | "Approaching {budget(s)} ({used}/{total} each). Continue, raise ceiling(s), or stop?" — combined into a single prompt across all simultaneously-tripped budgets | `continue`, `raise`, `stop` |
+| **Force-Unlock** | `--lock=force` AND lockfile is present | "Force-unlock previous iteration's lock? This may corrupt in-flight work." | `yes`, `no`, `stop` |
+| **Repeated Failure** | Same issue/PR failed in two consecutive iterations with the same root cause | "Issue/PR #{N} failed twice with: {root-cause}. Skip, retry once more, or stop the loop?" | `skip`, `retry`, `stop` |
+| **Resume-Divergence** (resume only) | A `tracked_prs[]` entry's `head_sha_at_iteration_end` does not match the live remote HEAD | "PR #{N} has diverged since the prior iteration crashed — re-attach, skip, or stop the loop?" | `re-attach`, `skip`, `stop` |
+
+Note: the **Post-Feedback Merge** gate is a `/sdd:review --loop` gate; it does NOT fire on the work side. Backlog-Drift is a work-side-only gate.
+
+#### Multi-budget batching (gate 80%)
+
+When two or more budgets cross 80% in the same tick, the gate fires **once** with a combined message listing every tripped budget (per SPEC-0020 REQ "Budget-Escalation Gate"). When any budget reaches 100% in the same tick that another crosses 80%, the **100%-stop wins** (conditions 3 / 4 / 5 / 12 take precedence) and the gate is suppressed. Pseudocode in `docs/openspec/specs/loop-autonomous-mode/design.md` § Multi-budget 80% gate batching.
+
+### Concurrency invariants
+
+`/sdd:work --loop` MUST NOT pick up an issue already labeled `in-progress` by a sibling iteration's worktree (per SPEC-0020 REQ "Concurrency Invariants for /sdd:work"). The check happens during workable-issue discovery in each iteration, before dispatch. The iteration MUST NOT clear or contest the label — it skips the issue and picks the next one.
+
+This invariant is independent of the lockfile (which scopes "is another *iteration* running?"). The label invariant scopes "is this *issue* already being implemented somewhere?".
+
+### Final report
+
+When the loop halts for any reason, the wrapped skill MUST emit a final report **before** lockfile release (per SPEC-0020 REQ "Final Report on Stop"). The report covers:
+
+- The stop cause (single line, machine-readable name + human prose)
+- Total iterations used / max
+- Total PRs touched (deduplicated count) / max
+- Total minutes elapsed / max
+- Total dollars estimated / max
+- List of every gate fired with its answer (across all iterations)
+- Path to `.sdd/loop/work.budget.json` and `.sdd/loop/work.history.jsonl` for further inspection
+
+The lockfile is released **after** the report is emitted so a stale-lock reaper on a subsequent tick sees a complete telemetry trail.
+
+### Post-PR Chain
+
+<!-- Governing: ADR-0030 (Post-PR Chain Pattern in /sdd:work), SPEC-0020 REQ "Post-PR Chain Invocation", SPEC-0020 REQ "Chain Outcome Telemetry" -->
+
+After each PR opened in an iteration, `/sdd:work` invokes the post-PR chain unless `--no-chain` or `--dry-run` is set. The chain is wired in story #148; this section is the contract surface — the implementation MUST follow ADR-0030 and `references/loop-telemetry.md` § Optional post-PR-chain fields.
+
+### Resume
+
+`--resume` recovers state from the most recent `history.jsonl` line per `references/loop-telemetry.md` § Resume Contract. Counters are restored; gate evaluations are recomputed; the lockfile is treated as stale per the PID-liveness rule; `tracked_prs[]` and `active_worktrees[]` are reconciled by SHA equality with no external probing substituted.
+
+### Telemetry
+
+Every iteration appends a line to `.sdd/loop/work.history.jsonl` and emits the stdout status block. Skipped ticks (lockfile contention) MUST also append a line with `outcome: "skipped_lock"` and MUST NOT increment `iterations_used`. Schema details in `references/loop-telemetry.md`.
+
+### Loop Mode Rules
+
+- MUST NOT modify the runtime `/loop` skill — re-invocation cadence is `/loop`'s concern; the wrapped skill enforces only intra-iteration semantics
+- MUST acquire the lockfile on entry, before any other work, per `references/loop-primitives.md` § Acquisition flow
+- MUST evaluate PID liveness as the **sole** staleness signal; worktree presence and team-membership state MUST NOT be consulted
+- MUST persist the budget atomically (write-temp + rename) on every tick
+- MUST record active ceilings on first write so `--resume` cannot silently widen them
+- MUST deduplicate `prs_touched` (a PR re-touched across iterations counts once)
+- MUST emit the stdout status block on every iteration including skipped ticks
+- MUST append a `history.jsonl` line on every iteration including skipped ticks
+- MUST NOT increment `iterations_used` for a skipped tick
+- MUST NOT cache or reuse a prior iteration's gate answer; every gate is re-evaluated on every tick
+- MUST refuse to start an iteration when any prior `gates[]` entry recorded `answer == "stop"` (condition #10)
+- MUST NOT pick up issues labeled `in-progress` by a sibling iteration's worktree (concurrency invariant)
+- MUST signal qmd unreachability via stderr token `qmd-unreachable` OR exit code `EX_QMD_UNREACHABLE=78` (the wrapped skill emits; the loop layer detects)
+- MUST emit the final report **before** releasing the lockfile on any halt path
+- MUST invoke the post-PR chain (per "Post-PR Chain" above) for every PR opened in an iteration unless `--no-chain` or `--dry-run` is set


### PR DESCRIPTION
Closes #144
Part of #136 (SPEC-0020)

## Summary

Wires the autonomous-mode contract into `/sdd:work`. Adds the `--loop` opt-in flag with the full CLI surface (`--max-iterations`, `--max-prs`, `--max-minutes`, `--max-dollars`, `--lock={skip|wait|force}`, `--resume`, `--budget-file`), all 12 stop conditions that apply to `/sdd:work`, the 5 work-side `AskUserQuestion` gates plus the resume-divergence gate from #140, the `in-progress` label concurrency invariant, and the qmd-unreachable detection protocol (stderr sentinel + `EX_QMD_UNREACHABLE=78`).

**Stacked on #150 (story #140 — telemetry + resume contract), which is itself stacked on #149 (story #138 — lockfile + budget primitives).** Merge order: #149 → #150 → this PR.

## Governing

- ADR-0028 (`/loop` Autonomous Mode for /sdd:work and /sdd:review)
- ADR-0024 (qmd as Hard Dependency) — for the qmd-unreachable detection contract
- SPEC-0020 REQs: "Loop Mode Opt-In", "CLI Surface for Loop Controls", "Backlog-Empty Stop", "Iteration Budget Stop", "PR-Touch Budget Stop", "Wall-Clock Budget Stop", "Repeated-Failure Stop", "Dependency-Cycle Stop", "User Interrupt Stop", "Lockfile Contention Skip", "Prior-Gate-Stop Honor", "qmd-Unreachable Stop", "Cost Budget Stop", "Concurrency Invariants for /sdd:work", "Backlog-Drift Gate", "Ambiguous-Acceptance-Criteria Gate", "Budget-Escalation Gate (80% Threshold, Multi-Budget Batching)", "Force-Unlock Gate", "Repeated-Failure Gate", "Gates Are Not Debounced Across Iterations", "Final Report on Stop"

## Changes

| File | Why |
|------|-----|
| `skills/work/SKILL.md` | Add a major "Loop Mode (autonomous)" section after the existing Rules block. Documents: the CLI surface table with all flags + defaults, the per-tick canonical flow (acquire lock → read budget → entry-time stop eval → gate block → iteration body → post-PR chain → update budget → emit telemetry → release lock), the 12 stop conditions table (with #2 explicitly NOT applicable to work), the qmd-unreachable detection protocol with both signal paths, the 6 gates that fire on the work side (5 work-only gates + resume-divergence; post-feedback-merge is review-side-only), multi-budget 80% batching with the 100%-stop-wins rule, the `in-progress`-label concurrency invariant, the final-report-before-lock-release rule, the post-PR chain pointer (full wiring lands in #148), the resume contract pointer (counter restoration via `--resume`), and the Loop Mode Rules block enumerating MUST/MUST NOT requirements. The argument-hint in the front-matter is extended to include all `--loop` flags. |
| `evals/triggers/work.json` | Add 5 positive triggers (`/loop /sdd:work --loop`, "grind down the backlog autonomously", `--max-iterations 10 --max-prs 5`, `--resume`, post-PR chain phrasing) and 2 negative triggers (questions about the loop should NOT trigger the work skill). Existing triggers are unchanged. |

## What this story is NOT

- Not the lockfile / budget atomic-write helpers — those are documented in `references/loop-primitives.md` (story #138)
- Not the `history.jsonl` schema or resume reconciliation — those are documented in `references/loop-telemetry.md` (story #140)
- Not the post-PR chain invocation logic — that is story #148 (this PR documents the chain at the contract level only)
- Not the review-side wiring — that is story #145 (separate PR, parallel to this one)

## Test plan

Markdown-native plugin; validation surface is documentary completeness. Acceptance criteria from #144:

- [ ] Per SPEC-0020 REQ "Loop Mode Opt-In": `/sdd:work` without `--loop` is unchanged; `/sdd:work --loop` enters autonomous-mode contract on every tick. Documented in the Loop Mode (autonomous) section's opening paragraph.
- [ ] Per SPEC-0020 REQ "CLI Surface for Loop Controls": all eight loop flags + `--no-chain` are listed in the CLI surface table with the documented defaults; the front-matter argument-hint also includes them.
- [ ] Per SPEC-0020 REQ "Backlog-Empty Stop": condition #1 documented in the stop-conditions table with the spec-quoted final-report message.
- [ ] Per SPEC-0020 REQ "Iteration Budget Stop", "PR-Touch Budget Stop", "Wall-Clock Budget Stop", "Cost Budget Stop": conditions #3, #4, #5, #12 documented with their entry-time / exit-time evaluation rules and the deduplicated `prs_touched` rule.
- [ ] Per SPEC-0020 REQ "Repeated-Failure Stop": condition #6 fires the Repeated-Failure gate (does NOT silently halt) — explicit in the stop-conditions table.
- [ ] Per SPEC-0020 REQ "Dependency-Cycle Stop": condition #7 documented; "do NOT attempt automatic break" called out.
- [ ] Per SPEC-0020 REQ "User Interrupt Stop": condition #8 documented with the drain-then-release behavior and the no-half-states guarantee.
- [ ] Per SPEC-0020 REQ "Lockfile Contention Skip": condition #9 documented with skip / wait / force semantics and the "do NOT increment counters" rule.
- [ ] Per SPEC-0020 REQ "Prior-Gate-Stop Honor": condition #10 documented with the spec-quoted "Loop already stopped at gate {name}" message.
- [ ] Per SPEC-0020 REQ "qmd-Unreachable Stop": condition #11 documented; both signals (stderr sentinel `qmd-unreachable` and exit code `EX_QMD_UNREACHABLE=78`); 2-consecutive-failure trigger; reset-on-success rule. The qmd-unreachable detection-protocol subsection is explicit.
- [ ] Per SPEC-0020 REQ "Concurrency Invariants for /sdd:work": the `in-progress`-label invariant is in its own subsection AND in the Loop Mode Rules block.
- [ ] Per SPEC-0020 REQ "Backlog-Drift Gate", "Ambiguous-Acceptance-Criteria Gate", "Budget-Escalation Gate", "Force-Unlock Gate", "Repeated-Failure Gate": all five are in the gates table with the spec-quoted prompts and option sets.
- [ ] Per SPEC-0020 REQ "Budget-Escalation Gate" (multi-budget batching): the multi-budget batching subsection covers the combined-prompt rule and the 100%-stop-wins rule.
- [ ] Per SPEC-0020 REQ "Gates Are Not Debounced Across Iterations": stated explicitly in the gate table preamble AND in the Loop Mode Rules block.
- [ ] Per SPEC-0020 REQ "Final Report on Stop": Final-report subsection enumerates all required content fields and the "before lockfile release" timing rule.
- [ ] Resume-divergence gate (from #140) is included in the gates table for the work side as well.
- [ ] SPEC-0017 eval triggers updated with `/loop /sdd:work --loop` invocation phrases.
- [ ] Governing comment block at the head of the new section cites SPEC-0020 REQ names per ADR-0020.

## Bootstrap note

Chain pattern (`/sdd:work` → `/sdd:review` → `/autofix-pr`) is not yet auto-invoked — that capability arrives in story #148. After this PR opens, manual `/sdd:review` is needed.
