### PR TITLE
evals(pipeline): add full-chain-with-review.json scenario (spec → plan → work → review)

### DIFF
--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -464,8 +464,11 @@ jobs:
                       high_cost.append(sd.get('id', sf.stem))
               except Exception:
                   pass
-          if high_cost and pipeline_data:
-              lines.append(f'> 💰 **High-cost scenarios ran:** {", ".join(f"`{s}`" for s in high_cost)} — these create real GitHub repos and run reviewer-responder pairs. Check Actions billing if runs are frequent.')
+          if high_cost:
+              if pipeline_data:
+                  lines.append(f'> 💰 **High-cost scenarios ran:** {", ".join(f"`{s}`" for s in high_cost)} — these create real GitHub repos and run reviewer-responder pairs. Check Actions billing if runs are frequent.')
+              else:
+                  lines.append(f'> ℹ️ **High-cost scenarios exist** ({", ".join(f"`{s}`" for s in high_cost)}) but did not run in this build. They run only on release PRs or manual pipeline dispatch.')
               lines.append('')
 
           tier1 = tier_stats.get('1', {})

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -276,8 +276,13 @@ jobs:
                - "local-tmp-init": mktemp -d, cd into it, git init, write
                  setup.seed.claude_md to ./CLAUDE.md, write each
                  setup.seed.files entry, git add + initial commit.
-               - "gh-disposable": gh repo create --private joestump/sdd-eval-{id}-{run-id},
-                 seed from setup.seed via local push, record repo name for cleanup.
+               - "gh-disposable": gh repo create --private joestump/sdd-eval-{id}-{GITHUB_RUN_ID},
+                 substitute {repo-name} in setup.seed.claude_md with the actual
+                 repo name (e.g. sdd-eval-{id}-{GITHUB_RUN_ID}), write CLAUDE.md,
+                 do a local git init + push to seed the remote, clone it, and
+                 record the repo name for cleanup. gh-disposable scenarios MAY
+                 push branches, open PRs, and create issues in the disposable
+                 repo — that is intentional and expected.
             3. Execute each step in order:
                a. cd into the test repo.
                b. Invoke the named skill via the matching slash command
@@ -317,12 +322,14 @@ jobs:
               "summary": { "scenarios": <n>, "passed": <n>, "failed": <n> }
             }
 
-            IMPORTANT: pipeline scenarios MUST NOT push branches, open PRs,
-            or create issues against any real tracker. The seeded CLAUDE.md
-            in each scenario configures the tasks.md fallback to enforce
-            this. If you detect outbound calls to api.github.com,
-            gitea.*, or gitlab.*, fail the scenario and record the
-            attempted call in the verify_results.
+            IMPORTANT (local-tmp-init scenarios only): scenarios using
+            "local-tmp-init" MUST NOT push branches, open PRs, or create
+            issues against any real tracker. The seeded CLAUDE.md configures
+            the tasks.md fallback to enforce this. If you detect outbound
+            calls to api.github.com, gitea.*, or gitlab.* in a local-tmp-init
+            scenario, fail it and record the attempted call in verify_results.
+            gh-disposable scenarios are explicitly allowed to make GitHub API
+            calls against their own disposable repo.
 
       - name: Upload pipeline results
         if: always()
@@ -445,6 +452,20 @@ jobs:
               for sc in scenarios:
                   icon = '✅' if sc.get('passed') else '❌'
                   lines.append(f'- {icon} `{sc.get("id", "unknown")}`')
+              lines.append('')
+
+          # --- Cost notice for high-cost pipeline scenarios ---
+          scenario_files = sorted(Path('evals/pipeline').glob('*.json')) if Path('evals/pipeline').exists() else []
+          high_cost = []
+          for sf in scenario_files:
+              try:
+                  sd = json.loads(sf.read_text())
+                  if sd.get('cost_class') == 'high':
+                      high_cost.append(sd.get('id', sf.stem))
+              except Exception:
+                  pass
+          if high_cost and pipeline_data:
+              lines.append(f'> 💰 **High-cost scenarios ran:** {", ".join(f"`{s}`" for s in high_cost)} — these create real GitHub repos and run reviewer-responder pairs. Check Actions billing if runs are frequent.')
               lines.append('')
 
           tier1 = tier_stats.get('1', {})

