### PR TITLE
feat(docs): move command tiles generation to plugin-content-claude-plugin-commands

### DIFF
--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -24,6 +24,7 @@
     "@mdx-js/react": "^3.0.0",
     "ajv": "^8.17.1",
     "clsx": "^2.0.0",
+    "plugin-content-claude-plugin-commands": "github:joestump/plugin-content-claude-plugin-commands#main",
     "lucide-react": "^0.575.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",

--- a/docs-site/scripts/generate-commands.js
+++ b/docs-site/scripts/generate-commands.js
@@ -1,224 +1,36 @@
 #!/usr/bin/env node
 /**
- * Generate Command Tiles for Docusaurus
+ * Generate command tiles for the docs-site.
  *
- * Reads skills/_index.json manifest and each skill's SKILL.md frontmatter,
- * then generates hero-tile panels for the commands.mdx guide page, organized
- * by the groups in the manifest.
+ * Thin wrapper over plugin-content-claude-plugin-commands — the plugin owns
+ * the implementation; this script just wires up the docs-site's fixed paths
+ * so it integrates with the existing build-docs.js pipeline.
  *
  * Governing: ADR-0029 (Auto-Generate Docusaurus Skill Pages),
- *            SPEC-0021 REQ "Hero-Tile Index Page",
- *            (extension to command tiles).
+ *            SPEC-0021 REQ "Hero-Tile Index Page".
  */
 
-const fs = require('fs');
-const path = require('path');
+const { loadManifest, loadCommandGroups, renderCommandsMdx } = require('plugin-content-claude-plugin-commands');
+const { writeFileSync, mkdirSync } = require('fs');
+const { join, dirname } = require('path');
 
