### PR TITLE
fix(docs): make the scaffolded docs-site's first build succeed

### DIFF
--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -20,7 +20,7 @@
     "@docusaurus/core": "3.9.2",
     "@docusaurus/plugin-client-redirects": "3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
-    "@docusaurus/theme-mermaid": "^3.9.2",
+    "@docusaurus/theme-mermaid": "3.9.2",
     "@mdx-js/react": "^3.0.0",
     "ajv": "^8.17.1",
     "clsx": "^2.0.0",

--- a/templates/docusaurus/package.json
+++ b/templates/docusaurus/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@docusaurus/core": "3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
-    "@docusaurus/theme-mermaid": "^3.9.2",
+    "@docusaurus/theme-mermaid": "3.9.2",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "lib-artifact-transforms": "github:joestump/lib-artifact-transforms#main",
@@ -32,6 +32,9 @@
     "@docusaurus/tsconfig": "3.9.2",
     "@docusaurus/types": "3.9.2",
     "typescript": "~5.6.2"
+  },
+  "overrides": {
+    "webpackbar": "^7.0.0"
   },
   "browserslist": {
     "production": [">0.5%", "not dead", "not op_mini all"],

--- a/templates/docusaurus/plugins/sdd-content/index.js
+++ b/templates/docusaurus/plugins/sdd-content/index.js
@@ -1052,6 +1052,12 @@ module.exports = function(context, options) {
   const specsSource = path.resolve(siteDir, specsDir);
   const docsDest = path.resolve(siteDir, outputDir);
 
+  // Docusaurus's docs plugin validates that its content directory exists at
+  // config-load time — before any plugin's loadContent() runs. Create the
+  // output directory eagerly at plugin construction so the first-ever build
+  // doesn't abort on a missing docs-generated/ (content lands in loadContent).
+  fs.mkdirSync(docsDest, { recursive: true });
+
   let baseUrl = '';
   const configPath = path.resolve(siteDir, 'docusaurus.config.ts');
   if (fs.existsSync(configPath)) {


### PR DESCRIPTION
## What changed

Three independent defects each hard-failed a freshly scaffolded docs-site's first-ever `npm run build` (reported from a real `/sdd:docs` adoption on Node 22, clean install):

1. **Missing `docs-generated/` at config load** — Docusaurus's `plugin-content-docs` validates that its content directory exists at config-load time, *before* any plugin's `loadContent()` runs. The `sdd-content` plugin only created `../docs-generated` during content generation, so the cold-start build aborted on a missing directory. `templates/docusaurus/plugins/sdd-content/index.js` now creates the output directory eagerly at plugin construction (`fs.mkdirSync(docsDest, { recursive: true })`), right where `docsDest` is resolved.

2. **`theme-mermaid` version drift** — the template pinned `@docusaurus/core` and `preset-classic` to exactly `3.9.2` but `theme-mermaid` to `^3.9.2`, which now resolves to 3.10.x and trips Docusaurus's own version-mismatch guard. Pinned exactly. The repo's own `docs-site/package.json` carried the identical latent defect one lockfile-regen away; pinned there too (its lockfile already resolves `3.9.2`, so `npm ci` is unaffected — verified).

3. **webpackbar 6 vs webpack ≥5.101** — a fresh install resolves a webpackbar 6.x that breaks against current webpack's ProgressPlugin schema. Added `"overrides": { "webpackbar": "^7.0.0" }` to the template `package.json`. Not applied to the repo's own docs-site: its lockfile freezes a compatible pair and touching it would force a lockfile regen out of scope here.

Scaffolded sites have no lockfile — every first `npm install` resolves fresh, which is why all three failed deterministically on cold start while the repo's own locked docs-site kept building.

## Verification

- `node --check templates/docusaurus/plugins/sdd-content/index.js` — parses
- Both `package.json` files parse as JSON
- Root docs-site: lockfile's resolved `@docusaurus/theme-mermaid` is `3.9.2`, so the exact pin keeps `npm ci` valid without regenerating the lockfile

Fixes #193

🤖 Posted on behalf of `@joestump` by [`claude-fable-5`](https://openrouter.ai/anthropic/claude-fable-5) using [Claude Code](https://claude.ai).