### PR TITLE
Add ADR-0034 and SPEC-0035 for skill distillation to local models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ templates/docs-generated/
 __pycache__/
 *.pyc
 .sdd-graph-backfill-skip
+.sdd/distillation/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ templates/docs-generated/
 __pycache__/
 *.pyc
 .sdd-graph-backfill-skip
-.sdd/distillation/
+.sdd/

--- a/docs/adrs/ADR-0034-skill-distillation-for-local-models.md
+++ b/docs/adrs/ADR-0034-skill-distillation-for-local-models.md
@@ -1,0 +1,128 @@
+---
+status: proposed
+date: 2026-06-10
+decision-makers: Joe Stump
+governs: [SPEC-0035]
+related: [ADR-0021, ADR-0028, ADR-0015]
+---
+
+# ADR-0034: Skill Distillation for Local Models
+
+## Context and Problem Statement
+
+Most SDD work is routine, repetitive, and structurally constrained — authoring an ADR, breaking a spec into issues, running drift checks. Running every one of these against a frontier model is expensive, rate-limited, and often overpowered for the task. Tomasz Tunguz's "skill distillation" technique (see *More Information*) shows that a frontier model can act as a **teacher** that iteratively authors and refines markdown `SKILL.md` files which a cheap **local** model — running in an open harness — then executes at near-frontier quality, with most work staying on the laptop and only the hardest tasks escalating to the cloud (the "minimill" pattern).
+
+How should the SDD plugin let Claude "train" cheaper, locally-hosted models to run its skills well enough to be trusted, and surface those recommendations at planning time?
+
+## Decision Drivers
+
+* **Cost and rate limits** — running routine SDD skills against a frontier model on every invocation is wasteful and throttles throughput; routine procedural work should run locally and cheaply.
+* **Existing substrate** — the plugin is already a skill-authoring system (`skills/`), already has a parity-capable evaluation harness (`evals/`, ADR-0021), and already produces planning artifacts (`/sdd:plan`). Distillation is a recombination of primitives we already own, not a new subsystem.
+* **Measurable, not vibes** — "good enough to run locally" must be a number, not a hunch. We need a repeatable way to measure how close a local model's output is to Claude's on the same task.
+* **Harness and model churn** — open harnesses (Crush, OpenCode, Goose, Codex CLI) and local models (Qwen, Gemma, GPT-OSS) move fast. The design must not hard-couple to any one of them.
+* **Planning visibility** — the value only lands if `/sdd:plan` tells an operator which model/harness/skill can do a given issue locally and when to fall back to the cloud.
+
+## Considered Options
+
+* **Option A — Skill distillation loop** (teacher authors/refines markdown skills; student executes in an open harness; the evals harness measures Claude-relative parity; routing is surfaced at plan time)
+* **Option B — Weight distillation / fine-tuning** (log Claude Code sessions, build a training set, fine-tune or prompt-optimize a local model with DSPy/GEPA)
+* **Option C — Static prompt porting** (hand-write per-model prompt variants once, no measurement or iteration loop)
+* **Option D — Do nothing** (cloud-only; every skill always runs against a frontier model)
+
+## Decision Outcome
+
+Chosen option: **Option A — Skill distillation loop**, because it reuses the plugin's existing skill, evaluation, and planning primitives; produces durable, inspectable, version-controlled markdown artifacts (not opaque weights); and keeps the iteration loop fully inside the SDD lifecycle the plugin already practices. It is the most direct mechanical translation of Tunguz's method onto what this plugin already is.
+
+The decision has four structural commitments, formalized in SPEC-0035:
+
+1. **A new `/sdd:distill` skill** runs a *distillation sprint* for a `{skill, model, harness}` triple: Claude performs the task to produce a gold **reference run**, the same task is dispatched to the local model via the harness adapter (the **pair run**), the **existing `evals/` harness** scores the pair run against the reference to produce a **parity score**, Claude then **refines** the `SKILL.md` / `references/` / helper `scripts/` to close the gap, and the loop repeats until parity converges past a threshold.
+2. **A new `/sdd:route` skill** reads the distillation manifest and, given a task or issue, recommends `{harness, model, skill}` plus a "fall back to cloud when…" condition.
+3. **Harness-agnostic adapters with a runner-agnostic model layer.** Harnesses are abstracted behind an adapter contract (install-skill, dispatch-task, capture-output); **Crush** is the reference adapter, others plug in later. The model layer targets a generic **OpenAI-compatible endpoint**, so Ollama / llama.cpp / vLLM serving Qwen/Gemma/GPT-OSS are all interchangeable and configured in the manifest.
+4. **`/sdd:plan` integration.** Behind a `--distill` flag (default off, mirroring `--no-branches`), each issue body gains an `### Execution` section populated by `/sdd:route`: suggested model, suggested harness, required distilled skills, and the cloud-escalation condition.
+
+Option B (weight distillation / DSPy/GEPA) is explicitly deferred to a **later, optional second track** layered on top of A — it is heavier, pulls in a Python optimizer dependency, and produces opaque artifacts. The skill-distillation loop is a prerequisite for it (it produces the logged pair sessions a training track would consume).
+
+### Consequences
+
+* Good, because routine SDD work can run on a cheap local model at measured, Claude-relative parity, cutting cost and dodging rate limits.
+* Good, because the distilled artifacts are markdown in the repo — inspectable, diffable, reviewable through the same SDD flow as everything else.
+* Good, because parity is a number from the existing evals harness, so "ready to run locally" is gated, not guessed.
+* Good, because the adapter + OpenAI-compatible-endpoint abstraction insulates the plugin from harness/model churn.
+* Bad, because the loop requires a working local harness + model endpoint in the environment, which not every operator will have — distillation must degrade gracefully when the endpoint is unreachable.
+* Bad, because refining a single `SKILL.md` to satisfy a weaker student risks diluting it for the frontier teacher; the design must keep distilled guidance additive (references/scripts) rather than dumbing down the core skill.
+* Neutral, because parity is *relative to Claude*, not absolute correctness — a high parity score inherits Claude's own variance on that task and must be read as such.
+
+### Confirmation
+
+* The presence and eval coverage of the `/sdd:distill` and `/sdd:route` skills under `skills/`, tracked by the existing `evals/` framework (ADR-0021).
+* Parity benchmarks persisted under `evals/benchmarks/` per `{skill, model, harness}` triple, with a documented convergence threshold.
+* `/sdd:plan --distill` issues containing a populated `### Execution` section, validated by a plan eval assertion.
+* A markdown-native distillation manifest (per ADR-0015) under `docs/distillation/` registering harnesses, model endpoints, and per-triple parity scores.
+
+## Pros and Cons of the Options
+
+### Option A — Skill distillation loop
+
+Teacher (Claude) authors and iteratively refines markdown skills; student (local model) executes them in an open harness; the evals harness measures Claude-relative parity; routing surfaces at plan time.
+
+* Good, because it reuses three primitives the plugin already owns (skills, evals, planning).
+* Good, because artifacts are version-controlled, human-readable markdown.
+* Good, because it is the faithful mechanical translation of the source technique.
+* Good, because it is the data-producing prerequisite for an optional later fine-tuning track.
+* Neutral, because parity is Claude-relative, not absolute.
+* Bad, because it needs a live local harness + endpoint and must degrade when absent.
+
+### Option B — Weight distillation / fine-tuning (DSPy/GEPA)
+
+Log sessions, build a training set, optimize or fine-tune a local model.
+
+* Good, because it can push tool-calling parity high (Tunguz reports ~93% on GPT-OSS 20B).
+* Bad, because it produces opaque weights/prompts that don't fit the SDD review flow.
+* Bad, because it adds a heavy Python optimizer dependency and training infrastructure.
+* Bad, because it presupposes the logged pair sessions that Option A produces — wrong layer to start at.
+
+### Option C — Static prompt porting
+
+Hand-write per-model prompt variants once.
+
+* Good, because it is simple and dependency-free.
+* Bad, because there is no measurement, so quality is unknown and unmaintained.
+* Bad, because it rots immediately as skills and models change, with no loop to catch drift.
+
+### Option D — Do nothing
+
+Every skill always runs against a frontier model.
+
+* Good, because zero new surface area.
+* Bad, because it forgoes the entire cost/rate-limit/sovereignty win that motivated the request.
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+    subgraph Sprint["/sdd:distill sprint (per skill × model × harness)"]
+        T[Claude teacher\nperforms task] --> REF[Gold reference run]
+        ADP[Harness adapter\nCrush / ...] --> PAIR[Local model pair run\nOpenAI-compatible endpoint]
+        REF --> EVAL[evals/ harness\nscore pair vs reference]
+        PAIR --> EVAL
+        EVAL --> PAR{Parity ≥ threshold?}
+        PAR -- no --> REFINE[Claude refines\nSKILL.md / references / scripts]
+        REFINE --> T
+        PAR -- yes --> MAN[(Distillation manifest\ndocs/distillation/)]
+    end
+
+    MAN --> ROUTE["/sdd:route\nrecommend model/harness/skill"]
+    ROUTE --> PLAN["/sdd:plan --distill\n### Execution section per issue"]
+    ROUTE --> ESC{Task parity\nhigh enough?}
+    ESC -- yes --> LOCAL[Run locally\nminimill]
+    ESC -- no --> CLOUD[Escalate to frontier model]
+```
+
+## More Information
+
+* Tomasz Tunguz, *Skill Distillation* — https://tomtunguz.com/the-pi-agent-skill-distillation/
+* Tomasz Tunguz, *Teaching Local Models to Call Tools Like Claude* — https://tomtunguz.com/distilling-claude-into-local-models/
+* Tomasz Tunguz, *The Minimill of AI* — https://tomtunguz.com/using-local-ai-to-work-faster/
+* ADR-0021 (Skill Evaluation and CI Testing Framework) — the parity-measurement substrate this decision reuses.
+* ADR-0028 (Loop Autonomous Mode) and ADR-0015 (Markdown-Native Configuration) — the autonomous-loop and config-format patterns this decision builds on.
+* Realized by SPEC-0035 (Skill Distillation).

--- a/docs/adrs/ADR-0034-skill-distillation-for-local-models.md
+++ b/docs/adrs/ADR-0034-skill-distillation-for-local-models.md
@@ -33,12 +33,15 @@ How should the SDD plugin let Claude "train" cheaper, locally-hosted models to r
 
 Chosen option: **Option A — Skill distillation loop**, because it reuses the plugin's existing skill, evaluation, and planning primitives; produces durable, inspectable, version-controlled markdown artifacts (not opaque weights); and keeps the iteration loop fully inside the SDD lifecycle the plugin already practices. It is the most direct mechanical translation of Tunguz's method onto what this plugin already is.
 
-The decision has four structural commitments, formalized in SPEC-0035:
+The decision has five structural commitments, formalized in SPEC-0035:
 
-1. **A new `/sdd:distill` skill** runs a *distillation sprint* for a `{skill, model, harness}` triple: Claude performs the task to produce a gold **reference run**, the same task is dispatched to the local model via the harness adapter (the **pair run**), the **existing `evals/` harness** scores the pair run against the reference to produce a **parity score**, Claude then **refines** the `SKILL.md` / `references/` / helper `scripts/` to close the gap, and the loop repeats until parity converges past a threshold.
-2. **A new `/sdd:route` skill** reads the distillation manifest and, given a task or issue, recommends `{harness, model, skill}` plus a "fall back to cloud when…" condition.
-3. **Harness-agnostic adapters with a runner-agnostic model layer.** Harnesses are abstracted behind an adapter contract (install-skill, dispatch-task, capture-output); **Crush** is the reference adapter, others plug in later. The model layer targets a generic **OpenAI-compatible endpoint**, so Ollama / llama.cpp / vLLM serving Qwen/Gemma/GPT-OSS are all interchangeable and configured in the manifest.
-4. **`/sdd:plan` integration.** Behind a `--distill` flag (default off, mirroring `--no-branches`), each issue body gains an `### Execution` section populated by `/sdd:route`: suggested model, suggested harness, required distilled skills, and the cloud-escalation condition.
+1. **A new `/sdd:distill` skill** runs a *distillation sprint* for a `{skill, model, harness}` triple: Claude performs the task to produce a gold **reference run**; the same task is dispatched to the local model by **shelling out to the harness's own CLI** (the **pair run**); the **existing `evals/` harness** scores the pair run against the reference to produce a **parity score**; Claude then closes the gap primarily by **decomposing the skill into smaller, single-purpose discrete skills** (and tightening their trigger keywords) so each unit fits a local model's limited context window; the loop repeats until parity converges past a threshold.
+2. **Execution substrate is subprocess dispatch, not Claude subagents.** The student runs in an external harness *process* (e.g. `crush`/`opencode` invoked headless) pointed at the local model — it does **not** use Claude Code's Task/subagent mechanism (those run Claude models), and it does **not** require a bespoke backend. An MCP-backed adapter is an optional future variant for harnesses exposed that way; the baseline contract is shelling out to the harness binary.
+3. **A new `/sdd:route` skill** reads the registered harnesses/models and recorded parity scores and, given a task or issue, recommends `{harness, model, skill}` plus a "fall back to cloud when…" condition.
+4. **Harness-agnostic adapters; endpoints/tokens from the environment.** Each harness is integrated through an adapter exposing three operations (install-skill, dispatch-task, capture-output); **Crush** is the reference adapter, others plug in later. The student model is reached through a standard **OpenAI-compatible endpoint configured by conventional environment variables** (`OPENAI_BASE_URL`, `OPENAI_API_KEY`, plus each harness's native env conventions) — never committed config — so Ollama / llama.cpp / vLLM serving Qwen/Gemma/GPT-OSS are interchangeable with no plugin-specific wiring.
+5. **`/sdd:plan` integration.** Behind a `--distill` flag (default off, mirroring `--no-branches`), each issue body gains an `### Execution` section populated by `/sdd:route`: suggested model, suggested harness, required distilled skills, and the cloud-escalation condition.
+
+Configuration — which harness adapters and model identifiers are registered — lives in a structured **Distillation** section in `CLAUDE.md` per ADR-0015 (not a bespoke config file). Runtime artifacts — pair-session transcripts and working parity state — are written to a **gitignored `.sdd/distillation/`** directory (consistent with the repo's existing `.sdd-*` hidden state); durable parity scores are recorded in `evals/benchmarks/` per SPEC-0017.
 
 Option B (weight distillation / DSPy/GEPA) is explicitly deferred to a **later, optional second track** layered on top of A — it is heavier, pulls in a Python optimizer dependency, and produces opaque artifacts. The skill-distillation loop is a prerequisite for it (it produces the logged pair sessions a training track would consume).
 
@@ -47,9 +50,10 @@ Option B (weight distillation / DSPy/GEPA) is explicitly deferred to a **later, 
 * Good, because routine SDD work can run on a cheap local model at measured, Claude-relative parity, cutting cost and dodging rate limits.
 * Good, because the distilled artifacts are markdown in the repo — inspectable, diffable, reviewable through the same SDD flow as everything else.
 * Good, because parity is a number from the existing evals harness, so "ready to run locally" is gated, not guessed.
-* Good, because the adapter + OpenAI-compatible-endpoint abstraction insulates the plugin from harness/model churn.
+* Good, because the adapter + OpenAI-compatible-endpoint abstraction (configured via standard env vars) insulates the plugin from harness/model churn and keeps secrets out of the repo.
+* Good, because decomposing skills into small, discrete, single-purpose units keeps each one inside a local model's limited context window — the unit of distillation is a small skill, not a monolith.
 * Bad, because the loop requires a working local harness + model endpoint in the environment, which not every operator will have — distillation must degrade gracefully when the endpoint is unreachable.
-* Bad, because refining a single `SKILL.md` to satisfy a weaker student risks diluting it for the frontier teacher; the design must keep distilled guidance additive (references/scripts) rather than dumbing down the core skill.
+* Bad, because decomposition adds surface area — more, smaller skills to maintain and route between — and the teacher must ensure the decomposed set still composes back to the frontier skill's behavior.
 * Neutral, because parity is *relative to Claude*, not absolute correctness — a high parity score inherits Claude's own variance on that task and must be read as such.
 
 ### Confirmation
@@ -57,7 +61,8 @@ Option B (weight distillation / DSPy/GEPA) is explicitly deferred to a **later, 
 * The presence and eval coverage of the `/sdd:distill` and `/sdd:route` skills under `skills/`, tracked by the existing `evals/` framework (ADR-0021).
 * Parity benchmarks persisted under `evals/benchmarks/` per `{skill, model, harness}` triple, with a documented convergence threshold.
 * `/sdd:plan --distill` issues containing a populated `### Execution` section, validated by a plan eval assertion.
-* A markdown-native distillation manifest (per ADR-0015) under `docs/distillation/` registering harnesses, model endpoints, and per-triple parity scores.
+* A structured **Distillation** configuration section in `CLAUDE.md` (per ADR-0015) registering harness adapters and model identifiers — with endpoints/tokens resolved from environment variables, not committed.
+* Pair-session transcripts and working parity state under a gitignored `.sdd/distillation/` directory; durable parity scores in `evals/benchmarks/` per `{skill, model, harness}` triple.
 
 ## Pros and Cons of the Options
 
@@ -102,13 +107,13 @@ Every skill always runs against a frontier model.
 flowchart TD
     subgraph Sprint["/sdd:distill sprint (per skill × model × harness)"]
         T[Claude teacher\nperforms task] --> REF[Gold reference run]
-        ADP[Harness adapter\nCrush / ...] --> PAIR[Local model pair run\nOpenAI-compatible endpoint]
+        ADP[Harness adapter\nshell out to crush/opencode CLI] --> PAIR[Local model pair run\nOpenAI-compatible endpoint via env vars]
         REF --> EVAL[evals/ harness\nscore pair vs reference]
         PAIR --> EVAL
         EVAL --> PAR{Parity ≥ threshold?}
-        PAR -- no --> REFINE[Claude refines\nSKILL.md / references / scripts]
+        PAR -- no --> REFINE[Claude decomposes skill into\nsmall discrete skills, tightens triggers]
         REFINE --> T
-        PAR -- yes --> MAN[(Distillation manifest\ndocs/distillation/)]
+        PAR -- yes --> MAN[(.sdd/distillation/ artifacts\n+ CLAUDE.md config + evals/benchmarks)]
     end
 
     MAN --> ROUTE["/sdd:route\nrecommend model/harness/skill"]

--- a/docs/adrs/ADR-0035-skill-distillation-for-local-models.md
+++ b/docs/adrs/ADR-0035-skill-distillation-for-local-models.md
@@ -2,11 +2,11 @@
 status: proposed
 date: 2026-06-10
 decision-makers: Joe Stump
-governs: [SPEC-0035]
+governs: [SPEC-0036]
 related: [ADR-0021, ADR-0028, ADR-0015]
 ---
 
-# ADR-0034: Skill Distillation for Local Models
+# ADR-0035: Skill Distillation for Local Models
 
 ## Context and Problem Statement
 
@@ -33,7 +33,7 @@ How should the SDD plugin let Claude "train" cheaper, locally-hosted models to r
 
 Chosen option: **Option A — Skill distillation loop**, because it reuses the plugin's existing skill, evaluation, and planning primitives; produces durable, inspectable, version-controlled markdown artifacts (not opaque weights); and keeps the iteration loop fully inside the SDD lifecycle the plugin already practices. It is the most direct mechanical translation of Tunguz's method onto what this plugin already is.
 
-The decision has five structural commitments, formalized in SPEC-0035:
+The decision has five structural commitments, formalized in SPEC-0036:
 
 1. **A new `/sdd:distill` skill** runs a *distillation sprint* for a `{skill, model, harness}` triple: Claude performs the task to produce a gold **reference run**; the same task is dispatched to the local model by **shelling out to the harness's own CLI** (the **pair run**); the **existing `evals/` harness** scores the pair run against the reference to produce a **parity score**; Claude then closes the gap primarily by **decomposing the skill into smaller, single-purpose discrete skills** (and tightening their trigger keywords) so each unit fits a local model's limited context window; the loop repeats until parity converges past a threshold.
 2. **Execution substrate is subprocess dispatch, not Claude subagents.** The student runs in an external harness *process* (e.g. `crush`/`opencode` invoked headless) pointed at the local model — it does **not** use Claude Code's Task/subagent mechanism (those run Claude models), and it does **not** require a bespoke backend. An MCP-backed adapter is an optional future variant for harnesses exposed that way; the baseline contract is shelling out to the harness binary.
@@ -130,4 +130,4 @@ flowchart TD
 * Tomasz Tunguz, *The Minimill of AI* — https://tomtunguz.com/using-local-ai-to-work-faster/
 * ADR-0021 (Skill Evaluation and CI Testing Framework) — the parity-measurement substrate this decision reuses.
 * ADR-0028 (Loop Autonomous Mode) and ADR-0015 (Markdown-Native Configuration) — the autonomous-loop and config-format patterns this decision builds on.
-* Realized by SPEC-0035 (Skill Distillation).
+* Realized by SPEC-0036 (Skill Distillation).

--- a/docs/openspec/specs/skill-distillation/design.md
+++ b/docs/openspec/specs/skill-distillation/design.md
@@ -9,10 +9,10 @@ This design covers the distillation sprint loop (`/sdd:distill`), the routing re
 ## Goals / Non-Goals
 
 ### Goals
-- Let Claude iteratively refine markdown skill artifacts until a local model reaches a measured, Claude-relative parity threshold on a given skill.
+- Let Claude iteratively refine — primarily by decomposing into smaller, discrete skills — until a local model reaches a measured, Claude-relative parity threshold on a given skill.
 - Reuse the existing eval harness (SPEC-0017) for parity scoring instead of building a second grader.
-- Keep all distilled artifacts as version-controlled, reviewable markdown (skills, references, scripts, manifest).
-- Insulate the design from harness and runner churn via an adapter contract and an OpenAI-compatible model endpoint.
+- Keep distilled skills as version-controlled, reviewable markdown; keep configuration in `CLAUDE.md` (ADR-0015) and noisy runtime artifacts in a gitignored `.sdd/distillation/` directory.
+- Insulate the design from harness and runner churn via a subprocess adapter contract and an OpenAI-compatible model endpoint configured by environment variables.
 - Surface, at plan time, which model/harness/skill can run an issue locally and when to escalate to the cloud.
 
 ### Non-Goals
@@ -31,25 +31,28 @@ This design covers the distillation sprint loop (`/sdd:distill`), the routing re
 - A bespoke distillation grader: rejected — duplicates SPEC-0017 and invites divergence.
 - Human spot-checking only: rejected — not repeatable, can't gate convergence.
 
-### Harness-agnostic adapters, runner-agnostic model layer
+### Subprocess adapters; endpoints/tokens from the environment
 
-**Choice**: Harnesses sit behind a three-operation adapter contract (install-skill, dispatch-task, capture-output); Crush is the reference adapter. Models are reached through a generic OpenAI-compatible endpoint configured in the manifest.
-**Rationale**: The open-harness and local-model ecosystems move fast. Pinning to one of either would date the plugin quickly. The adapter contract is the smallest surface that supports the loop, and the OpenAI-compatible endpoint is the de-facto common interface across Ollama, llama.cpp, and vLLM.
+**Choice**: Harnesses sit behind a three-operation adapter contract (install-skill, dispatch-task, capture-output) where dispatch shells out to the harness's own CLI as a subprocess; Crush is the reference adapter. The student model is reached through a generic OpenAI-compatible endpoint whose URL and token come from conventional environment variables (`OPENAI_BASE_URL`, `OPENAI_API_KEY`, plus each harness's native env conventions).
+**Rationale**: The student is a different model running in a different program, so it cannot be a Claude Code subagent (those run Claude); shelling out to the harness binary is the substrate that already exists. The open-harness and local-model ecosystems move fast, so pinning to one would date the plugin; the three-operation subprocess contract is the smallest surface that supports the loop, and env-var endpoints keep secrets out of the repo while making any OpenAI-compatible runner (Ollama, llama.cpp, vLLM) interchangeable.
 **Alternatives considered**:
-- Hard-code Crush + Ollama: rejected — couples the plugin to two fast-moving externals.
+- Claude Code subagents as the student: rejected — they run Claude models, not the local student.
+- A bespoke backend/daemon to manage harness+model selection: rejected for v1 — adds an always-on service; an MCP-backed adapter remains an optional variant for harnesses exposed that way.
+- Endpoints/tokens in committed config: rejected — leaks secrets and duplicates what env vars already standardize.
 - Support every harness up front: rejected — unbounded adapter work before the loop is proven; Crush-first proves the contract, others follow.
 
-### Refinements are additive and student-scoped
+### Convergence by skill decomposition
 
-**Choice**: Gap-closing changes prefer `references/` and `scripts/` over edits to the core `SKILL.md` body, and any change that would weaken the skill for the frontier teacher is rejected or relocated.
-**Rationale**: A single skill serves both teacher and student. Dumbing down the body to satisfy a weaker model would regress frontier quality and the skill's CI evals. Additive, student-scoped guidance closes the gap without that regression.
+**Choice**: Gap-closing happens primarily by decomposing a skill into smaller, single-purpose discrete skills with tightened triggers — not by accumulating additive guidance on one skill. Any decomposition that would change the frontier outcome is rejected.
+**Rationale**: Many local models have small context windows, so the binding constraint is per-skill context budget, not the teacher's. Small discrete skills keep each unit inside the student's context while remaining individually reviewable; routing then selects the minimal skill(s) per step. The decomposed set must still compose back to the frontier skill's behavior so the teacher's CI evals do not regress.
 **Alternatives considered**:
-- Maintain separate per-model skill forks: rejected for v1 — multiplies maintenance and diverges from the single-source-of-truth skill model; reconsider if additive guidance proves insufficient.
+- Additive references/scripts on one `SKILL.md`: rejected — inflates context, the opposite of what small-context students need.
+- Separate per-model skill forks: rejected for v1 — multiplies maintenance; decomposition keeps a single shared set that composes for both teacher and student.
 
-### Markdown-native manifest as the routing source of truth
+### Configuration in CLAUDE.md, runtime artifacts in a hidden directory
 
-**Choice**: A markdown manifest under `docs/distillation/` (per ADR-0015) records adapters, endpoints, and per-triple parity scores with dates; `/sdd:route` reads only this file.
-**Rationale**: Consistent with the plugin's markdown-native configuration convention; keeps distillation state diffable and reviewable through the same SDD flow as ADRs and specs.
+**Choice**: Registration of harness adapters and model identifiers lives in a structured **Distillation** section in `CLAUDE.md` (per ADR-0015), not a bespoke file. Pair-session transcripts and working parity state are written to a gitignored `.sdd/distillation/` directory; durable parity scores are recorded in `evals/benchmarks/` (per SPEC-0017). `/sdd:route` reads the CLAUDE.md registration plus the recorded scores.
+**Rationale**: ADR-0015 already mandates configuration as `CLAUDE.md` sections rather than parallel config files, so a separate "manifest" would reintroduce the split-truth problem that ADR retired. Transcripts are bulky and regenerable, so they belong in hidden, gitignored state (matching the repo's existing `.sdd-*` convention), not the committed docs tree.
 
 ### Plan integration is opt-in and non-destructive
 
@@ -62,19 +65,19 @@ This design covers the distillation sprint loop (`/sdd:distill`), the routing re
 flowchart TD
     subgraph Distill["/sdd:distill — sprint loop"]
         TASK[Task input] --> TEACH[Claude teacher run]
-        TASK --> DISP[Harness adapter:\ninstall · dispatch · capture]
-        DISP --> ENDPT[(OpenAI-compatible\nmodel endpoint)]
+        TASK --> DISP[Harness adapter:\nsubprocess install · dispatch · capture]
+        DISP --> ENDPT[(OpenAI-compatible endpoint\nURL/token from env vars)]
         ENDPT --> STUD[Student pair run]
         TEACH --> SCORE[Eval harness\nSPEC-0017 assertions]
         STUD --> SCORE
         SCORE --> THRESH{Parity ≥ threshold\nor max iters?}
-        THRESH -- below, iters left --> REFINE[Refine references/\nscripts/ · SKILL.md]
+        THRESH -- below, iters left --> REFINE[Decompose into small\ndiscrete skills, tighten triggers]
         REFINE --> TASK
-        THRESH -- converged / ceiling --> WRITE[Write parity\nto manifest + benchmarks]
+        THRESH -- converged / ceiling --> WRITE[Record parity\n+ persist transcripts]
     end
 
-    WRITE --> MANIFEST[(docs/distillation/\nmanifest)]
-    MANIFEST --> ROUTE["/sdd:route"]
+    WRITE --> STORE[(.sdd/distillation/ transcripts\nCLAUDE.md config · evals/benchmarks)]
+    STORE --> ROUTE["/sdd:route"]
     ROUTE --> PLAN["/sdd:plan --distill\n### Execution section"]
     ROUTE --> DECISION{Triple ≥ threshold\nfor this skill?}
     DECISION -- yes --> LOCAL[Recommend local\nminimill execution]
@@ -83,15 +86,15 @@ flowchart TD
 
 ## Risks / Trade-offs
 
-- **Parity is Claude-relative, not absolute** → label every score as parity-relative-to-Claude in outputs and the manifest; document that a high score inherits Claude's own task variance.
-- **Refining for the student dilutes the teacher** → enforce the additive/student-scoped refinement rule; reject core-body edits that regress the skill's own CI evals.
+- **Parity is Claude-relative, not absolute** → label every score as parity-relative-to-Claude in outputs and benchmarks; document that a high score inherits Claude's own task variance.
+- **Decomposition diverges from the teacher** → require the decomposed set to compose back to the frontier outcome; reject splits that regress the skill's own CI evals.
 - **Local harness/endpoint absent in many environments** → every dependent operation degrades gracefully, names the missing dependency, and never fabricates results or blocks the SDD flow.
-- **Manifest drift vs. reality** → record the measurement date per triple; treat stale parity as a routing signal to re-distill rather than trust silently.
-- **Adapter sprawl** → keep the adapter contract to three operations; add harness adapters only after Crush proves the contract.
+- **Parity drift vs. reality** → record the measurement date per triple in `evals/benchmarks/`; treat stale parity as a routing signal to re-distill rather than trust silently.
+- **Adapter sprawl** → keep the adapter contract to three subprocess operations; add harness adapters only after Crush proves the contract.
 
 ## Migration Plan
 
-Greenfield capability — additive only. The two new skills, the manifest directory, and the `--distill` flag introduce no changes to existing skill behavior; `/sdd:plan` without `--distill` is unchanged. No data migration is required. Initial rollout seeds an empty manifest, so `/sdd:route` and `/sdd:plan --distill` default to cloud recommendations until the first sprint records a distilled triple.
+Greenfield capability — additive only. The two new skills, the `.sdd/distillation/` artifact directory (gitignored), the `CLAUDE.md` Distillation section, and the `--distill` flag introduce no changes to existing skill behavior; `/sdd:plan` without `--distill` is unchanged. No data migration is required. With no triples recorded yet, `/sdd:route` and `/sdd:plan --distill` default to cloud recommendations until the first sprint records a distilled triple.
 
 ## Open Questions
 

--- a/docs/openspec/specs/skill-distillation/design.md
+++ b/docs/openspec/specs/skill-distillation/design.md
@@ -1,0 +1,101 @@
+# Design: Skill Distillation
+
+## Context
+
+The SDD plugin already is, in effect, a skill factory: it authors `SKILL.md` files, measures them with an eval harness (SPEC-0017 / ADR-0021), and plans work from specs (SPEC-0007). Tomasz Tunguz's "skill distillation" technique uses a frontier model as a teacher that refines markdown skills until a cheap local model can run them well, keeping most work on a laptop and escalating only the hard cases to the cloud (the "minimill"). ADR-0034 adopts this technique by recombining the plugin's existing primitives rather than building a new subsystem.
+
+This design covers the distillation sprint loop (`/sdd:distill`), the routing recommender (`/sdd:route`), the harness-adapter abstraction, the markdown-native manifest, and the `/sdd:plan --distill` integration. It deliberately scopes out weight-level fine-tuning.
+
+## Goals / Non-Goals
+
+### Goals
+- Let Claude iteratively refine markdown skill artifacts until a local model reaches a measured, Claude-relative parity threshold on a given skill.
+- Reuse the existing eval harness (SPEC-0017) for parity scoring instead of building a second grader.
+- Keep all distilled artifacts as version-controlled, reviewable markdown (skills, references, scripts, manifest).
+- Insulate the design from harness and runner churn via an adapter contract and an OpenAI-compatible model endpoint.
+- Surface, at plan time, which model/harness/skill can run an issue locally and when to escalate to the cloud.
+
+### Non-Goals
+- Weight distillation, fine-tuning, or DSPy/GEPA prompt optimization. These are a deferred, optional second track (see Open Questions) that would consume the pair-session transcripts this capability produces.
+- Shipping or endorsing any specific local model. The design is model-agnostic; models are configured, not bundled.
+- Building or vendoring a harness. Harnesses are external dependencies reached through adapters; Crush is the only adapter implemented first.
+- Absolute-correctness benchmarking. Parity is relative to Claude's own (variable) output on the same task.
+
+## Decisions
+
+### Distillation loop reuses the eval harness for scoring
+
+**Choice**: Parity is computed by running the skill's existing eval assertions (SPEC-0017) against the student's pair run, scored relative to Claude's reference run — not by a new grader.
+**Rationale**: The plugin already maintains per-skill assertions and a benchmark store; a second scoring path would drift from them and double the maintenance surface. Reuse also means a skill's distillation parity and its CI eval share one definition of "good."
+**Alternatives considered**:
+- A bespoke distillation grader: rejected — duplicates SPEC-0017 and invites divergence.
+- Human spot-checking only: rejected — not repeatable, can't gate convergence.
+
+### Harness-agnostic adapters, runner-agnostic model layer
+
+**Choice**: Harnesses sit behind a three-operation adapter contract (install-skill, dispatch-task, capture-output); Crush is the reference adapter. Models are reached through a generic OpenAI-compatible endpoint configured in the manifest.
+**Rationale**: The open-harness and local-model ecosystems move fast. Pinning to one of either would date the plugin quickly. The adapter contract is the smallest surface that supports the loop, and the OpenAI-compatible endpoint is the de-facto common interface across Ollama, llama.cpp, and vLLM.
+**Alternatives considered**:
+- Hard-code Crush + Ollama: rejected — couples the plugin to two fast-moving externals.
+- Support every harness up front: rejected — unbounded adapter work before the loop is proven; Crush-first proves the contract, others follow.
+
+### Refinements are additive and student-scoped
+
+**Choice**: Gap-closing changes prefer `references/` and `scripts/` over edits to the core `SKILL.md` body, and any change that would weaken the skill for the frontier teacher is rejected or relocated.
+**Rationale**: A single skill serves both teacher and student. Dumbing down the body to satisfy a weaker model would regress frontier quality and the skill's CI evals. Additive, student-scoped guidance closes the gap without that regression.
+**Alternatives considered**:
+- Maintain separate per-model skill forks: rejected for v1 — multiplies maintenance and diverges from the single-source-of-truth skill model; reconsider if additive guidance proves insufficient.
+
+### Markdown-native manifest as the routing source of truth
+
+**Choice**: A markdown manifest under `docs/distillation/` (per ADR-0015) records adapters, endpoints, and per-triple parity scores with dates; `/sdd:route` reads only this file.
+**Rationale**: Consistent with the plugin's markdown-native configuration convention; keeps distillation state diffable and reviewable through the same SDD flow as ADRs and specs.
+
+### Plan integration is opt-in and non-destructive
+
+**Choice**: `/sdd:plan --distill` (default off) adds an `### Execution` section per issue; without the flag, output is byte-for-byte unchanged.
+**Rationale**: Mirrors the existing optional-section flag pattern (`--no-branches`, `--no-projects`), so the feature is additive and cannot regress the default planning path.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph Distill["/sdd:distill — sprint loop"]
+        TASK[Task input] --> TEACH[Claude teacher run]
+        TASK --> DISP[Harness adapter:\ninstall · dispatch · capture]
+        DISP --> ENDPT[(OpenAI-compatible\nmodel endpoint)]
+        ENDPT --> STUD[Student pair run]
+        TEACH --> SCORE[Eval harness\nSPEC-0017 assertions]
+        STUD --> SCORE
+        SCORE --> THRESH{Parity ≥ threshold\nor max iters?}
+        THRESH -- below, iters left --> REFINE[Refine references/\nscripts/ · SKILL.md]
+        REFINE --> TASK
+        THRESH -- converged / ceiling --> WRITE[Write parity\nto manifest + benchmarks]
+    end
+
+    WRITE --> MANIFEST[(docs/distillation/\nmanifest)]
+    MANIFEST --> ROUTE["/sdd:route"]
+    ROUTE --> PLAN["/sdd:plan --distill\n### Execution section"]
+    ROUTE --> DECISION{Triple ≥ threshold\nfor this skill?}
+    DECISION -- yes --> LOCAL[Recommend local\nminimill execution]
+    DECISION -- no --> CLOUD[Recommend cloud\nescalation]
+```
+
+## Risks / Trade-offs
+
+- **Parity is Claude-relative, not absolute** → label every score as parity-relative-to-Claude in outputs and the manifest; document that a high score inherits Claude's own task variance.
+- **Refining for the student dilutes the teacher** → enforce the additive/student-scoped refinement rule; reject core-body edits that regress the skill's own CI evals.
+- **Local harness/endpoint absent in many environments** → every dependent operation degrades gracefully, names the missing dependency, and never fabricates results or blocks the SDD flow.
+- **Manifest drift vs. reality** → record the measurement date per triple; treat stale parity as a routing signal to re-distill rather than trust silently.
+- **Adapter sprawl** → keep the adapter contract to three operations; add harness adapters only after Crush proves the contract.
+
+## Migration Plan
+
+Greenfield capability — additive only. The two new skills, the manifest directory, and the `--distill` flag introduce no changes to existing skill behavior; `/sdd:plan` without `--distill` is unchanged. No data migration is required. Initial rollout seeds an empty manifest, so `/sdd:route` and `/sdd:plan --distill` default to cloud recommendations until the first sprint records a distilled triple.
+
+## Open Questions
+
+- Should the optional weight/prompt-optimization second track (DSPy/GEPA over logged pair sessions) be a future spec that `requires` this one, and what artifacts would it add to the manifest?
+- What is the right default parity threshold and maximum iteration count, and should they be per-skill (tier-aware, per SPEC-0017 tiers) rather than global?
+- Beyond Crush, what is the priority order for additional harness adapters (OpenCode, Goose, Codex CLI), and do any require more than the three-operation contract?
+- Should `/sdd:work` eventually consume the `### Execution` annotations to actually dispatch local runs, or does routing stay advisory in v1?

--- a/docs/openspec/specs/skill-distillation/design.md
+++ b/docs/openspec/specs/skill-distillation/design.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-The SDD plugin already is, in effect, a skill factory: it authors `SKILL.md` files, measures them with an eval harness (SPEC-0017 / ADR-0021), and plans work from specs (SPEC-0007). Tomasz Tunguz's "skill distillation" technique uses a frontier model as a teacher that refines markdown skills until a cheap local model can run them well, keeping most work on a laptop and escalating only the hard cases to the cloud (the "minimill"). ADR-0034 adopts this technique by recombining the plugin's existing primitives rather than building a new subsystem.
+The SDD plugin already is, in effect, a skill factory: it authors `SKILL.md` files, measures them with an eval harness (SPEC-0017 / ADR-0021), and plans work from specs (SPEC-0007). Tomasz Tunguz's "skill distillation" technique uses a frontier model as a teacher that refines markdown skills until a cheap local model can run them well, keeping most work on a laptop and escalating only the hard cases to the cloud (the "minimill"). ADR-0035 adopts this technique by recombining the plugin's existing primitives rather than building a new subsystem.
 
 This design covers the distillation sprint loop (`/sdd:distill`), the routing recommender (`/sdd:route`), the harness-adapter abstraction, the markdown-native manifest, and the `/sdd:plan --distill` integration. It deliberately scopes out weight-level fine-tuning.
 

--- a/docs/openspec/specs/skill-distillation/spec.md
+++ b/docs/openspec/specs/skill-distillation/spec.md
@@ -1,0 +1,140 @@
+---
+status: draft
+date: 2026-06-10
+implements: [ADR-0034]
+requires: [SPEC-0017, SPEC-0007]
+---
+
+# SPEC-0035: Skill Distillation
+
+## Overview
+
+This capability lets Claude (the frontier **teacher**) iteratively author and refine markdown skill artifacts that a cheaper, locally-hosted **student** model can execute inside an open agent harness at measured, Claude-relative parity. It adds two skills — `/sdd:distill` (the distillation sprint loop) and `/sdd:route` (model/harness/skill recommendation) — a markdown-native distillation manifest, and an integration point in `/sdd:plan` that annotates issues with suggested local execution. See ADR-0034. Parity is measured by reusing the evaluation harness from SPEC-0017; routing annotations extend the planning flow from SPEC-0007.
+
+## Requirements
+
+### Requirement: Distillation Sprint Loop
+
+The `/sdd:distill` skill MUST run a distillation sprint scoped to a `{skill, model, harness}` triple. Each sprint iteration MUST, in order: produce a teacher reference run, produce a student pair run, score the pair run against the reference to yield a parity score, and — when parity is below the configured threshold — refine the skill artifacts before repeating. The skill MUST terminate when parity converges past the threshold or a configured maximum iteration count is reached, whichever comes first.
+
+#### Scenario: Sprint converges
+
+- **WHEN** `/sdd:distill` is run for a `{skill, model, harness}` triple and a pair run reaches or exceeds the parity threshold
+- **THEN** the loop stops, the converged parity score and the refined artifacts are recorded in the distillation manifest, and the skill reports the triple as distilled
+
+#### Scenario: Sprint hits iteration ceiling without converging
+
+- **WHEN** the configured maximum iteration count is reached before parity crosses the threshold
+- **THEN** the loop stops, the best observed parity score is recorded, and the triple is reported as NOT distilled with the remaining gap summarized
+
+### Requirement: Pair-Session Execution and Reference Capture
+
+Each sprint iteration MUST capture a teacher **reference run** by having Claude perform the task, and a student **pair run** by dispatching the identical task to the local model through the configured harness adapter. Both runs MUST be persisted as inspectable transcripts so the gap can be evaluated and later reused as training data.
+
+#### Scenario: Reference and pair runs captured for the same task
+
+- **WHEN** a sprint iteration executes a task
+- **THEN** the teacher reference transcript and the student pair transcript for that identical task input are both persisted under the distillation artifact directory
+
+#### Scenario: Local endpoint unreachable during a pair run
+
+- **WHEN** the harness adapter cannot reach the configured model endpoint
+- **THEN** the skill MUST surface the failure with the endpoint and harness named, MUST NOT fabricate a pair run or parity score, and MUST stop the sprint rather than silently degrade
+
+### Requirement: Parity Evaluation Reuses the Eval Harness
+
+Parity scoring MUST reuse the evaluation harness defined in SPEC-0017 rather than introduce a parallel grader. The pair run MUST be scored against the same per-skill assertions used by the existing evals, and the result MUST be expressed as a **Claude-relative parity score** (how close the student came to the teacher's reference), explicitly NOT as an absolute-correctness score.
+
+#### Scenario: Parity computed from existing assertions
+
+- **WHEN** a pair run is scored
+- **THEN** the score is derived from the skill's existing eval assertions and labeled as parity-relative-to-Claude in all outputs and manifest entries
+
+#### Scenario: Parity persisted as a benchmark
+
+- **WHEN** a sprint records a parity score
+- **THEN** the score is persisted under the eval benchmarks directory keyed by the `{skill, model, harness}` triple, consistent with the SPEC-0017 benchmark format
+
+### Requirement: Artifact Refinement and Convergence
+
+When parity is below threshold, the skill MUST refine the student-facing artifacts — the skill's `references/` and helper `scripts/`, and the `SKILL.md` where necessary — to close the measured gap. Refinements that target the weaker student (added procedural detail, sharper trigger keywords, tool-call scaffolding) SHOULD be additive (references and scripts) and MUST NOT degrade the skill's quality for the frontier teacher.
+
+#### Scenario: Gap closed by additive guidance
+
+- **WHEN** a parity gap is traced to a step the student performed incorrectly
+- **THEN** the refinement adds clarifying guidance via references or scripts, and the change is recorded so the next iteration can be attributed to it
+
+#### Scenario: Refinement must not regress the teacher
+
+- **WHEN** a proposed refinement would reduce the skill's effectiveness for the frontier model
+- **THEN** the refinement MUST be rejected or relocated into student-scoped references rather than applied to the core skill body
+
+### Requirement: Harness Adapter Abstraction
+
+Harnesses MUST be integrated through an adapter contract exposing three operations: install a skill into the harness, dispatch a task, and capture the task's output. **Crush** MUST be provided as the reference adapter. The model layer MUST target a generic OpenAI-compatible endpoint so that any runner (e.g., Ollama, llama.cpp, vLLM) serving any compatible model is interchangeable via configuration. No skill in this capability MAY hard-code a specific harness or runner.
+
+#### Scenario: Crush adapter dispatches a pair run
+
+- **WHEN** the manifest selects the Crush adapter for a triple
+- **THEN** `/sdd:distill` installs the skill into Crush, dispatches the task, and captures the output through the adapter contract without harness-specific logic leaking into the skill body
+
+#### Scenario: Model runner swapped via configuration
+
+- **WHEN** the manifest's OpenAI-compatible endpoint is repointed from one runner to another serving a different model
+- **THEN** the distillation loop runs unchanged against the new endpoint with no skill edits required
+
+### Requirement: Distillation Manifest
+
+The capability MUST persist a markdown-native manifest (per ADR-0015) under `docs/distillation/` that registers the available harness adapters, model endpoints, and per-`{skill, model, harness}`-triple parity scores with the date each was measured. The manifest MUST be the single source of truth that `/sdd:route` reads.
+
+#### Scenario: Manifest updated after a sprint
+
+- **WHEN** a distillation sprint completes
+- **THEN** the manifest's entry for that triple is created or updated with the converged (or best) parity score and the measurement date
+
+#### Scenario: Manifest is human-readable and diffable
+
+- **WHEN** a manifest entry changes
+- **THEN** the change is expressed as a reviewable markdown diff rather than an opaque binary or generated blob
+
+### Requirement: Routing Recommendation
+
+The `/sdd:route` skill MUST, given a task description or a tracker issue, read the manifest and recommend a `{harness, model, skill}` for local execution together with an explicit cloud-escalation condition. When no triple meets the parity threshold for the relevant skill, the recommendation MUST default to frontier-model (cloud) execution.
+
+#### Scenario: Local recommendation above threshold
+
+- **WHEN** `/sdd:route` is given a task whose skill has a distilled triple at or above threshold
+- **THEN** it recommends that harness + model + skill for local execution and states the condition under which the task should instead escalate to the cloud
+
+#### Scenario: No qualifying triple
+
+- **WHEN** no triple for the relevant skill meets the parity threshold
+- **THEN** `/sdd:route` recommends frontier-model execution and names the missing/under-threshold triple
+
+### Requirement: Plan Integration via Execution Section
+
+`/sdd:plan` MUST accept a `--distill` flag, default off, mirroring the existing optional-section flags. When `--distill` is set, each generated issue body MUST include an `### Execution` section populated from `/sdd:route` containing the suggested model, suggested harness, required distilled skill(s), and the cloud-escalation condition. When `--distill` is not set, issue bodies MUST be unchanged from current behavior.
+
+#### Scenario: Plan with --distill annotates issues
+
+- **WHEN** `/sdd:plan --distill` runs against a spec
+- **THEN** every generated story issue body contains an `### Execution` section with suggested model, harness, required skills, and escalation condition
+
+#### Scenario: Plan without --distill is unchanged
+
+- **WHEN** `/sdd:plan` runs without `--distill`
+- **THEN** no `### Execution` section is added and the issue bodies match the pre-existing plan output exactly
+
+### Requirement: Graceful Degradation
+
+Every part of the capability that depends on an external harness or model endpoint MUST degrade gracefully and MUST NOT block the SDD flow when those dependencies are absent. Distillation-specific failures MUST surface a clear, actionable message naming the missing dependency rather than producing fabricated or silent results.
+
+#### Scenario: Routing with an empty manifest
+
+- **WHEN** `/sdd:route` or `/sdd:plan --distill` runs and no distilled triples exist yet
+- **THEN** the recommendation defaults to cloud execution with a note that no local triples are available, and the plan/route operation still completes successfully
+
+#### Scenario: Harness adapter missing on the host
+
+- **WHEN** the configured harness binary is not installed in the environment
+- **THEN** `/sdd:distill` surfaces a one-line unavailability notice naming the harness and stops the sprint without raising an unhandled error

--- a/docs/openspec/specs/skill-distillation/spec.md
+++ b/docs/openspec/specs/skill-distillation/spec.md
@@ -9,7 +9,7 @@ requires: [SPEC-0017, SPEC-0007]
 
 ## Overview
 
-This capability lets Claude (the frontier **teacher**) iteratively author and refine markdown skill artifacts that a cheaper, locally-hosted **student** model can execute inside an open agent harness at measured, Claude-relative parity. It adds two skills — `/sdd:distill` (the distillation sprint loop) and `/sdd:route` (model/harness/skill recommendation) — a markdown-native distillation manifest, and an integration point in `/sdd:plan` that annotates issues with suggested local execution. See ADR-0034. Parity is measured by reusing the evaluation harness from SPEC-0017; routing annotations extend the planning flow from SPEC-0007.
+This capability lets Claude (the frontier **teacher**) iteratively author and refine small, discrete markdown skills that a cheaper, locally-hosted **student** model can execute inside an open agent harness at measured, Claude-relative parity. It adds two skills — `/sdd:distill` (the distillation sprint loop) and `/sdd:route` (model/harness/skill recommendation), an integration point in `/sdd:plan` that annotates issues with suggested local execution, configuration carried in `CLAUDE.md` per ADR-0015, and runtime artifacts under a gitignored `.sdd/distillation/` directory. See ADR-0034. The student runs by shelling out to the harness's own CLI; endpoints and tokens come from conventional environment variables. Parity is measured by reusing the evaluation harness from SPEC-0017; routing annotations extend the planning flow from SPEC-0007.
 
 ## Requirements
 
@@ -55,51 +55,56 @@ Parity scoring MUST reuse the evaluation harness defined in SPEC-0017 rather tha
 - **WHEN** a sprint records a parity score
 - **THEN** the score is persisted under the eval benchmarks directory keyed by the `{skill, model, harness}` triple, consistent with the SPEC-0017 benchmark format
 
-### Requirement: Artifact Refinement and Convergence
+### Requirement: Convergence by Skill Decomposition
 
-When parity is below threshold, the skill MUST refine the student-facing artifacts — the skill's `references/` and helper `scripts/`, and the `SKILL.md` where necessary — to close the measured gap. Refinements that target the weaker student (added procedural detail, sharper trigger keywords, tool-call scaffolding) SHOULD be additive (references and scripts) and MUST NOT degrade the skill's quality for the frontier teacher.
+When parity is below threshold, the skill MUST close the gap primarily by **decomposing** the target skill into smaller, single-purpose discrete skills, each sized to fit a local model's limited context window, and by tightening each skill's trigger keywords so the right small skill surfaces for the right step. The skill MUST NOT close gaps by accumulating guidance that inflates a single skill's context beyond what the student model can hold. Decomposition MUST preserve behavior: the decomposed set MUST compose back to the frontier skill's outcome and MUST NOT degrade the skill's quality for the frontier teacher.
 
-#### Scenario: Gap closed by additive guidance
+#### Scenario: Gap closed by splitting a skill
 
-- **WHEN** a parity gap is traced to a step the student performed incorrectly
-- **THEN** the refinement adds clarifying guidance via references or scripts, and the change is recorded so the next iteration can be attributed to it
+- **WHEN** a parity gap is traced to a step the student performed incorrectly and the student's context is a limiting factor
+- **THEN** the failing concern is split into a smaller discrete skill with focused triggers, and the split is recorded so the next iteration's parity change can be attributed to it
 
-#### Scenario: Refinement must not regress the teacher
+#### Scenario: Decomposition must not regress the teacher
 
-- **WHEN** a proposed refinement would reduce the skill's effectiveness for the frontier model
-- **THEN** the refinement MUST be rejected or relocated into student-scoped references rather than applied to the core skill body
+- **WHEN** a proposed decomposition would change or reduce the skill's outcome for the frontier model
+- **THEN** the decomposition MUST be rejected or reworked so the small skills still compose to the original frontier behavior
+
+#### Scenario: Context budget respected
+
+- **WHEN** a candidate skill's instructions would exceed the configured student model's context budget
+- **THEN** the skill MUST be split further rather than shipped as a single oversized unit
 
 ### Requirement: Harness Adapter Abstraction
 
-Harnesses MUST be integrated through an adapter contract exposing three operations: install a skill into the harness, dispatch a task, and capture the task's output. **Crush** MUST be provided as the reference adapter. The model layer MUST target a generic OpenAI-compatible endpoint so that any runner (e.g., Ollama, llama.cpp, vLLM) serving any compatible model is interchangeable via configuration. No skill in this capability MAY hard-code a specific harness or runner.
+Harnesses MUST be integrated through an adapter contract exposing three operations: install a skill into the harness, dispatch a task, and capture the task's output. The dispatch operation MUST execute by **shelling out to the harness's own CLI as a subprocess** — it MUST NOT depend on Claude Code's Task/subagent mechanism (which runs Claude models) and MUST NOT require a bespoke backend service. An MCP-backed adapter MAY be provided as an alternative variant for harnesses exposed that way. **Crush** MUST be provided as the reference adapter. The student model MUST be reached through a generic OpenAI-compatible endpoint whose location and credentials are resolved from **conventional environment variables** (e.g., `OPENAI_BASE_URL`, `OPENAI_API_KEY`, plus each harness's native env conventions) so that any runner (e.g., Ollama, llama.cpp, vLLM) serving any compatible model is interchangeable. Endpoints and tokens MUST NOT be stored in committed configuration. No skill in this capability MAY hard-code a specific harness or runner.
 
 #### Scenario: Crush adapter dispatches a pair run
 
-- **WHEN** the manifest selects the Crush adapter for a triple
-- **THEN** `/sdd:distill` installs the skill into Crush, dispatches the task, and captures the output through the adapter contract without harness-specific logic leaking into the skill body
+- **WHEN** the registered configuration selects the Crush adapter for a triple
+- **THEN** `/sdd:distill` installs the skill into Crush, dispatches the task by invoking the Crush CLI as a subprocess, and captures the output through the adapter contract without harness-specific logic leaking into the skill body
 
-#### Scenario: Model runner swapped via configuration
+#### Scenario: Model runner swapped via environment
 
-- **WHEN** the manifest's OpenAI-compatible endpoint is repointed from one runner to another serving a different model
-- **THEN** the distillation loop runs unchanged against the new endpoint with no skill edits required
+- **WHEN** the OpenAI-compatible endpoint environment variables are repointed from one runner to another serving a different model
+- **THEN** the distillation loop runs unchanged against the new endpoint with no skill or committed-config edits required
 
-### Requirement: Distillation Manifest
+### Requirement: Configuration and Artifact Layout
 
-The capability MUST persist a markdown-native manifest (per ADR-0015) under `docs/distillation/` that registers the available harness adapters, model endpoints, and per-`{skill, model, harness}`-triple parity scores with the date each was measured. The manifest MUST be the single source of truth that `/sdd:route` reads.
+Configuration — which harness adapters and model identifiers are registered for distillation — MUST live in a structured **Distillation** section in `CLAUDE.md` per ADR-0015, NOT in a bespoke config file. Endpoints and tokens MUST be resolved from environment variables rather than recorded in that section. Runtime artifacts — pair-session transcripts and working parity state — MUST be written under a gitignored `.sdd/distillation/` directory consistent with the repo's existing `.sdd-*` hidden state. Durable parity scores MUST be recorded in `evals/benchmarks/` per `{skill, model, harness}` triple per SPEC-0017. `/sdd:route` MUST read the registered configuration together with the recorded parity scores.
 
-#### Scenario: Manifest updated after a sprint
+#### Scenario: Configuration registered in CLAUDE.md
 
-- **WHEN** a distillation sprint completes
-- **THEN** the manifest's entry for that triple is created or updated with the converged (or best) parity score and the measurement date
+- **WHEN** a harness adapter or model is registered for distillation
+- **THEN** the registration appears as a human-readable entry in the `CLAUDE.md` Distillation section, and no endpoint URL or token is committed there
 
-#### Scenario: Manifest is human-readable and diffable
+#### Scenario: Runtime artifacts are gitignored
 
-- **WHEN** a manifest entry changes
-- **THEN** the change is expressed as a reviewable markdown diff rather than an opaque binary or generated blob
+- **WHEN** a sprint writes pair-session transcripts or working parity state
+- **THEN** those artifacts land under `.sdd/distillation/` and are excluded from version control, while the durable parity score is recorded in `evals/benchmarks/`
 
 ### Requirement: Routing Recommendation
 
-The `/sdd:route` skill MUST, given a task description or a tracker issue, read the manifest and recommend a `{harness, model, skill}` for local execution together with an explicit cloud-escalation condition. When no triple meets the parity threshold for the relevant skill, the recommendation MUST default to frontier-model (cloud) execution.
+The `/sdd:route` skill MUST, given a task description or a tracker issue, read the registered configuration and recorded parity scores and recommend a `{harness, model, skill}` for local execution together with an explicit cloud-escalation condition. When no triple meets the parity threshold for the relevant skill, the recommendation MUST default to frontier-model (cloud) execution.
 
 #### Scenario: Local recommendation above threshold
 
@@ -129,9 +134,9 @@ The `/sdd:route` skill MUST, given a task description or a tracker issue, read t
 
 Every part of the capability that depends on an external harness or model endpoint MUST degrade gracefully and MUST NOT block the SDD flow when those dependencies are absent. Distillation-specific failures MUST surface a clear, actionable message naming the missing dependency rather than producing fabricated or silent results.
 
-#### Scenario: Routing with an empty manifest
+#### Scenario: Routing with no registered triples
 
-- **WHEN** `/sdd:route` or `/sdd:plan --distill` runs and no distilled triples exist yet
+- **WHEN** `/sdd:route` or `/sdd:plan --distill` runs and no distilled triples have been recorded yet
 - **THEN** the recommendation defaults to cloud execution with a note that no local triples are available, and the plan/route operation still completes successfully
 
 #### Scenario: Harness adapter missing on the host

--- a/docs/openspec/specs/skill-distillation/spec.md
+++ b/docs/openspec/specs/skill-distillation/spec.md
@@ -1,15 +1,15 @@
 ---
 status: draft
 date: 2026-06-10
-implements: [ADR-0034]
+implements: [ADR-0035]
 requires: [SPEC-0017, SPEC-0007]
 ---
 
-# SPEC-0035: Skill Distillation
+# SPEC-0036: Skill Distillation
 
 ## Overview
 
-This capability lets Claude (the frontier **teacher**) iteratively author and refine small, discrete markdown skills that a cheaper, locally-hosted **student** model can execute inside an open agent harness at measured, Claude-relative parity. It adds two skills — `/sdd:distill` (the distillation sprint loop) and `/sdd:route` (model/harness/skill recommendation), an integration point in `/sdd:plan` that annotates issues with suggested local execution, configuration carried in `CLAUDE.md` per ADR-0015, and runtime artifacts under a gitignored `.sdd/distillation/` directory. See ADR-0034. The student runs by shelling out to the harness's own CLI; endpoints and tokens come from conventional environment variables. Parity is measured by reusing the evaluation harness from SPEC-0017; routing annotations extend the planning flow from SPEC-0007.
+This capability lets Claude (the frontier **teacher**) iteratively author and refine small, discrete markdown skills that a cheaper, locally-hosted **student** model can execute inside an open agent harness at measured, Claude-relative parity. It adds two skills — `/sdd:distill` (the distillation sprint loop) and `/sdd:route` (model/harness/skill recommendation), an integration point in `/sdd:plan` that annotates issues with suggested local execution, configuration carried in `CLAUDE.md` per ADR-0015, and runtime artifacts under a gitignored `.sdd/distillation/` directory. See ADR-0035. The student runs by shelling out to the harness's own CLI; endpoints and tokens come from conventional environment variables. Parity is measured by reusing the evaluation harness from SPEC-0017; routing annotations extend the planning flow from SPEC-0007.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

Design-only scaffolding for grafting Tomasz Tunguz's ["skill distillation"](https://tomtunguz.com/the-pi-agent-skill-distillation/) technique onto the SDD plugin. Claude (the **teacher**) iteratively refines markdown skills that a cheap, locally-hosted model (the **student**) runs in an open agent harness at measured, Claude-relative parity — keeping routine SDD work local and escalating only hard tasks to the cloud (the "minimill"). Routing recommendations surface at plan time.

No skills or config are implemented yet — this PR is **governing docs only**, authored through the plugin's own SDD conventions (MADR ADR + paired OpenSpec spec).

## What's in here

**ADR-0034 — Skill Distillation for Local Models** (`docs/adrs/`)
- Weighs four options (distillation loop / weight fine-tuning / static prompt porting / do nothing) and chooses the **skill-distillation loop** because it recombines primitives the plugin already owns (skills, evals, planning) into version-controlled markdown rather than opaque weights.
- Commits to: harness-agnostic adapters (**Crush** as the reference adapter), a **runner-agnostic** OpenAI-compatible model layer, parity measured via the existing eval harness, and a `/sdd:plan --distill` integration.
- DSPy/GEPA weight-optimization is explicitly deferred to an optional later track that would consume the pair-session transcripts this capability produces.
- Frontmatter: `governs: [SPEC-0035]`, `related: [ADR-0021, ADR-0028, ADR-0015]`.

**SPEC-0035 — Skill Distillation** (`docs/openspec/specs/skill-distillation/`, paired `spec.md` + `design.md`)
- Nine RFC-2119 requirements with WHEN/THEN scenarios: the `/sdd:distill` sprint loop, pair-session capture, parity scoring that **reuses the SPEC-0017 eval harness**, additive/student-scoped refinement, the three-operation harness adapter contract, the markdown-native manifest, `/sdd:route`, the opt-in `### Execution` section in `/sdd:plan --distill`, and graceful degradation.
- Frontmatter: `implements: [ADR-0034]`, `requires: [SPEC-0017, SPEC-0007]`.

## Design decisions baked in

- **Crush** is the first/reference harness adapter; the three-operation contract (install-skill, dispatch-task, capture-output) keeps OpenCode/Goose/Codex as easy follow-ons.
- **Runner-agnostic** model layer — targets a generic OpenAI-compatible endpoint, so Ollama / llama.cpp / vLLM are interchangeable via config.
- **Parity is Claude-relative, not absolute** — the spec mandates labeling it as such everywhere.
- Refinements are **additive and student-scoped** (into `references/`/`scripts/`) so distilling for a weaker student can't regress the skill for the frontier teacher.

## Next steps (not in this PR)

- Mark ADR-0034 `accepted` when the decision is settled.
- `/sdd:plan SPEC-0035` to break the spec into implementation issues (natural first slices: adapter contract + Crush adapter, `/sdd:distill` loop, `/sdd:route` + `--distill` plan integration).

https://claude.ai/code/session_015X2X2RyztEnd3zTZQ6avM9

---
_Generated by [Claude Code](https://claude.ai/code/session_015X2X2RyztEnd3zTZQ6avM9)_