### PR TITLE
fix(ci): point eval-tier3 at evals/evals.json instead of nonexistent tier3.json

### DIFF
--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            Run eval prompts from evals/tier3.json for Tier 3 skills (adr, init, prime, list, status, organize, enrich).
+            Run eval prompts from evals/evals.json, filtered to the Tier 3 skills (adr, init, prime, list, status, organize, enrich) — run only the entries whose "skill" field is one of those.
 
             For each eval entry:
             1. Read the eval prompt and assertions


### PR DESCRIPTION
## What changed

The `eval-tier3` job in `.github/workflows/skill-evals.yml` told the agent to read eval prompts from `evals/tier3.json` — a file that has never existed. The only prompt corpus is `evals/evals.json`, which is what the sibling `eval-changed` and `eval-full` jobs already read, and the change-detection step only keys on `evals/evals.json` / `evals/triggers/`, so nothing could have kept a separate `tier3.json` in sync even if one were added.

The job now reads from `evals/evals.json` filtered by each entry's `skill` field to the Tier 3 set (adr, init, prime, list, status, organize, enrich) — the same scoping approach `eval-changed` uses with its changed-skills list.

The remaining `eval-results/tier3.json` references in the job are untouched: that path is the job's **output** artifact, not an input.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/skill-evals.yml'))"` — parses clean
- `grep tier3.json` on the workflow now matches only the two output-artifact lines
- Confirmed `evals/evals.json` entries carry a `skill` field covering all seven Tier 3 skills

Fixes #190

🤖 Posted on behalf of `@joestump` by [`claude-fable-5`](https://openrouter.ai/anthropic/claude-fable-5) using [Claude Code](https://claude.ai).