### PR TITLE
fix(docs): drop hash-fragment redirects (plugin-client-redirects build error)

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -26,18 +26,17 @@ const GROUP_ANCHORS = [
   'creating', 'discovery', 'documentation', 'drift',
   'implementation', 'lifecycle', 'planning', 'session',
 ];
+// The @docusaurus/plugin-client-redirects plugin only accepts pathnames in `from`
+// (no hash fragments — pathnames "should start with slash and not contain any domain
+// or query string"). Server-side redirects can't rewrite the URL fragment, so the
+// per-anchor mappings (`#prime`, `#work`, ...) are out of reach for this plugin.
+// We keep one bare-path redirect; the browser preserves the hash, the index page
+// renders the full skill grid, and users land in the right neighborhood.
+// SKILL_ANCHORS and GROUP_ANCHORS are retained as documentation of the prior
+// inbound surface so a future client-side bridge (e.g., redirect.html with
+// `window.location.hash` lookup) can use them. See ADR-0029, SPEC-0021 REQ
+// "Migration of commands.mdx (Step 2 — Audit and Redirect)".
 const COMMANDS_REDIRECTS = [
-  // Skill-level: /guides/commands#{name} -> /skills/{name}
-  ...SKILL_ANCHORS.map((name) => ({
-    from: `/guides/commands#${name}`,
-    to: `/skills/${name}`,
-  })),
-  // Group-level: /guides/commands#{group} -> /skills/ (the hero-tile index).
-  ...GROUP_ANCHORS.map((group) => ({
-    from: `/guides/commands#${group}`,
-    to: `/skills/`,
-  })),
-  // Bare /guides/commands -> /skills/
   {from: '/guides/commands', to: '/skills/'},
 ];
 


### PR DESCRIPTION
Build break introduced by #159: `@docusaurus/plugin-client-redirects` rejects hash fragments in the `from` field with ValidationError. Replaces the 23 per-anchor redirects with a single bare-path redirect from `/guides/commands` to `/skills/`. The browser preserves the hash and users land on the hero-tile index.

The SKILL_ANCHORS / GROUP_ANCHORS constants are retained for documentation and as a hand-off for a future client-side hash-bridge (e.g., a redirect.html that reads window.location.hash).

Verified `npm run build` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)