### PR TITLE
feat(spec): optional call graph generation in /sdd:spec authoring

### DIFF
--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -65,6 +65,82 @@ When creating a new spec from scratch, both files are created together — align
      - If converting from an ADR, the spec-writer should read the ADR and use it as the basis
      - If `TeamCreate` fails, fall back to single-agent mode: draft both files directly, then self-review against the architect's checklist in the Rules section before writing.
 
+4b. **Optional call graph generation** (v5.1.0+):
+
+   <!-- Governing: ADR-0033 (cgg call graph integration), SPEC-0034 REQ "Call Graph Generation Uses cgg With Filtering" -->
+
+   After requirements are authored (Step 4) and before writing to disk (Step 5), ask the user whether to generate call graphs showing the current implementation scope.
+
+   **Opt-in prompt**: Use `AskUserQuestion` with the text:
+
+   > Generate call graphs showing current implementation scope? (yes / no / skip)
+
+   Default to **no** on timeout or in batch/non-interactive mode. If the user answers **no** or **skip**, skip this step entirely — spec.md and design.md are written without an `## Implementation` section. No error, no deviation.
+
+   **When user answers yes**:
+
+   1. **Availability check**: Run `which cgg >/dev/null 2>&1` per `references/cgg-integration.md` § "Availability Check". If cgg is not found, surface the one-line unavailability notice from that section and skip to Step 5 — write spec.md without an `## Implementation` section.
+
+   2. **Extract requirement keywords**: For each `### Requirement:` section heading in the drafted spec.md, extract the requirement name (text after `### Requirement:`). Apply the **From requirement keywords** filter derivation from `references/cgg-integration.md` § "Filter Derivation Strategy":
+      - Lowercase and split on spaces/punctuation
+      - Strip common stop words
+      - Compose a regex alternation from remaining terms (e.g., `payment|processing|token|validation`)
+
+   3. **Find implementing code files via qmd**: Search the `{repo}-code` collection (or `{repo}-{module}-code` in workspace mode) using the requirement keywords as query terms. This surfaces the file paths most likely to implement each requirement.
+
+   4. **Invoke cgg**: Use the invocation pattern from `references/cgg-integration.md` § "cgg Invocation Pattern":
+      - Derive `--filter` by combining qmd file-path stems with requirement keyword terms per § "Filter Derivation Strategy" → "From qmd code matches"
+      - Apply the 20-node cap and Mermaid normalization per § "Node cap" and § "Mermaid Output Normalization"
+      - Handle all exit codes and degradation cases per § "Exit code handling" and § "Graceful Degradation"
+      - In workspace mode, scope `<target-path>` to the module directory per § "Workspace-Mode Scoping"
+
+   5. **Build the `## Implementation` section**: Append to the in-memory spec.md draft (not yet on disk):
+
+      ```markdown
+      ## Implementation
+
+      > Call graphs generated from current codebase. Re-run `/sdd:spec --update SPEC-XXXX` after implementation to refresh.
+
+      ### Requirement-to-Function Mapping
+
+      **REQ "{Requirement Name}"**: functions `fn_a()` → `fn_b()` → `fn_c()`
+
+      *(One line per requirement. List functions extracted from the call graph for that requirement's filter. If cgg returned no nodes for a requirement, omit that requirement's line rather than showing an empty entry.)*
+
+      ### Call Graph
+
+      <!-- Call graph: <filter used>, generated <date> -->
+      ```mermaid
+      graph TD
+          ...
+      %% Showing entry points + main flow; internal helpers omitted
+      ```
+      ```
+
+   6. **Before/after for `--update`**: When running `/sdd:spec --update SPEC-XXXX` and the existing spec.md already contains an `## Implementation` section, produce **side-by-side** Mermaid blocks labeled "Before" and "After":
+
+      ```markdown
+      ### Call Graph
+
+      **Before** (prior to this update):
+
+      <!-- Call graph: <prior filter>, generated <prior date> -->
+      ```mermaid
+      graph TD
+          ... (preserved from prior run)
+      ```
+
+      **After** (current implementation scope):
+
+      <!-- Call graph: <new filter>, generated <new date> -->
+      ```mermaid
+      graph TD
+          ...
+      ```
+      ```
+
+      Preserve the prior Mermaid block exactly as it appeared in the existing spec.md.
+
 5. **Write both files**:
    - `{spec-dir}/{capability-name}/spec.md` — include the user-confirmed frontmatter edges from Step 3a (per the canonical edge schema in `references/shared-patterns.md` § "Graph Edge Resolution")
    - `{spec-dir}/{capability-name}/design.md`
