### PR TITLE
fix(loop): flag the built-in rate table as a point-in-time snapshot with a staleness notice

### DIFF
--- a/references/loop-primitives.md
+++ b/references/loop-primitives.md
@@ -344,7 +344,17 @@ The plugin compiles in this default rate table as the fallback:
 | `claude-sonnet-4-7` | 3.00 | 15.00 |
 | `claude-haiku-4-7` | 0.25 | 1.25 |
 
+> **Freshness**: this table is a point-in-time snapshot (models and prices as of the `claude-*-4-7` generation). It is only revised when this file is edited — models released after it fall into the unknown-model $0 path below, and listed prices may lag the current rate card. The CLAUDE.md block above is the authoritative path; this table exists so a loop without one still gets order-of-magnitude cost accounting.
+
 When the CLAUDE.md block is missing or unparseable, set `rate_table_source = "built-in default"`.
+
+**Built-in-table staleness notice.** Because the fallback pins model IDs and prices at authoring time, implementations MUST surface a one-line notice on the first budget tick of a run whenever BOTH hold: `rate_table_source` is `"built-in default"` AND the dollar ceiling is active (`max_dollars` non-zero):
+
+```
+Cost accounting is using the plugin's built-in rate table (a point-in-time snapshot — newer models count $0.00, listed prices may be stale). Add a "#### Loop Cost Rates" block to CLAUDE.md's "### SDD Configuration" for authoritative rates.
+```
+
+The notice fires once per run and is independent of the per-model unknown-model warning below: it also covers the case where every model in the run *does* match the built-in table but the pinned prices have drifted, which the unknown-model path cannot detect.
 
 #### Unknown models
 


### PR DESCRIPTION
## What changed

The loop-budget fallback rate table in `references/loop-primitives.md` pins model IDs and per-Mtok prices at authoring time. A loop without a CLAUDE.md `#### Loop Cost Rates` block falls through to it, and once newer models ship they miss the table and silently contribute **$0** to `dollars_estimate` — the cost ceiling under-counts exactly when a budget matters most, with nothing flagging the default table as stale.

Issue #192 offered two options. Option (a) — dropping the built-in table and failing loud — is off the table: SPEC-0020 REQ "Cost Budget Stop" *mandates* the built-in fallback as priority 2 of the sourcing order. So this implements option (b):

1. **Freshness marker on the table itself** — an explicit note that it's a point-in-time snapshot, revised only when the file is edited, with the CLAUDE.md block as the authoritative path.
2. **Mandatory once-per-run staleness notice** whenever cost accounting runs on the built-in default with an active dollar ceiling (`rate_table_source == "built-in default"` AND `max_dollars` non-zero).

The notice is deliberately independent of the existing per-model unknown-model warning: it also covers the case where every model in the run *does* match the built-in table but the pinned prices have drifted — which the unknown-model path structurally cannot detect. The loop design doc already acknowledges this risk ("values may need refresh as rate cards evolve; the sourcing path is the durable contract") — this PR turns that acknowledgment into a user-visible signal.

## Verification

- Doc-only change; rendered markdown checked (table, blockquote, fenced notice block all valid)
- Consistent with SPEC-0020's mandated two-level sourcing order — no spec change required

Fixes #192

🤖 Posted on behalf of `@joestump` by [`claude-fable-5`](https://openrouter.ai/anthropic/claude-fable-5) using [Claude Code](https://claude.ai).