### PR TITLE
fix(review): stop flagging standalone ======= as a conflict marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Picks up tracker issues and implements them in parallel using git worktrees:
 Reviews and merges PRs produced by `/sdd:work` using reviewer-responder agent pairs:
 - Discovers open PRs by spec number or explicit PR numbers
 - Organizes agents into reviewer-responder pairs (default 2 pairs, configurable with `--pairs`)
-- **Conflict-marker CI gate**: Before any review logic, scans all PR files for unresolved merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`). PRs with conflict markers are rejected immediately with file paths and line numbers — zero tolerance across all file types.
+- **Conflict-marker CI gate**: Before any review logic, scans all PR files for unresolved merge conflict markers (`<<<<<<<` and `>>>>>>>` anywhere; `=======` only between such a pair, so Markdown setext underlines don't false-positive). PRs with conflict markers are rejected immediately with file paths and line numbers — zero tolerance across all file types.
 - Verifies all CI/CD status checks (GitHub Actions, Gitea Actions, GitLab CI) are green before reviewing — PRs with failing checks are skipped
 - Reviewers check diffs against spec acceptance criteria and ADR compliance (not just style)
 - Responders address feedback by pushing fix commits and replying to review comments

--- a/docs/openspec/specs/parallel-agent-coordination/spec.md
+++ b/docs/openspec/specs/parallel-agent-coordination/spec.md
@@ -167,7 +167,7 @@ Agents MUST NOT modify spec files (`docs/openspec/specs/`), ADR files (`docs/adr
 
 ### Requirement: Conflict-Marker CI Gate
 
-`/sdd:review` MUST check all files in a PR diff for conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) before approving the PR. If any conflict markers are found, `/sdd:review` MUST reject the PR with a clear error message identifying the file(s) and line numbers containing conflict markers. This check MUST run before any other review logic. `/sdd:review` MUST NOT approve or merge a PR that contains conflict markers under any circumstances.
+`/sdd:review` MUST check all files in a PR diff for conflict markers before approving the PR. The bracketing markers `<<<<<<<` and `>>>>>>>` are each sufficient on their own; a `=======` separator line MUST be treated as a conflict marker only when it appears between a `<<<<<<<` line and a `>>>>>>>` line in the same file, because a standalone `=======` is legitimate content (e.g. a Markdown setext H1 underline beneath a seven-character title, or an ASCII divider). If any conflict markers are found, `/sdd:review` MUST reject the PR with a clear error message identifying the file(s) and line numbers containing conflict markers. This check MUST run before any other review logic. `/sdd:review` MUST NOT approve or merge a PR that contains conflict markers under any circumstances.
 
 #### Scenario: Conflict markers detected in PR
 
