### PR TITLE
feat(review): wire /sdd:review --loop with single-PR mode, post-feedback-merge gate, ADR-0010 preservation

### DIFF
--- a/evals/triggers/review.json
+++ b/evals/triggers/review.json
@@ -9,6 +9,10 @@
   {"query": "spec-aware review of PR #93 please", "should_trigger": true},
   {"query": "run the reviewer-responder cycle on the auth-rewrite PR", "should_trigger": true},
   {"query": "review PR #88 and post structured feedback as comments", "should_trigger": true},
+  {"query": "/loop /sdd:review --loop --pr 142", "should_trigger": true},
+  {"query": "watch PR #142 autonomously until it merges", "should_trigger": true},
+  {"query": "/sdd:review --loop --max-iterations 10 --pr 142", "should_trigger": true},
+  {"query": "resume the review loop on PR #142 after the crash", "should_trigger": true},
 
   {"query": "review my code for typos and grammar", "should_trigger": false},
   {"query": "review my decision to use Redis as a session store", "should_trigger": false},
@@ -19,5 +23,7 @@
   {"query": "look at this code and tell me if the algorithm is right", "should_trigger": false},
   {"query": "approve PR #88 directly via gh pr review --approve", "should_trigger": false},
   {"query": "merge PR #88 already, I've reviewed it manually", "should_trigger": false},
-  {"query": "review my essay for the Substack post", "should_trigger": false}
+  {"query": "review my essay for the Substack post", "should_trigger": false},
+  {"query": "what is /loop and how does it differ from --loop?", "should_trigger": false},
+  {"query": "explain how /sdd:review --loop preserves ADR-0010", "should_trigger": false}
 ]

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -4,7 +4,7 @@
 name: review
 description: Review and merge PRs produced by /sdd:work using reviewer-responder agent pairs. Use when the user says "review PRs", "review the spec PRs", or wants automated spec-aware code review.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, WebFetch, WebSearch, TeamCreate, TeamDelete, TaskCreate, TaskUpdate, TaskList, TaskGet, SendMessage, AskUserQuestion, ToolSearch
-argument-hint: [SPEC-XXXX or PR numbers] [--pairs N] [--no-merge] [--dry-run] [--module <name>]
+argument-hint: [SPEC-XXXX or PR numbers] [--pairs N] [--no-merge] [--dry-run] [--module <name>] [--loop [--pr N] [--max-iterations N] [--max-prs N] [--max-minutes N] [--max-dollars N] [--lock={skip|wait|force}] [--resume] [--budget-file PATH]]
 ---
 
 <!-- Governing: ADR-0015 (Markdown-Native Configuration), SPEC-0014 REQ "Config Resolution Pattern" -->
@@ -315,3 +315,174 @@ You are reviewing PRs produced by `/sdd:work` using reviewer-responder agent pai
 - **v5.0.0+**: MUST trigger Tier 4 issues sync on entry per Step 3c — sync from tracker before Step 4a (qmd-aware missing-reference retrieval) and Step 11a (topological merge order). On failure, fall back to live queries with a warning, never block (Governing: ADR-0026, SPEC-0019 REQ "Tier 4 Always-Sync Issues for Sprint Skills")
 - **v5.0.0+**: Reviewers MUST run qmd-aware missing-reference retrieval per Step 4a — qmd-search `{repo}-adrs` and `{repo}-issues` for ADRs and prior issues the PR should reference; surface missing ADR refs as findings (with citation), surface missing issue refs as informational notes (Governing: ADR-0024, SPEC-0019 REQ "qmd-Smart Sprint Skills")
 - **v5.0.0+**: After successful merge, MUST trigger Tier 1 updates of BOTH `{repo}-code` AND `{repo}-issues` per Step 11.5a — best-effort, silent on success, one-line warnings on failure (Governing: ADR-0026, SPEC-0019 REQ "Tier 1 Mutation-Aware Updates")