-const REPO_ROOT = path.join(__dirname, '../..');
-const SKILLS_SOURCE = path.join(REPO_ROOT, 'skills');
-const MANIFEST_PATH = path.join(SKILLS_SOURCE, '_index.json');
-
-/**
- * Parse YAML frontmatter into a flat object. Supports the limited YAML used
- * by SKILL.md files: scalar strings, scalar booleans, and inline arrays
- * `[a, b, c]`. Reused from transform-skills.js.
- */
-function parseFrontmatter(content) {
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---\n?/);
-  if (!fmMatch) return { frontmatter: {}, body: content };
-
-  const fm = {};
-  for (const line of fmMatch[1].split('\n')) {
-    if (!line.trim() || line.trimStart().startsWith('#')) continue;
-    const m = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
-    if (!m) continue;
-    const [, key, rawValue] = m;
-    let value = rawValue.trim();
-    const isFlowArray =
-      value.startsWith('[') &&
-      value.endsWith(']') &&
-      value.indexOf(',') !== -1 &&
-      value.indexOf('[', 1) === -1;
-    if (isFlowArray) {
-      value = value
-        .slice(1, -1)
-        .split(',')
-        .map((v) => v.trim().replace(/^['"]|['"]$/g, ''))
-        .filter(Boolean);
-    } else if (/^(true|false)$/i.test(value)) {
-      value = /^true$/i.test(value);
-    } else {
-      value = value.replace(/^['"]|['"]$/g, '');
-    }
-    fm[key] = value;
-  }
-
-  const body = content.slice(fmMatch[0].length);
-  return { frontmatter: fm, body };
-}
-
-/**
- * Truncate a description at a word boundary near 140 chars.
- * Reused from transform-skills.js.
- */
-function truncateDescription(description, max = 140) {
-  if (!description) return '';
-  if (description.length <= max) return description;
-  const slice = description.slice(0, max);
-  const lastSpace = slice.lastIndexOf(' ');
-  return (lastSpace > 0 ? slice.slice(0, lastSpace) : slice).trimEnd() + '…';
-}
-
-function normalizeArgumentHint(argumentHint) {
-  if (argumentHint == null) return '';
-  if (Array.isArray(argumentHint)) {
-    return argumentHint.map((p) => String(p)).join(' ').trim();
-  }
-  return String(argumentHint).trim();
-}
-
-/**
- * Load manifest and validate structure.
- */
-function loadManifest() {
-  if (!fs.existsSync(MANIFEST_PATH)) {
-    return null;
-  }
-
-  const raw = fs.readFileSync(MANIFEST_PATH, 'utf-8');
-  try {
-    return JSON.parse(raw);
-  } catch (err) {
-    console.warn(`  Warning: skills/_index.json invalid JSON — ${err.message}`);
-    return null;
-  }
-}
-
-/**
- * Load a single skill's frontmatter from its SKILL.md.
- */
-function loadSkillFrontmatter(name) {
-  const skillMd = path.join(SKILLS_SOURCE, name, 'SKILL.md');
-  if (!fs.existsSync(skillMd)) {
-    return null;
-  }
-  const raw = fs.readFileSync(skillMd, 'utf-8');
-  const { frontmatter } = parseFrontmatter(raw);
-  return frontmatter;
-}
-
-/**
- * Generate the header and tile section for a single group.
- */
-function generateGroupTiles(groupName, skillNames) {
-  const parts = [];
-  parts.push(`## ${groupName}\n`);
-  parts.push('<div className="command-tiles">\n');
-
-  for (const name of skillNames) {
-    const fm = loadSkillFrontmatter(name);
-    if (!fm) {
-      console.warn(`  Warning: ${name}/SKILL.md not found, skipping tile`);
-      continue;
-    }
-
-    const description = (fm.description || '').trim();
-    const truncated = truncateDescription(description);
-    const argHint = normalizeArgumentHint(fm['argument-hint']);
-
-    // Escape quotes for JSX attributes
-    const safeName = `{${JSON.stringify(name)}}`;
-    const safeDesc = `{${JSON.stringify(truncated)}}`;
-    const safeHint = `{${JSON.stringify(argHint)}}`;
-    const safeHref = `{${JSON.stringify(`/skills/${name}`)}}`;
-
-    parts.push(
-      `  <CommandTile name=${safeName} description=${safeDesc} argumentHint=${safeHint} href=${safeHref} />`
-    );
-  }
-
-  parts.push('</div>\n');
-  return parts.join('\n');
-}
-
-/**
- * Generate the full command tiles introduction page.
- */
-function generateCommandTilesIntro(manifest) {
-  const fm = [
-    '---',
-    'title: "Commands — Quick Reference"',
-    'sidebar_label: "Quick Reference"',
-    'sidebar_position: 1',
-    'description: "Quick-access tiles for all SDD plugin skills, organized by workflow stage. See Commands Reference for detailed documentation."',
-    '---',
-    '',
-  ].join('\n');
-
-  const parts = [
-    fm,
-    '# Commands',
-    '',
-    'All SDD plugin skills are invoked as Claude Code slash commands. Browse by workflow stage:',
-    '',
-  ];
-
-  for (const [groupName, names] of Object.entries(manifest)) {
-    parts.push(generateGroupTiles(groupName, names));
-    parts.push('');
-  }
-
-  parts.push(
-    '<div className="note">',
-    'For detailed reference, see the <a href="/guides/commands-reference">commands reference</a>.',
-    '</div>',
-    ''
-  );
-
-  return parts.join('\n');
-}
-
-/**
- * Check if CommandTile component exists; if not, suggest creating it.
- */
-function checkCommandTileComponent() {
-  const componentPath = path.join(__dirname, '../src/components/CommandTile.tsx');
-  if (!fs.existsSync(componentPath)) {
-    console.warn(
-      '  Note: CommandTile.tsx component not found at ' + componentPath
-    );
-    console.warn('  Create it using SkillTile.tsx as a template.');
-  }
-}
+const REPO_ROOT = join(__dirname, '../..');
+const MANIFEST_PATH = join(REPO_ROOT, 'skills/_index.json');
+const SKILLS_DIR = join(REPO_ROOT, 'skills');
+const OUTPUT_PATH = join(REPO_ROOT, 'docs-generated/guides/commands-quick-reference.mdx');
 
 function main() {
-  console.log('Generating command tiles...');
-
-  const manifest = loadManifest();
+  const manifest = loadManifest(MANIFEST_PATH);
   if (!manifest) {
     console.log('  Skipped: skills/_index.json not found or invalid');
     return;
   }
-
-  checkCommandTileComponent();
-
-  const tilesContent = generateCommandTilesIntro(manifest);
-
-  const tilesDestPath = path.join(REPO_ROOT, 'docs-generated/guides/commands-quick-reference.mdx');
-  fs.writeFileSync(tilesDestPath, tilesContent);
-
-  console.log(`  Generated command tiles at ${path.relative(REPO_ROOT, tilesDestPath)}`);
+  const groups = loadCommandGroups(manifest, SKILLS_DIR);
+  const mdx = renderCommandsMdx(groups, 'sdd');
+  mkdirSync(dirname(OUTPUT_PATH), { recursive: true });
+  writeFileSync(OUTPUT_PATH, mdx);
+  console.log('  Generated command tiles → docs-generated/guides/commands-quick-reference.mdx');
 }
 
-if (require.main === module) {
-  main();
-}
-
-module.exports = {
-  main,
-  loadManifest,
-  loadSkillFrontmatter,
-  truncateDescription,
-  generateGroupTiles,
-  generateCommandTilesIntro,
-};
+if (require.main === module) main();
+module.exports = { main };

--- a/templates/docusaurus/package.json
+++ b/templates/docusaurus/package.json
@@ -21,7 +21,8 @@
     "lib-artifact-transforms": "github:joestump/lib-artifact-transforms#main",
     "plugin-content-adrs": "github:joestump/plugin-content-adrs#main",
     "plugin-content-openspec": "github:joestump/plugin-content-openspec#main",
-    "plugin-content-skills": "github:joestump/plugin-content-skills#main",
+    "plugin-content-claude-plugin-commands": "github:joestump/plugin-content-claude-plugin-commands#main",
+    "plugin-content-claude-plugin-skills": "github:joestump/plugin-content-claude-plugin-skills#main",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/templates/docusaurus/plugins/sdd-content/index.js
+++ b/templates/docusaurus/plugins/sdd-content/index.js
@@ -170,7 +170,6 @@ const HTML_TAGS = new Set([
 const JSX_COMPONENTS = new Set([
   'StatusBadge', 'DateBadge', 'DomainBadge', 'PriorityBadge', 'SeverityBadge',
   'RFCLevelBadge', 'RequirementBox', 'Field', 'FieldGroup',
-  'CommandTile',
   'Tabs', 'TabItem', 'Admonition',
 ]);
 
@@ -1038,111 +1037,6 @@ JSON output (\`--json\`) is the stable contract for any future MCP, IDE plugin, 
 }
 
 // ============================================================================
-// Command Tiles Generation (from generate-commands.js)
-// ============================================================================
-
-function parseSkillFrontmatter(content) {
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---\n?/);
-  if (!fmMatch) return {};
-
-  const fm = {};
-  for (const line of fmMatch[1].split('\n')) {
-    if (!line.trim() || line.trimStart().startsWith('#')) continue;
-    const m = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
-    if (!m) continue;
-    const [, key, rawValue] = m;
-    let value = rawValue.trim();
-    const isFlowArray =
-      value.startsWith('[') && value.endsWith(']') &&
-      value.indexOf(',') !== -1 && value.indexOf('[', 1) === -1;
-    if (isFlowArray) {
-      value = value.slice(1, -1).split(',')
-        .map((v) => v.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean);
-    } else if (/^(true|false)$/i.test(value)) {
-      value = /^true$/i.test(value);
-    } else {
-      value = value.replace(/^['"]|['"]$/g, '');
-    }
-    fm[key] = value;
-  }
-  return fm;
-}
-
-function truncateDescription(description, max = 140) {
-  if (!description || description.length <= max) return description || '';
-  const slice = description.slice(0, max);
-  const lastSpace = slice.lastIndexOf(' ');
-  return (lastSpace > 0 ? slice.slice(0, lastSpace) : slice).trimEnd() + '…';
-}
-
-function normalizeArgumentHint(argumentHint) {
-  if (argumentHint == null) return '';
-  if (Array.isArray(argumentHint)) return argumentHint.map(String).join(' ').trim();
-  return String(argumentHint).trim();
-}
-
-function generateCommandsPage(skillsSource, docsDest) {
-  const manifestPath = path.join(skillsSource, '_index.json');
-  if (!fs.existsSync(manifestPath)) return;
-
-  let manifest;
-  try {
-    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
-  } catch (e) {
-    console.warn(`  [sdd-content] Could not parse skills manifest: ${e.message}`);
-    return;
-  }
-
-  const parts = [
-    '---',
-    'title: "Commands — Quick Reference"',
-    'sidebar_label: "Quick Reference"',
-    'sidebar_position: 1',
-    'description: "Quick-access tiles for all SDD plugin skills, organized by workflow stage."',
-    '---',
-    '',
-    '# Commands',
-    '',
-    'All SDD plugin skills are invoked as Claude Code slash commands. Browse by workflow stage:',
-    '',
-  ];
-
-  for (const [groupName, skillNames] of Object.entries(manifest)) {
-    parts.push(`## ${groupName}`, '');
-    parts.push('<div className="command-tiles">', '');
-    for (const name of skillNames) {
-      const skillMd = path.join(skillsSource, name, 'SKILL.md');
-      if (!fs.existsSync(skillMd)) {
-        console.warn(`  [sdd-content] ${name}/SKILL.md not found, skipping tile`);
-        continue;
-      }
-      const fm = parseSkillFrontmatter(fs.readFileSync(skillMd, 'utf-8'));
-      const description = truncateDescription((fm.description || '').trim());
-      const argHint = normalizeArgumentHint(fm['argument-hint']);
-      const safeName = JSON.stringify(name);
-      const safeDesc = JSON.stringify(description);
-      const safeHint = JSON.stringify(argHint);
-      const safeHref = JSON.stringify(`/skills/${name}`);
-      parts.push(
-        `  <CommandTile name={${safeName}} description={${safeDesc}} argumentHint={${safeHint}} href={${safeHref}} />`
-      );
-    }
-    parts.push('</div>', '');
-  }
-
-  parts.push(
-    '<div className="note">',
-    'For detailed reference, see the <a href="/guides/commands-reference">commands reference</a>.',
-    '</div>',
-    ''
-  );
-
-  const guidesDir = path.join(docsDest, 'guides');
-  fs.mkdirSync(guidesDir, { recursive: true });
-  fs.writeFileSync(path.join(guidesDir, 'commands.mdx'), parts.join('\n'));
-}
-
-// ============================================================================
 // Plugin Export
 // ============================================================================
 
@@ -1153,12 +1047,10 @@ module.exports = function(context, options) {
   const adrsDir = opts.adrsDir || '../docs/adrs';
   const specsDir = opts.specsDir || '../docs/openspec/specs';
   const outputDir = opts.outputDir || '../docs-generated';
-  const skillsDir = opts.skillsDir ?? null;
 
   const adrsSource = path.resolve(siteDir, adrsDir);
   const specsSource = path.resolve(siteDir, specsDir);
   const docsDest = path.resolve(siteDir, outputDir);
-  const skillsSource = skillsDir ? path.resolve(siteDir, skillsDir) : null;
 
   let baseUrl = '';
   const configPath = path.resolve(siteDir, 'docusaurus.config.ts');
@@ -1277,14 +1169,6 @@ module.exports = function(context, options) {
       generateGraphPage(graph, docsDest);
       console.log(`  Generated graph page`);
 
-      // Generate command tiles (only when skills manifest is present)
-      if (skillsSource) {
-        generateCommandsPage(skillsSource, docsDest);
-        if (fs.existsSync(path.join(skillsSource, '_index.json'))) {
-          console.log(`  Generated command tiles`);
-        }
-      }
-
       console.log('[sdd-content] Documentation content build complete!');
 
       // Return undefined (MDX writing is a side effect, same as sync-spec-docs)
@@ -1292,17 +1176,10 @@ module.exports = function(context, options) {
     },
 
     getPathsToWatch() {
-      const paths = [
+      return [
         path.join(adrsSource, '**/*.md'),
         path.join(specsSource, '**/*.md'),
       ];
-      if (skillsSource) {
-        paths.push(
-          path.join(skillsSource, '_index.json'),
-          path.join(skillsSource, '*/SKILL.md'),
-        );
-      }
-      return paths;
     },
   };
 };


### PR DESCRIPTION
## Summary

- Replaces the 200-line inline `generate-commands.js` with a thin wrapper that delegates to `plugin-content-claude-plugin-commands`
- Adds `plugin-content-claude-plugin-commands` dependency to `docs-site/package.json`
- Updates `templates/docusaurus/package.json` to reference the renamed `plugin-content-claude-plugin-skills` and new `plugin-content-claude-plugin-commands` packages
- Removes the old `plugin-content-skills` reference (now renamed to `plugin-content-claude-plugin-skills`)

Stacks on #166 (already merged). This is the extraction half — the plugin itself lives at `github:joestump/plugin-content-claude-plugin-commands#main`.

## Test plan

- [ ] `cd docs-site && npm install && npm run build-content` — verify `docs-generated/guides/commands-quick-reference.mdx` is generated
- [ ] Confirm command tiles render correctly in `docusaurus start`
- [ ] Verify `templates/docusaurus/package.json` references correct package names

🤖 Generated with [Claude Code](https://claude.com/claude-code)