@@ -419,6 +495,13 @@ date: {YYYY-MM-DD}
 - For backend specs with database interactions: MUST inject transaction, connection lifecycle, and parameterized query requirements
 - ALL backend quality guidelines MUST be language-agnostic — use "structured logging" not "slog", "error wrapping" not "%w", "project manifest" not "go.mod", "parallel workers" not "goroutines"
 - MUST NOT inject backend quality requirements for non-backend specs (static docs, pure frontend, CSS, declarative config)
+- **v5.1.0+ call graph (opt-in)**: MUST use `AskUserQuestion` with text "Generate call graphs showing current implementation scope? (yes / no / skip)" AFTER requirements are drafted and BEFORE writing files (Step 4b). Default to **no** on timeout or in batch mode (Governing: ADR-0033, SPEC-0034 REQ "Call Graph Generation Uses cgg With Filtering")
+- **v5.1.0+ call graph (opt-in)**: When user answers yes, MUST probe for cgg availability before invoking; if unavailable, surface the one-line notice from `references/cgg-integration.md` § "Availability Check" and write spec.md without `## Implementation` section — no hard failure (Governing: ADR-0033, SPEC-0034)
+- **v5.1.0+ call graph (opt-in)**: When generating, MUST derive `--filter` from requirement keywords per `references/cgg-integration.md` § "Filter Derivation Strategy" → "From requirement keywords"; MUST apply 20-node cap and Mermaid normalization per that reference; MUST handle all exit codes and degradation cases (Governing: SPEC-0034 REQ "Call Graph Generation Uses cgg With Filtering")
+- **v5.1.0+ call graph (opt-in)**: The `## Implementation` section MUST list each requirement name alongside the functions from the call graph in the format: `**REQ "{name}"**: functions \`fn_a()\` → \`fn_b()\` → \`fn_c()\`` (Governing: SPEC-0034)
+- **v5.1.0+ call graph (opt-in)**: When user answers no or skip, MUST write spec.md without `## Implementation` section; MUST NOT produce any error or deviation from normal workflow (Governing: SPEC-0034)
+- **v5.1.0+ call graph (opt-in)**: When `/sdd:spec --update SPEC-XXXX` is used and existing spec.md already has `## Implementation`, MUST produce side-by-side "Before" / "After" Mermaid blocks preserving the prior block exactly as it appeared (Governing: SPEC-0034)
+- **v5.1.0+ call graph (opt-in)**: MUST NOT produce unfiltered call graphs by default; `--unfiltered` escape hatch is only available when explicitly passed (Governing: SPEC-0034 REQ "Call Graph Generation Uses cgg With Filtering")
 
 ## Graph Edge Frontmatter (per ADR-0023 / SPEC-0018)
 


### PR DESCRIPTION
## Summary

- Adds opt-in Step 4b to `/sdd:spec` workflow: after requirements are drafted and before writing to disk, surface an `AskUserQuestion` prompt asking the user whether to generate call graphs showing current implementation scope
- When user answers yes: extracts requirement keywords, queries the `{repo}-code` qmd collection for implementing files, invokes cgg with a derived `--filter`, applies the 20-node cap + Mermaid normalization from `references/cgg-integration.md`, and embeds the result in a new `## Implementation` section in spec.md with per-requirement function mappings
- When user answers no/skip (or on timeout/batch mode): spec.md and design.md are written exactly as before — zero deviation from existing workflow
- For `--update` on a spec that already has `## Implementation`: produces side-by-side Before/After Mermaid blocks
- Graceful degradation: cgg unavailable or failing surfaces a one-line notice and continues without the `## Implementation` section

## Closes

Closes #174
Closes #170 (part of cgg integration epic)

## Test plan

- [ ] Run `/sdd:spec` and answer "no" — verify spec.md written without `## Implementation` section, no errors
- [ ] Run `/sdd:spec` and answer "skip" — same as above
- [ ] Run `/sdd:spec` and answer "yes" with cgg not installed — verify one-line unavailability notice, spec.md written without `## Implementation`
- [ ] Run `/sdd:spec` and answer "yes" with cgg installed — verify `## Implementation` section present with requirement mapping and Mermaid diagram
- [ ] Run `/sdd:spec --update SPEC-XXXX` where existing spec has `## Implementation` and answer "yes" — verify Before/After side-by-side blocks
- [ ] Verify all existing step numbers (0–9, 3a, 5a) are unchanged and their content is untouched
- [ ] Verify Rules section contains 7 new `v5.1.0+ call graph (opt-in)` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)