+
+## Loop Mode (autonomous)
+
+<!-- Governing: ADR-0028 (/loop Autonomous Mode for /sdd:work and /sdd:review), ADR-0010 (Parallel PR Review and Response Skill), SPEC-0020 REQ "Loop Mode Opt-In", REQ "CLI Surface for Loop Controls", REQ "Terminal-PR Stop", REQ "Iteration Budget Stop", REQ "Wall-Clock Budget Stop", REQ "Cost Budget Stop", REQ "PR-Touch Budget Stop", REQ "Repeated-Failure Stop", REQ "User Interrupt Stop", REQ "Lockfile Contention Skip", REQ "Prior-Gate-Stop Honor", REQ "qmd-Unreachable Stop", REQ "Concurrency Invariants for /sdd:review", REQ "Ambiguous-Acceptance-Criteria Gate", REQ "Budget-Escalation Gate", REQ "Post-Feedback-Merge Gate", REQ "Force-Unlock Gate", REQ "Repeated-Failure Gate", REQ "Single-PR Review Loop Semantics", REQ "ADR-0010 Bounded-Iteration Preservation", REQ "Final Report on Stop" -->
+
+When `/sdd:review` is invoked under `/loop` with the `--loop` flag (e.g. `/loop /sdd:review --loop` or `/loop /sdd:review --loop --pr 142`), the skill enters autonomous-mode and follows the contract below on every tick. Without `--loop`, the skill behaves exactly as the rest of this document specifies and creates **no** `.sdd/loop/` artifacts (per SPEC-0020 REQ "Loop Mode Opt-In").
+
+The runtime `/loop` skill is unchanged. `--loop` is a skill-side opt-in. `/loop` schedules ticks; everything inside a tick is the wrapped skill's concern. **ADR-0010's bounded one-round invariant is preserved verbatim**: each iteration executes exactly one review-response round per PR; loop iteration MUST NOT amount to multiple review-response rounds on the same PR within one iteration (per SPEC-0020 REQ "ADR-0010 Bounded-Iteration Preservation").
+
+### CLI surface
+
+When `--loop` is set, `/sdd:review` accepts the following additional flags. All shared loop flags carry the documented conservative defaults; `--pr <N>` is review-specific (per SPEC-0020 REQ "CLI Surface for Loop Controls"). Budgets are inclusive **across the entire loop run**, not per-iteration.
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--loop` | off | Opt into autonomous-mode |
+| `--max-iterations N` | 5 | Iteration ceiling across the run |
+| `--max-prs N` | 20 | Distinct-PR ceiling across the run (inactive in single-PR mode — see "Single-PR Review Loop Semantics") |
+| `--max-minutes N` | 60 | Wall-clock ceiling across the run |
+| `--max-dollars N` | 25 | Dollar-cost ceiling; `0` disables condition #12 (estimate still tracked) |
+| `--lock={skip\|wait\|force}` | `skip` | Concurrency mode on lockfile contention |
+| `--resume` | off | Recover state from the most recent `history.jsonl` line |
+| `--budget-file PATH` | `.sdd/loop/review.budget.json` | Override the budget-file location |
+| `--pr N` | none | Single-PR watch mode — see "Single-PR Review Loop Semantics" below |
+
+The first write of `budget.json` records the active ceilings (per `references/loop-primitives.md` § First-write rule) so a later `--resume` cannot silently widen them.
+
+### Per-tick flow
+
+Each tick follows this canonical flow:
+
+1. **Acquire lockfile** at `.sdd/loop/review.lock` per `references/loop-primitives.md` § Acquisition flow (skip / wait / force per `--lock`).
+2. **Read budget** from `.sdd/loop/review.budget.json`; on first write, initialize ceilings, `started_at`, and `rate_table_source`.
+3. **Evaluate stop conditions on entry** (see "Stop conditions" below). Any matching condition halts the loop, emits the final report, and releases the lockfile.
+4. **Run the gate block** (see "AskUserQuestion Gates" below).
+5. **Discover or fetch the target PR(s)** — the existing flow (Steps 3–11 above) runs as the iteration body, scoped to either the discovered PR set (multi-PR mode) or the single PR named by `--pr` (single-PR mode).
+6. **Apply the head-SHA concurrency invariant** (see below) — defer review of any PR whose remote HEAD matches the prior iteration's recorded `head_sha_at_iteration_end`.
+7. **Run the review round** for each non-deferred PR — exactly one round per PR per iteration (ADR-0010 invariant).
+8. **Before merging an APPROVED PR**, evaluate the **Post-Feedback-Merge** gate (see below).
+9. **Update budget** — increment `iterations_used`, `comments_pushed` (top-level + replies both count, per SPEC-0020 REQ "Budget Schema — comments_pushed Definition"), `merges_attempted`, `agents_dispatched`, `tokens_in`/`tokens_out`, recompute `dollars_estimate`, evaluate exit-time stop conditions 3 / 5 / 12 (and #4 in multi-PR mode).
+10. **Emit telemetry** — append a line to `.sdd/loop/review.history.jsonl` (per `references/loop-telemetry.md`) and emit the stdout status block.
+11. **Release lockfile** and let `/loop` schedule the next tick.
+
+### Stop conditions
+
+Active stop conditions for `/sdd:review --loop`. Note: condition #1 (backlog empty) and #7 (dependency cycle) are work-side-only.
+
+| # | Condition | Behavior |
+|---|-----------|----------|
+| 2 | Target PR reaches a terminal state (merged, closed, or labeled with the project's configured do-not-merge label) — single-PR mode only | Halt with "PR #{N} reached terminal state: {state}"; release lock; do NOT signal another tick (SPEC-0020 REQ "Terminal-PR Stop") |
+| 3 | `iterations_used >= max_iterations` (entry-time check) | `stop_conditions_fired: ["iteration_budget"]` (SPEC-0020 REQ "Iteration Budget Stop") |
+| 4 | `len(prs_touched) >= max_prs` — **inactive in single-PR mode** (see "Single-PR Review Loop Semantics") | `stop_conditions_fired: ["prs_touched_budget"]` for multi-PR mode (SPEC-0020 REQ "PR-Touch Budget Stop") |
+| 5 | `minutes_elapsed >= max_minutes` (clock anchored at `started_at`, persists across `--resume`) | `stop_conditions_fired: ["wall_clock_budget"]` (SPEC-0020 REQ "Wall-Clock Budget Stop") |
+| 6 | Same PR failed twice consecutively with the same root cause | Fire the **Repeated-Failure** gate (does NOT silently halt) (SPEC-0020 REQ "Repeated-Failure Stop") |
+| 8 | User interrupt (Ctrl-C / session close / explicit `/loop stop`) | Drain in-flight responder pushes, release lock, emit final report, no half-states (SPEC-0020 REQ "User Interrupt Stop") |
+| 9 | Lockfile holds a live PID under `--lock=skip` | Emit one-line skip note; do NOT increment counters (SPEC-0020 REQ "Lockfile Contention Skip"). `--lock=wait` blocks bounded by `max_minutes`; `--lock=force` fires the Force-Unlock gate. |
+| 10 | Any prior `gates[]` entry recorded `answer == "stop"` | "Loop already stopped at gate {name} in iteration {N}"; release lock; do NOT increment counters (SPEC-0020 REQ "Prior-Gate-Stop Honor") |
+| 11 | qmd unreachable for **2 consecutive** iterations | Halt with the ADR-0024 remediation message; the wrapped skill signals via stderr token `qmd-unreachable` OR exit code `EX_QMD_UNREACHABLE=78`; any successful iteration resets `qmd_failures_consecutive` to 0 (SPEC-0020 REQ "qmd-Unreachable Stop") |
+| 12 | `dollars_estimate >= max_dollars` (and `max_dollars > 0`) | "Cost budget reached: $X / $Y"; `--max-dollars 0` disables but `dollars_estimate` is still tracked (SPEC-0020 REQ "Cost Budget Stop") |
+
+### qmd-unreachable detection protocol
+
+Identical contract as `/sdd:work --loop`. The wrapped skill signals qmd-unreachable using either of these signals (per SPEC-0020 REQ "qmd-Unreachable Stop"):
+
+1. **Stderr sentinel**: a line on stderr containing the literal token `qmd-unreachable`
+2. **Reserved exit code**: `EX_QMD_UNREACHABLE = 78`
+
+The loop reads exit status first; on non-zero, scans stderr for the sentinel as a fallback. On detection, increment `qmd_failures_consecutive`. On any successful iteration, reset to 0. On increment to 2, condition #11 trips.
+
+### AskUserQuestion gates
+
+All gates are re-evaluated **on every tick** (per SPEC-0020 REQ "Gates Are Not Debounced Across Iterations") — the skill MUST NOT cache or reuse a prior iteration's answer. Each invocation is captured verbatim in the iteration's `gates[]` array per `references/loop-telemetry.md`.
+
+The review-side gate set is:
+
+| Gate | Trigger | Prompt template | Options |
+|------|---------|-----------------|---------|
+| **Ambiguous Criteria** | The PR's underlying issue lacks `### Acceptance Criteria` OR contains TBD/TODO markers | "Issue #{N} has ambiguous criteria. Skip, escalate, or proceed with my best interpretation?" | `skip`, `escalate`, `proceed`, `stop` |
+| **Budget Escalation (80%)** | One or more active budgets cross 80% on this tick. **In single-PR mode**, the gate evaluates only `max_iterations`, `max_minutes`, and `max_dollars` and MUST NOT mention `prs_touched`. | "Approaching {budget(s)} ({used}/{total} each). Continue, raise ceiling(s), or stop?" | `continue`, `raise`, `stop` |
+| **Post-Feedback Merge** | The responder addressed *human* review comments (login is not an agent identity) since the previous iteration AND the loop is about to merge | "Responder addressed human feedback on PR #{N}. Merge now or hold for human re-review?" | `merge`, `hold`, `stop` |
+| **Force-Unlock** | `--lock=force` AND lockfile is present | "Force-unlock previous iteration's lock? This may corrupt in-flight work." | `yes`, `no`, `stop` |
+| **Repeated Failure** | Same PR failed in two consecutive iterations with the same root cause | "Issue/PR #{N} failed twice with: {root-cause}. Skip, retry once more, or stop the loop?" | `skip`, `retry`, `stop` |
+| **Resume-Divergence** (resume only) | A `tracked_prs[]` entry's `head_sha_at_iteration_end` does not match the live remote HEAD | "PR #{N} has diverged since the prior iteration crashed — re-attach, skip, or stop the loop?" | `re-attach`, `skip`, `stop` |
+
+Note: **Backlog-Drift** is a `/sdd:work --loop` gate; it does NOT fire on the review side.
+
+#### Multi-budget batching (gate 80%)
+
+When two or more budgets cross 80% in the same tick, the gate fires **once** with a combined message listing every tripped budget. When any budget reaches 100% in the same tick that another crosses 80%, the **100%-stop wins** (conditions 3 / 5 / 12 — and 4 in multi-PR mode) and the gate is suppressed.
+
+In single-PR mode, the gate's combined message MUST NOT mention `prs_touched` regardless of `--max-prs` (per SPEC-0020 REQ "Single-PR Review Loop Semantics").
+
+#### Why the Post-Feedback-Merge gate exists
+
+ADR-0010 caps each `/sdd:review` invocation at exactly one review-response round per PR. Across loop iterations, a sequence of approve → next-iteration could approximate "infinite review rounds" if the responder kept pushing fixes. The Post-Feedback-Merge gate breaks that approximation by inserting a human-mediated checkpoint when **human** review comments (not sibling-agent reviewer comments) have been addressed. This preserves ADR-0010's bounded-iteration invariant under loop wrapping.
+
+The gate's "human vs. agent" detection compares the comment author's tracker login against a list of known agent identities (configurable in the future; for V1, treat the loop's own session identity and the configured `### SDD Configuration > Agent Logins` list as agent identities — everyone else is human).
+
+### Concurrency invariants (head-SHA defer)
+
+`/sdd:review --loop` MUST NOT submit a new review on a PR whose previous-iteration responder has not yet pushed fixes (per SPEC-0020 REQ "Concurrency Invariants for /sdd:review"). The check is **SHA equality alone**:
+
+```
+recorded_sha = last_history_line.tracked_prs[#PR].head_sha_at_iteration_end
+current_sha  = git ls-remote origin {pr.branch} | head -1
+if recorded_sha == current_sha:
+    defer review of this PR with the spec-quoted note:
+    "PR #{N}: no new commits since iteration {M} (head_sha_at_iteration_end matches remote HEAD)"
+```
+
+Out-of-band signals (e.g., responder commentary about fixes being incoming) MUST NOT be used. CI mid-flight is NOT a lock-contention condition; it remains under the existing per-PR CI gate (skip until green) — see Step 9.3 above.
+
+### Single-PR Review Loop Semantics
+
+When `--pr <N>` is provided, the loop watches a single PR across iterations (per SPEC-0020 REQ "Single-PR Review Loop Semantics"):
+
+- `prs_touched` MUST be informational and MUST remain `["#N"]` for the life of the run
+- Condition #4 (PR-touch budget) MUST be **inactive**
+- Active stop conditions are: #2 (terminal PR), #3 (iterations), #5 (minutes), #6 (repeated failure), #8 (interrupt), #9 (lock), #10 (prior gate stop), #11 (qmd), #12 (dollars)
+- `comments_pushed` and `merges_attempted` MUST remain visible counters — uncapped by default, reported on every tick in the status block
+- The Budget-Escalation 80% gate MUST evaluate only `max_iterations`, `max_minutes`, and `max_dollars` and MUST NOT mention `prs_touched`
+
+Single-PR mode is the canonical "watch this PR until it merges" shape. Multi-PR mode (no `--pr`) is the "review whatever is in the discovered PR set" shape and uses the full active-condition set.
+
+### ADR-0010 bounded-iteration preservation
+
+The single most-important invariant the review-side loop preserves: **each `/sdd:review` invocation MUST still execute exactly one review-response round per PR within the iteration** (per SPEC-0020 REQ "ADR-0010 Bounded-Iteration Preservation"). The reviewer evaluates, the responder addresses (if REQUEST_CHANGES), the reviewer re-evaluates. After that round closes, the iteration moves on or stops. A second architectural round on the same PR within the same iteration is forbidden by ADR-0010 and forbidden here.
+
+Across iterations, the **Post-Feedback-Merge** gate (above) is the only path that could otherwise approximate "infinite review rounds" — and it is human-mediated rather than agentic. The user explicitly approves each merge that follows a human-feedback-addressed iteration.
+
+### Final report
+
+When the loop halts for any reason, the wrapped skill MUST emit a final report **before** lockfile release (per SPEC-0020 REQ "Final Report on Stop"). The report covers:
+
+- The stop cause (single line, machine-readable name + human prose)
+- Total iterations used / max
+- In multi-PR mode: total PRs touched (deduplicated count) / max. In single-PR mode: total comments pushed and merges attempted (informational, no max).
+- Total minutes elapsed / max
+- Total dollars estimated / max
+- List of every gate fired with its answer (across all iterations)
+- Path to `.sdd/loop/review.budget.json` and `.sdd/loop/review.history.jsonl` for further inspection
+
+### Resume
+
+`--resume` recovers state from the most recent `history.jsonl` line per `references/loop-telemetry.md` § Resume Contract. Counters are restored; gate evaluations are recomputed; the lockfile is treated as stale per the PID-liveness rule; `tracked_prs[]` is reconciled by SHA equality (silent re-attach on match, resume-divergence gate on mismatch, skip on terminal state) — no external probing substituted.
+
+### Telemetry
+
+Every iteration appends a line to `.sdd/loop/review.history.jsonl` and emits the stdout status block. Skipped ticks (lockfile contention) MUST also append a line with `outcome: "skipped_lock"` and MUST NOT increment `iterations_used`. Schema details in `references/loop-telemetry.md`.
+
+### Loop Mode Rules
+
+- MUST NOT modify the runtime `/loop` skill — re-invocation cadence is `/loop`'s concern; the wrapped skill enforces only intra-iteration semantics
+- MUST acquire the lockfile on entry, before any other work, per `references/loop-primitives.md` § Acquisition flow
+- MUST evaluate PID liveness as the **sole** staleness signal
+- MUST persist the budget atomically (write-temp + rename) on every tick
+- MUST record active ceilings on first write so `--resume` cannot silently widen them
+- In multi-PR mode, MUST deduplicate `prs_touched` (a PR re-reviewed across iterations counts once)
+- In single-PR mode, MUST keep `prs_touched == ["#N"]` for the life of the run; condition #4 MUST NOT fire
+- MUST emit the stdout status block on every iteration including skipped ticks
+- MUST append a `history.jsonl` line on every iteration including skipped ticks
+- MUST NOT increment `iterations_used` for a skipped tick
+- MUST NOT cache or reuse a prior iteration's gate answer; every gate is re-evaluated on every tick
+- MUST refuse to start an iteration when any prior `gates[]` entry recorded `answer == "stop"` (condition #10)
+- MUST defer review of any PR whose remote HEAD matches the prior iteration's `head_sha_at_iteration_end` (head-SHA concurrency invariant; SHA equality is the sole verification rule)
+- MUST NOT treat CI mid-flight as lock contention — that stays under the existing per-PR CI gate
+- MUST signal qmd unreachability via stderr token `qmd-unreachable` OR exit code `EX_QMD_UNREACHABLE=78` (the wrapped skill emits; the loop layer detects)
+- MUST count BOTH top-level review comments AND reply-to-comment messages in `comments_pushed` (per SPEC-0020 REQ "Budget Schema — comments_pushed Definition")
+- MUST fire the Post-Feedback-Merge gate before invoking the merge API when the responder addressed *human* review comments since the prior iteration; only `merge` invokes the merge API
+- MUST execute exactly one review-response round per PR per iteration (ADR-0010 invariant; never multiple rounds on the same PR within one iteration)
+- MUST emit the final report **before** releasing the lockfile on any halt path


### PR DESCRIPTION
Closes #145
Part of #136 (SPEC-0020)

## Summary

Wires the autonomous-mode contract into `/sdd:review`. Adds the `--loop` opt-in flag, the shared loop CLI surface, and the review-only `--pr <N>` single-PR watch flag. Implements the active stop-condition subset (#2 / #3 / #4 / #5 / #6 / #8 / #9 / #10 / #11 / #12 — with #4 inactive in single-PR mode and #1 / #7 not applicable to review), the review-side `AskUserQuestion` gates (ambiguous-criteria, budget-escalation, **post-feedback-merge**, force-unlock, repeated-failure, plus the resume-divergence gate), the head-SHA concurrency invariant against the previous iteration's responder, **ADR-0010 per-iteration round preservation** (the single most-important invariant), and the qmd-unreachable detection protocol.

**Stacked on #150 (story #140 — telemetry + resume contract), which is itself stacked on #149 (story #138 — lockfile + budget primitives).** This branch is parallel to #152 (story #144); the two do NOT share modified files. Merge order: #149 → #150 → this PR (#152 can land in any order relative to this PR).

## Governing

- ADR-0028 (`/loop` Autonomous Mode for /sdd:work and /sdd:review)
- ADR-0010 (Parallel PR Review and Response Skill) — bounded one-round invariant preserved per iteration
- ADR-0024 (qmd as Hard Dependency) — qmd-unreachable detection contract
- SPEC-0020 REQs: "Loop Mode Opt-In", "CLI Surface for Loop Controls", "Terminal-PR Stop", "Iteration Budget Stop", "Wall-Clock Budget Stop", "Cost Budget Stop", "PR-Touch Budget Stop" (single-PR semantics), "Repeated-Failure Stop", "User Interrupt Stop", "Lockfile Contention Skip", "Prior-Gate-Stop Honor", "qmd-Unreachable Stop", "Concurrency Invariants for /sdd:review", "Ambiguous-Acceptance-Criteria Gate", "Budget-Escalation Gate", "Post-Feedback-Merge Gate", "Force-Unlock Gate", "Repeated-Failure Gate", "Single-PR Review Loop Semantics", "ADR-0010 Bounded-Iteration Preservation", "Final Report on Stop"

## Changes

| File | Why |
|------|-----|
| `skills/review/SKILL.md` | Add a major "Loop Mode (autonomous)" section after the existing Rules block. Documents: the CLI surface table including the review-only `--pr <N>` flag, the per-tick canonical flow with the head-SHA defer step, the active stop-conditions table (10 conditions; explicit notes on which are inactive in which mode), the qmd-unreachable detection protocol, the 5 review-side gates plus resume-divergence (with explicit notes that backlog-drift is work-side-only), multi-budget batching with the single-PR-mode prompt-omission rule, the head-SHA concurrency invariant subsection (SHA equality is the sole verification rule; CI mid-flight is NOT lock contention), the Single-PR Review Loop Semantics subsection (per-mode active-condition enumeration, `prs_touched` informational, gate scope), the ADR-0010 bounded-iteration preservation subsection (the single most-important invariant), the final-report timing rule, the resume contract pointer, and the Loop Mode Rules block. The argument-hint in the front-matter is extended to include all `--loop` flags. |
| `evals/triggers/review.json` | Add 4 positive triggers (`/loop /sdd:review --loop --pr 142`, "watch PR #142 autonomously until it merges", explicit `--max-iterations` invocation, `--resume`) and 2 negative triggers (questions about `--loop` should NOT trigger the review skill). Existing triggers are unchanged. |

## What this story is NOT

- Not the lockfile / budget atomic-write helpers — those are in `references/loop-primitives.md` (story #138)
- Not the `history.jsonl` schema or resume reconciliation — those are in `references/loop-telemetry.md` (story #140)
- Not the work-side wiring — that is story #144 (parallel branch / PR)
- Not the post-PR chain pattern — that is story #148 (sequenced after #144 because both touch `skills/work/SKILL.md`)

## Test plan

Markdown-native plugin; validation surface is documentary completeness. Acceptance criteria from #145:

- [ ] Per SPEC-0020 REQ "Loop Mode Opt-In": `/sdd:review` without `--loop` is unchanged; `/sdd:review --loop` enters autonomous-mode contract on every tick.
- [ ] Per SPEC-0020 REQ "CLI Surface for Loop Controls": all shared loop flags + `--pr N` are listed in the CLI surface table with the documented defaults; the front-matter argument-hint includes them.
- [ ] Per SPEC-0020 REQ "Terminal-PR Stop": condition #2 documented for single-PR mode with the spec-quoted "PR #N reached terminal state: {state}" message.
- [ ] Per SPEC-0020 REQ "Single-PR Review Loop Semantics": dedicated subsection enumerates per-mode active stop conditions, `prs_touched == ["#N"]` invariant, condition #4 inactive in single-PR mode, `comments_pushed`/`merges_attempted` visible-but-uncapped behavior, gate-scope rule (no `prs_touched` mention in single-PR mode).
- [ ] Per SPEC-0020 REQ "Concurrency Invariants for /sdd:review": dedicated subsection covers the SHA-equality defer rule, the spec-quoted "PR #N: no new commits since iteration M" note, the explicit prohibition of out-of-band signals, and the CI-mid-flight-is-NOT-lock-contention rule.
- [ ] Per SPEC-0020 REQ "qmd-Unreachable Stop": both signal paths (stderr sentinel + exit code 78) documented; 2-consecutive-failure trigger; reset-on-success rule.
- [ ] Per SPEC-0020 REQ "Ambiguous-Acceptance-Criteria Gate", "Budget-Escalation Gate", "Force-Unlock Gate", "Repeated-Failure Gate": all in the gates table with the spec-quoted prompts and option sets.
- [ ] Per SPEC-0020 REQ "Post-Feedback-Merge Gate": dedicated subsection explains the human-vs-agent detection, the prompt template, the option set, and the explicit cross-reference to ADR-0010 ("the only path that could otherwise approximate 'infinite review rounds'").
- [ ] Per SPEC-0020 REQ "Budget-Escalation Gate" (single-PR mode): single-PR-mode subsection AND the multi-budget batching subsection both call out the "MUST NOT mention `prs_touched`" rule.
- [ ] Per SPEC-0020 REQ "ADR-0010 Bounded-Iteration Preservation": dedicated subsection explicitly states "exactly one review-response round per PR per iteration" and explains how the Post-Feedback-Merge gate is the only cross-iteration mediation.
- [ ] Per SPEC-0020 REQ "User Interrupt Stop", "Lockfile Contention Skip", "Prior-Gate-Stop Honor", "Final Report on Stop": same acceptance behavior as in #144 for the review side; final report cites paths to `.sdd/loop/review.budget.json` and `.sdd/loop/review.history.jsonl`.
- [ ] Per SPEC-0020 REQ "Gates Are Not Debounced Across Iterations": stated in the gate-table preamble AND in the Loop Mode Rules block.
- [ ] Per SPEC-0020 REQ "Budget Schema — comments_pushed Definition": the per-tick flow MUST count BOTH top-level review comments AND replies — explicit in the per-tick flow Step 9 AND in the Loop Mode Rules block.
- [ ] SPEC-0017 eval triggers updated with `/loop /sdd:review --loop --pr 142` invocation phrases.
- [ ] Governing comment block at the head of the new section cites SPEC-0020 REQ names + ADR-0010 + ADR-0024 per ADR-0020.

## Bootstrap note

Chain pattern (`/sdd:work` → `/sdd:review` → `/autofix-pr`) is not yet auto-invoked — that is story #148 on the work side. After this PR opens, manual `/sdd:review` is needed.