@@ -183,3 +183,8 @@ Agents MUST NOT modify spec files (`docs/openspec/specs/`), ADR files (`docs/adr
 
 - **WHEN** `/sdd:review` examines a PR that contains conflict markers in a markdown documentation file (`README.md`)
 - **THEN** the conflict-marker gate still triggers and rejects the PR, because conflict markers in any file type indicate an unresolved merge conflict
+
+#### Scenario: Setext heading underline is not a conflict marker
+
+- **WHEN** `/sdd:review` examines a PR whose diff adds a Markdown setext heading (a seven-character title such as `Summary` underlined by `=======`) with no `<<<<<<<` or `>>>>>>>` lines in the same file
+- **THEN** the conflict-marker gate passes, because a standalone `=======` line is legitimate Markdown and only counts as a conflict marker between a `<<<<<<<`/`>>>>>>>` pair

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -388,7 +388,7 @@
           "type": "structural"
         },
         {
-          "text": "PR diffs scanned for <<<<<<<, =======, >>>>>>> markers",
+          "text": "PR diffs scanned for conflict markers: <<<<<<< and >>>>>>> anywhere, ======= only between a <<<<<<</>>>>>>> pair in the same file",
           "type": "structural"
         },
         {

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -55,7 +55,7 @@ You are reviewing PRs produced by `/sdd:work` using reviewer-responder agent pai
       - **Gitea**: Use MCP tools (discovered via `ToolSearch`) to fetch the PR diff.
       - **GitLab**: Use MCP tools or `glab mr diff`.
 
-   2. Scan every line of the diff for conflict markers: `<<<<<<<`, `=======`, `>>>>>>>`.
+   2. Scan every line of the diff for conflict markers. The bracketing markers `<<<<<<<` (conflict start) and `>>>>>>>` (conflict end) are distinctive — flag any diff line beginning with either. Treat a `=======` separator line as a conflict marker **only when it appears between a `<<<<<<<` line and a `>>>>>>>` line in the same file** — a standalone run of seven equals signs is legitimate content (a Markdown setext H1 underline beneath a 7-character title like `Summary`, or an ASCII divider) and MUST NOT trigger the gate on its own.
 
    3. **If ANY conflict markers are found:**
       - Collect all offending file paths and line numbers.
@@ -307,7 +307,7 @@ You are reviewing PRs produced by `/sdd:work` using reviewer-responder agent pai
 - MUST re-verify CI status after responder pushes fixes — never merge with failing checks
 - MUST NOT merge a PR unless ALL status checks are passing
 - This skill reads CLAUDE.md configuration but MUST NOT write to it (consumer, not producer) (Governing: SPEC-0009 REQ "Configuration Persistence")
-- MUST scan ALL files in every PR diff for conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) before any review logic runs (Governing: SPEC-0015 REQ "Conflict-Marker CI Gate")
+- MUST scan ALL files in every PR diff for conflict markers before any review logic runs; `<<<<<<<` and `>>>>>>>` flag on their own, while `=======` counts only between a `<<<<<<<`/`>>>>>>>` pair in the same file — a standalone `=======` (e.g. a Markdown setext heading underline) is not a conflict marker (Governing: SPEC-0015 REQ "Conflict-Marker CI Gate")
 - MUST reject PRs with conflict markers using REQUEST_CHANGES with file paths and line numbers — zero tolerance, any file type
 - MUST skip all further review (architecture context loading, spec compliance, code quality) for PRs rejected by the conflict-marker gate
 - Conflict-marker gate runs before CI checks — a PR with conflict markers is rejected even if CI is green


### PR DESCRIPTION
## What changed

The conflict-marker CI gate scanned diffs for three tokens including a bare `=======`. A Git conflict separator is exactly seven equals signs — but so is a Markdown **setext H1 underline** beneath any seven-character title (`Summary`, `Roadmap`, `Details`), and so are common ASCII dividers. A PR that merely *added* such a heading was rejected with `REQUEST_CHANGES` before any review logic ran.

The rule is now stated consistently everywhere it appears: `<<<<<<<` and `>>>>>>>` still flag on their own (they're distinctive and essentially never legitimate prose), while `=======` counts as a conflict marker **only when it appears between a `<<<<<<<` line and a `>>>>>>>` line in the same file** — per the issue's suggestion, anchoring alone (`^=======$`) is not enough since a setext underline still matches that.

Touched, in dependency order:

- `docs/openspec/specs/parallel-agent-coordination/spec.md` — REQ "Conflict-Marker CI Gate" reworded; new scenario added covering the setext-underline case
- `skills/review/SKILL.md` — step 3a.2 scan instruction + the Rules bullet
- `README.md` — feature blurb parenthetical
- `evals/evals.json` — the review-skill assertion text, so the eval checks the corrected rule

## Verification

- `python3 -c "import json; json.load(open('evals/evals.json'))"` — parses clean
- The spec's existing scenarios (bracketed markers in a Go file; markers in a markdown file) remain valid under the tightened rule — both describe full `<<<<<<<`…`>>>>>>>` occurrences

Fixes #191

🤖 Posted on behalf of `@joestump` by [`claude-fable-5`](https://openrouter.ai/anthropic/claude-fable-5) using [Claude Code](https://claude.ai).