--- a/evals/pipeline/full-chain-with-review.json
+++ b/evals/pipeline/full-chain-with-review.json
@@ -1,0 +1,59 @@
+{
+  "id": "full-chain-with-review",
+  "description": "Full spec → plan → work → review chain on a real disposable GitHub repo. Exercises /sdd:review end-to-end: a reviewer-responder pair reviews the PR opened in the work step and posts a verdict comment.",
+  "cost_class": "high",
+  "setup": {
+    "repo_strategy": "gh-disposable",
+    "seed": {
+      "claude_md": "# Pipeline Eval Test Repo\n\nDisposable repo seeded by the SDD plugin's full-chain pipeline eval. This repo is temporary and will be deleted after the eval run.\n\n## Architecture Context\n\n- Architecture Decision Records are in `docs/adrs/`\n- Specifications are in `docs/openspec/specs/`\n\n## SDD Configuration\n\n**Tracker**: GitHub\n**Owner**: joestump\n**Repo**: {repo-name}\n\n### Branch Conventions\n- **Prefix**: feature\n- **Slug Max Length**: 50\n\n### PR Conventions\n- **Close keyword**: Closes\n- **Spec reference**: Include SPEC-XXXX in PR body\n",
+      "files": []
+    }
+  },
+  "steps": [
+    {
+      "skill": "spec",
+      "prompt": "Create a spec for a small webhook-delivery service: it accepts JSON payloads at POST /webhook, validates an HMAC-SHA256 signature header, and forwards verified payloads to a configurable downstream URL with at-most-once-per-request retry semantics.",
+      "verify": [
+        "A directory under docs/openspec/specs/ was created and contains a spec.md file",
+        "spec.md has a top-level heading matching '# SPEC-XXXX: <title>'",
+        "spec.md uses RFC 2119 keywords (MUST, SHOULD, MAY) at least three times",
+        "spec.md contains at least one '#### Scenario:' subsection per requirement"
+      ]
+    },
+    {
+      "skill": "plan",
+      "prompt": "Plan the spec we just created into trackable GitHub issues. The tracker config in CLAUDE.md points to this disposable repo — create the issues there.",
+      "verify": [
+        "At least one GitHub issue was created in the disposable repo",
+        "Each issue body includes a Branch line matching the feature/{slug} convention from CLAUDE.md",
+        "Each issue body includes a PR Convention section with a 'Closes #N' close keyword",
+        "Each issue references the spec by its SPEC-XXXX id"
+      ]
+    },
+    {
+      "skill": "work",
+      "prompt": "Pick the foundation story (or the first story if no foundation was detected) from the GitHub issues, implement it via a git worktree, push the branch, and open a draft PR in the disposable repo.",
+      "verify": [
+        "A git branch matching feature/{slug} exists on the remote",
+        "A PR is open (state: open or draft) in the disposable repo",
+        "At least one commit was made on that branch with files implementing the chosen story",
+        "The PR body contains 'Closes #N' referencing the issue"
+      ]
+    },
+    {
+      "skill": "review",
+      "prompt": "Review the open PR in the disposable repo using /sdd:review. Run the reviewer-responder pair and post the verdict.",
+      "verify": [
+        "A review comment was posted to the open PR in the disposable repo",
+        "The comment includes a verdict (LGTM, changes requested, or a mergeability decision)",
+        "The PR was either merged or a verdict comment was posted explaining why it was not merged"
+      ]
+    }
+  ],
+  "final_assertions": [
+    "Step 2's issues reference the SPEC-XXXX id created in step 1 (verifies spec -> plan handoff)",
+    "Step 3's branch name matches a Branch line from an issue created in step 2 (verifies plan -> work handoff)",
+    "Step 4's review comment appears on the PR opened in step 3 (verifies work -> review handoff)",
+    "Cleanup: delete the disposable repo — run: gh repo delete joestump/sdd-eval-full-chain-with-review-{run-id} --yes"
+  ]
+}

--- a/evals/pipeline/full-chain-with-review.json
+++ b/evals/pipeline/full-chain-with-review.json
@@ -54,6 +54,6 @@
     "Step 2's issues reference the SPEC-XXXX id created in step 1 (verifies spec -> plan handoff)",
     "Step 3's branch name matches a Branch line from an issue created in step 2 (verifies plan -> work handoff)",
     "Step 4's review comment appears on the PR opened in step 3 (verifies work -> review handoff)",
-    "Cleanup: delete the disposable repo — run: gh repo delete joestump/sdd-eval-full-chain-with-review-{run-id} --yes"
+    "Cleanup: delete the disposable repo created in setup (name: joestump/sdd-eval-full-chain-with-review-{GITHUB_RUN_ID}) — run: gh repo delete joestump/sdd-eval-full-chain-with-review-{GITHUB_RUN_ID} --yes"
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `evals/pipeline/full-chain-with-review.json`: a `gh-disposable` pipeline scenario that runs the full spec → plan → work → review chain against a real private GitHub repo, exercises `/sdd:review` end-to-end with a reviewer-responder pair
- Updates `skill-evals.yml` pipeline prompt to allow real GitHub API calls in `gh-disposable` scenarios (previously the IMPORTANT note blanket-banned all GitHub API calls), adds `{repo-name}` substitution instruction for seeding disposable repo CLAUDE.md
- Adds cost notice in the `report` job for scenarios with `"cost_class": "high"` (reads `evals/pipeline/*.json`, surfaces a 💰 notice when high-cost scenarios ran alongside pipeline results)

**Foundation story #182 (rename + schema) is already merged.**

## Test plan

- [ ] `evals/pipeline/full-chain-with-review.json` exists and validates against the schema in README
- [ ] `"cost_class": "high"` is set and `"repo_strategy": "gh-disposable"` is set
- [ ] All four steps (spec, plan, work, review) are present with verify assertions
- [ ] `final_assertions` includes the `gh repo delete` cleanup line
- [ ] `skill-evals.yml` pipeline prompt no longer blanket-bans GitHub API calls for `gh-disposable` scenarios
- [ ] Report job surfaces 💰 cost notice when `full-chain-with-review` runs in pipeline mode

Closes #183
Ref: #181, #94, SPEC-0017, ADR-0021

🤖 Generated with [Claude Code](https://claude.com/claude-code)