### PR TITLE
feat(skills): harness portability + fix qmd priming syntax (#200) and fallback context hygiene (#201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the SDD plugin (`claude-plugin-sdd`) are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/) and the project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Harness portability across Codex CLI, OpenCode, and Crush**: new `references/harness-compat.md` maps every Claude Code-specific tool surface the skills name (`AskUserQuestion`, `Task`, `TeamCreate`/`SendMessage`, `Task*`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) to per-harness equivalents and documented fallbacks, defines the project memory file resolution (`CLAUDE.md` / `AGENTS.md` / `CRUSH.md`), plugin-root resolution, permissions equivalents, and worktree placement rules. All 20 skills carry a standard portability note, `shared-patterns.md` generalizes Config Resolution to the memory file, `/sdd:init` selects the harness-native memory file and gates the `.claude/settings.local.json` permissions step to Claude Code, and `/sdd:work`'s `/autofix-pr` stage skips cleanly (without filing version issues) on harnesses that can never ship the built-in.
+
+### Fixed
+
+- **`/sdd:prime` untargeted-priming qmd commands now work against the real CLI** ([#200](https://github.com/joestump/claude-plugin-sdd/issues/200)): the documented `qmd query --json -c {c} --limit 10000 --minScore 0` pattern failed three ways — `--minScore` is the MCP parameter name (CLI is `--min-score`), the result cap flag is `-n`, and an empty query is not a wildcard (qmd's query expansion garbles it). Untargeted mode now enumerates via `qmd ls` per a new `qmd-helpers.md` § "Exhaustive Retrieval (list-all)" section; topic mode puts the positional query first with kebab-case flags. The `qmd-helpers.md` CLI example is corrected to match.
+- **Single-agent fallback in `/sdd:work` and `/sdd:review` no longer burns tokens on inline diff-reading** ([#201](https://github.com/joestump/claude-plugin-sdd/issues/201)): the TeamCreate-unavailable fallback paths now carry explicit context-hygiene rules — fork per-PR diff-read-and-verify to a subagent returning only a verdict + compact summary when subagents exist, otherwise default to `--name-only` plus targeted excerpts, and carry only outcome summaries between items. Canonical guidance lives in `harness-compat.md` § "Single-Agent Sequential Fallback".
+
 ## [5.2.1] — 2026-07-31
 
 Bug-fix release addressing five issues reported from real-world adoption ([#190](https://github.com/joestump/claude-plugin-sdd/issues/190)–[#194](https://github.com/joestump/claude-plugin-sdd/issues/194)). No new features, no breaking changes.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Claude Code plugin for architecture governance: ADRs, specifications, sprint planning, parallel implementation, code review, and documentation generation.
 
+The skills are written in the open Agent Skills format and are harness-portable: they also run under Codex CLI, OpenCode, and Crush. Claude Code-specific tool names in the skill bodies denote capabilities with per-harness mappings and fallbacks — see [references/harness-compat.md](references/harness-compat.md).
+
 ## Skills
 
 | Skill | Invoke | Description |

--- a/references/harness-compat.md
+++ b/references/harness-compat.md
@@ -1,0 +1,97 @@
+<!-- Governing: ADR-0015 (Markdown-Native Configuration), SPEC-0014 REQ "Config Resolution Pattern in shared-patterns.md" -->
+
+# Harness Compatibility Reference
+
+SDD skills are written in the open Agent Skills format (`SKILL.md`) and are designed to run on any agent harness that loads skills — Claude Code, Codex CLI, OpenCode, and Crush are the four we target explicitly. Skill bodies name Claude Code tool surfaces (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`/`TaskUpdate`/`TaskList`/`TaskGet`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) because that is the richest capability set; this reference defines how to interpret those names everywhere else.
+
+**The rule: tool names denote capabilities, not hard requirements.** When a SKILL.md names a tool your harness does not have, map it to your harness's equivalent capability, or apply the documented fallback below. A skill MUST NOT abort solely because a named tool does not exist — the fallback paths are part of the skill's contract.
+
+## Capability Map
+
+| Capability | Claude Code | Codex CLI | OpenCode | Crush | Fallback when absent |
+|------------|-------------|-----------|----------|-------|----------------------|
+| Ask the user a structured question | `AskUserQuestion` | Plain question in chat | Plain question in chat | Plain question in chat | Ask in plain text with options as a numbered list; in non-interactive/batch/CI mode, take the skill's documented default without asking |
+| Spawn a subagent | `Task` / `Agent` tool | None (treat as absent) | Subagent/task support (version-dependent) | None (treat as absent) | Do the work inline, sequentially, following § Single-Agent Sequential Fallback |
+| Team coordination + inter-agent messaging | `TeamCreate`, `SendMessage`, team-scoped `Task*` tools | None | None | None | Single-agent sequential mode (§ below). Skills with a `TeamCreate` flow always document this fallback |
+| Session task tracking | `TaskCreate` / `TaskUpdate` / `TaskList` / `TaskGet` | Harness todo/plan feature if present | Harness todo/plan feature if present | Harness todo/plan feature if present | Maintain a markdown checklist in the session (or a scratch file) and keep it current |
+| MCP tool discovery | `ToolSearch` | Configured MCP servers (no runtime probe) | Configured MCP servers | Configured MCP servers | If you cannot probe for an MCP tool, assume it is absent and use the CLI path |
+| MCP tools (`mcp__{server}__{tool}`) | Same naming | Server/tool naming differs per harness | Server/tool naming differs per harness | Server/tool naming differs per harness | Every MCP usage in these skills has a CLI equivalent (`gh`, `glab`, `tea`, `qmd`, `curl`); prefer the CLI when in doubt |
+| Web fetch / search | `WebFetch` / `WebSearch` | Built-in browsing if enabled | Built-in fetch if enabled | Built-in fetch if enabled | `curl -sL {url}` for fetch; skip non-essential web searches |
+| Worktree helpers | `EnterWorktree` | — | — | — | Plain `git worktree add` / `git worktree remove` commands (the skills already spell these out) |
+
+Harness capabilities change between releases — when in doubt, probe for the capability (attempt the call, or check the harness's tool list) rather than assuming from this table, and fall back gracefully.
+
+### Frontmatter
+
+The `allowed-tools` frontmatter key is Claude Code-specific (it restricts the tool surface there). Other harnesses ignore unknown frontmatter keys — treat it as informative, not restrictive.
+
+## Plugin Root Resolution
+
+`${CLAUDE_PLUGIN_ROOT}` means "the directory this plugin is installed in" — the directory containing `skills/`, `references/`, and `templates/`. Resolve it in this order:
+
+1. The `CLAUDE_PLUGIN_ROOT` environment variable, if set (Claude Code plugin runtime).
+2. Two levels up from the running skill's `SKILL.md` (`{plugin-root}/skills/{name}/SKILL.md`) — works on any harness that tells you where the skill was loaded from.
+3. Ask the user where the plugin is installed.
+
+Never silently substitute a stale copy of a reference file — if a `${CLAUDE_PLUGIN_ROOT}/references/*.md` path cannot be resolved, say so.
+
+## Project Memory File
+
+Wherever a SKILL.md or reference says "CLAUDE.md" in the context of project configuration (`## Architecture Context`, `### SDD Configuration`, `### Workspace Modules`), read it as **the project memory file**: the instructions file the harness auto-loads per project.
+
+| Harness | Native memory file |
+|---------|--------------------|
+| Claude Code | `CLAUDE.md` |
+| Codex CLI | `AGENTS.md` |
+| OpenCode | `AGENTS.md` |
+| Crush | `CRUSH.md` (also reads `AGENTS.md`/`CLAUDE.md` in most builds) |
+
+### Resolution rules
+
+- **Read**: check `CLAUDE.md`, then `AGENTS.md`, then `CRUSH.md` at the relevant root (project or module). The first file containing the SDD sections (`## Architecture Context` or `### SDD Configuration`) is the memory file for all subsequent reads and writes in the session. If none contains them, the project is not initialized — suggest `/sdd:init`.
+- **Write** (config producers: `/sdd:init`, `/sdd:plan`): converge into the file that already carries the SDD sections. On a fresh init, write to your harness's native memory file (table above); when unsure, `CLAUDE.md` remains the default for backward compatibility.
+- **Never duplicate** the SDD sections across multiple memory files — two sources of truth will drift. If the sections live in `CLAUDE.md` but your harness only auto-loads `AGENTS.md`, add a one-line pointer in `AGENTS.md` ("Architecture context and SDD configuration live in CLAUDE.md") rather than copying the content.
+
+## Single-Agent Sequential Fallback
+
+Skills that orchestrate parallel work (`/sdd:work`, `/sdd:review`, and the `--review`/`--scrum` modes of `/sdd:adr`, `/sdd:spec`, `/sdd:plan`, `/sdd:audit`) fall back to **single-agent sequential mode** when team primitives are unavailable — whether `TeamCreate` fails at runtime or was never a registered tool. The work still completes; what changes is *where reading happens*, and that has a real token cost: everything pulled into the lead session's context is resent on every subsequent turn, so a long multi-PR session compounds.
+
+Context-hygiene rules for sequential mode:
+
+1. **Never pull a full PR diff into the lead session by default.** Start with `gh pr diff {N} --name-only` (or tracker equivalent), then fetch targeted per-file excerpts for the files that matter to the acceptance criteria. Escalate to a full diff only when the targeted read is genuinely insufficient, and prefer reading it in a subagent (rule 2) when you do.
+2. **If subagents are available (just not teams), fork read-heavy verification.** Dispatch the per-PR "read the diff, check against acceptance criteria and CI" step to a subagent that returns only a verdict plus a compact summary — not the diff. The lead keeps orchestration state; the subagent absorbs the bulk reading.
+3. **Summarize, then move on.** After verifying a PR (or reading a large log, or dumping qmd results), carry forward only the verdict and a few-line summary. Do not re-quote large content in later turns.
+4. **Batch hygiene applies per item.** In a multi-PR loop, apply rules 1–3 to *each* PR — the compounding cost comes from the accumulation, not any single read.
+
+## Permissions and Approvals
+
+`/sdd:init`'s permissions step writes tool allowlists to `.claude/settings.local.json` — that file is Claude Code-specific. On other harnesses, skip the step and instead tell the user which commands the SDD skills will invoke (`git`, `gh`/`glab`/`tea`, `qmd`) so they can pre-approve them in their harness's own mechanism:
+
+| Harness | Where approvals live |
+|---------|----------------------|
+| Claude Code | `.claude/settings.local.json` `permissions.allow` |
+| Codex CLI | `~/.codex/config.toml` (approval policy / sandbox settings) |
+| OpenCode | `opencode.json` permission configuration |
+| Crush | Crush config (`crush.json`) allowed-tools settings |
+
+Do not write another harness's config file by guessing its schema — name the commands and let the user (or their harness docs) do the wiring.
+
+## Worktrees
+
+The default worktree base directory (`.claude/worktrees/`, from `### SDD Configuration` → `#### Worktrees` → `Base Dir`) matches Claude Code's managed worktree location, which is gitignored there. On other harnesses, set `Base Dir` to a path that is invisible to git and build tooling — `.sdd/worktrees/` works (`/sdd:init` already gitignores `.sdd/`), as does a sibling directory outside the repo. The invariant is the location's gitignore status, not the specific path: a worktree must never show up in `git status`, builds, or linters.
+
+## Skill-to-Skill Invocation
+
+The `/sdd:{name}` prefix is Claude Code plugin namespacing. When a SKILL.md says "run `/sdd:check`" (or suggests it to the user), read: "invoke the `check` skill however your harness invokes skills" — by slash command, by name, or by asking the agent to apply the skill. Non-SDD built-ins referenced by skills (e.g. `/autofix-pr` in `/sdd:work`) exist only on the harness that ships them; the referencing skill documents what to do when they are unavailable — follow that path rather than emulating the built-in.
+
+## Consumers
+
+All skills consume this reference via the standard harness-portability note under their title. Skills with harness-specific deep behavior additionally reference specific sections:
+
+| Skill | Sections |
+|-------|----------|
+| `/sdd:init` | Project Memory File; Permissions and Approvals |
+| `/sdd:work`, `/sdd:review` | Single-Agent Sequential Fallback; Worktrees; Skill-to-Skill Invocation |
+| `/sdd:respond` | Worktrees; Capability Map (MCP fallbacks) |
+| `/sdd:search`, `/sdd:index`, `/sdd:prime` | Capability Map (MCP tool discovery); Plugin Root Resolution |
+| All others | Capability Map; Plugin Root Resolution; Project Memory File |

--- a/references/qmd-helpers.md
+++ b/references/qmd-helpers.md
@@ -20,6 +20,8 @@ ToolSearch with query "select:mcp__plugin_qmd_qmd__status"
 
 If the tool resolves, the qmd MCP is loaded. If not, fall back to the `qmd` CLI.
 
+On harnesses without `ToolSearch` (Codex, OpenCode, Crush — per `harness-compat.md` § "Capability Map"), check your configured MCP servers for a qmd server if the harness exposes that list; otherwise skip the probe and use the CLI directly. The CLI path is always sufficient — MCP is an optimization, not a requirement.
+
 ### Operation routing
 
 | Operation | MCP tool (preferred when loaded) | CLI fallback |
@@ -61,10 +63,17 @@ mcp__plugin_qmd_qmd__query({
 ### Calling via CLI
 
 ```bash
-qmd query --json --limit 8 --min-score 0.3 \
-  -c "{repo}-adrs" -c "{repo}-specs" \
-  $'lex: <terms>\nvec: <question>\nintent: <context>'
+qmd query $'lex: <terms>\nvec: <question>\nintent: <context>' \
+  --json -n 8 --min-score 0.3 \
+  -c "{repo}-adrs" -c "{repo}-specs"
 ```
+
+CLI surface rules (verified against qmd 2.x; the CLI and MCP parameter names differ):
+
+- **The positional query MUST come immediately after `query`, before any flags.** Some qmd versions fail to parse the query when flags precede it.
+- **Flags are kebab-case on the CLI**: `--min-score`, not `--minScore`. `minScore`/`limit` are the MCP tool's parameter names only — never pass them as CLI flags.
+- **The result cap is `-n {K}`** (`--limit` is accepted by some versions but not all; `-n` is the documented flag). `--all` returns every match and pairs with `--min-score`.
+- On any usage error, check `qmd query --help` for the installed version's flag surface rather than retrying permutations.
 
 ### Strategy: choosing sub-query types
 
@@ -83,6 +92,21 @@ Put your strongest signal first — qmd weights the first sub-query 2× in its R
 Every result has `score` (0.0–1.0), `path`, `snippet`, and `context` (the human-written summary attached via `qmd context add`). Filter by `score >= minScore` and treat scores below ~0.3 as non-matches.
 
 For top-K retrieval used to "decide which artifacts to deep-read", typical K is 6–10. Going wider dilutes the signal; going narrower risks missing relevant artifacts.
+
+## Exhaustive Retrieval (list-all)
+
+Some skills need *every* document in a collection rather than a relevance-ranked top-K — e.g. `/sdd:prime`'s untargeted mode listing all ADRs and specs. **Do NOT use `qmd query` for this.** `qmd query` requires a real query string: an empty query is not a wildcard — qmd's query-expansion step garbles it (it has been observed expanding the empty query plus stray flag values into nonsense sub-queries) and the pipeline fails downstream.
+
+The correct primitive is `qmd ls`, which enumerates a collection deterministically with no search pipeline involved:
+
+```bash
+qmd ls {repo}-adrs
+qmd ls {repo}-specs
+```
+
+Output is one line per indexed file (`size  date  qmd://{collection}/{path}`). Parse the `qmd://` paths to get the document list, then read documents either via `qmd get qmd://{collection}/{path}` / `qmd multi-get`, or — since collections index local files — directly from disk at the corresponding repo path, whichever the consuming skill prefers.
+
+If `qmd ls` is unavailable or errors, fall back to direct file enumeration over the resolved artifact directories (`{adr-dir}/*.md`, `{spec-dir}/*/spec.md`) — for exhaustive listing the filesystem is an acceptable substitute because no ranking is involved. This fallback does NOT license skipping qmd for *ranked* retrieval (per ADR-0024).
 
 ## This-Repo Collection Identification
 

--- a/references/shared-patterns.md
+++ b/references/shared-patterns.md
@@ -4,6 +4,8 @@
 
 Patterns used across multiple SDD plugin skills. Skills reference specific sections by heading instead of duplicating the content.
 
+> **Harness portability.** Throughout this reference, "CLAUDE.md" means the **project memory file** — `CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`, resolved per `harness-compat.md` § "Project Memory File" (same directory as this file). Likewise, named tools (`AskUserQuestion`, `TeamCreate`, `SendMessage`, `ToolSearch`, …) denote capabilities with per-harness mappings and fallbacks defined in `harness-compat.md` § "Capability Map".
+
 ## Artifact Path Resolution
 
 <!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
@@ -160,7 +162,7 @@ Canonical algorithm for reading plugin configuration from CLAUDE.md. All skills 
 
 ### Step 1: Read Root CLAUDE.md
 
-Read the project-root `CLAUDE.md` and look for a `### SDD Configuration` section. If found, parse the subsections (`#### Tracker`, `#### Branch Conventions`, `#### PR Conventions`, `#### Review`, `#### Worktrees`, `#### Projects`) to extract configuration values.
+Resolve the project memory file at the project root (`CLAUDE.md`, then `AGENTS.md`, then `CRUSH.md` — first file containing the SDD sections wins, per `harness-compat.md` § "Project Memory File"; called `CLAUDE.md` below). Read it and look for a `### SDD Configuration` section. If found, parse the subsections (`#### Tracker`, `#### Branch Conventions`, `#### PR Conventions`, `#### Review`, `#### Worktrees`, `#### Projects`) to extract configuration values.
 
 ### Step 2: Merge Module Config (if applicable)
 
@@ -378,6 +380,8 @@ Skills use different team structures depending on the task:
 ### TeamCreate Required
 
 Any skill or session that spawns 2+ parallel agents MUST use `TeamCreate`, not ad-hoc `Agent` calls. `SendMessage` (required for the Worker Communication Protocol) only works within a Team. Ad-hoc background agents are isolated and cannot coordinate — they cannot see sibling agents' file claims, type creations, or conflict alerts. This applies both to skills and to sessions orchestrating multiple skills.
+
+On harnesses without team primitives (Codex, OpenCode, Crush — or a Claude Code session where `TeamCreate` is not registered), do NOT approximate a team with isolated parallel agents: the coordination protocols above cannot run, and uncoordinated parallel workers produce exactly the duplicate-type and file-conflict failures the protocols exist to prevent. Use the skill's single-agent sequential fallback instead, following `harness-compat.md` § "Single-Agent Sequential Fallback" for context hygiene.
 
 ## Try-Then-Create Label Pattern
 

--- a/skills/adr/SKILL.md
+++ b/skills/adr/SKILL.md
@@ -7,6 +7,8 @@ argument-hint: "[short description of the decision] [--review] [--module <name>]
 
 # Create an Architecture Decision Record (ADR)
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 You are creating a new ADR using the MADR (Markdown Architectural Decision Records) format.
 
 ## Process
@@ -52,7 +54,7 @@ You are creating a new ADR using the MADR (Markdown Architectural Decision Recor
      - Spawn an **architect** agent (`general-purpose`) to review the drafter's output for completeness, accuracy, and adherence to MADR format
      - The architect MUST review and approve the ADR before it is finalized
      - The drafter should research the codebase (read relevant files, understand the current architecture) before writing
-     - If `TeamCreate` fails, fall back to single-agent mode: draft the ADR directly, then self-review against the architect's checklist in the Rules section before writing.
+     - If `TeamCreate` fails — or is not a registered tool on this harness — fall back to single-agent mode: draft the ADR directly, then self-review against the architect's checklist in the Rules section before writing.
 
 2b. **Optional call graph embedding** (opt-in, SPEC-0034):
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -7,6 +7,8 @@ argument-hint: "[scope] [--review] [--scrum] [--module <name>]"
 
 # Comprehensive Design Audit
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 You are performing a deep, comprehensive audit of design artifact alignment across the project or a specified scope. This skill covers all six drift categories and produces a structured report with prioritized findings.
 
 ## Process
@@ -44,7 +46,7 @@ You are performing a deep, comprehensive audit of design artifact alignment acro
    - Create a Claude Team with `TeamCreate`:
      - Spawn an **auditor** agent (`general-purpose`) to perform the full analysis and write the audit report
      - Spawn a **reviewer** agent (`general-purpose`) to validate the auditor's findings for accuracy, completeness, and correct severity assignments
-   - If `TeamCreate` fails, fall back to single-agent mode and tell the user: "Team creation failed. Proceeding with single-agent audit and self-review."
+   - If `TeamCreate` fails — or is not a registered tool on this harness — fall back to single-agent mode and tell the user: "Team creation failed. Proceeding with single-agent audit and self-review."
 
    **With `--scrum`**: Scrum triage mode — see the **Scrum Triage Ceremony** section below. When `--scrum` is set, complete the standard audit analysis (steps 4–6) first, then enter the ceremony. Do NOT run `--review` mode when `--scrum` is set.
 

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -7,6 +7,8 @@ argument-hint: "[target] [--module <name>]"
 
 # Quick Drift Check
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 You are performing a fast, focused drift check on a specific target. This skill detects whether code aligns with its governing ADRs and specs.
 
 ## Process

--- a/skills/discover/SKILL.md
+++ b/skills/discover/SKILL.md
@@ -7,6 +7,8 @@ argument-hint: "[scope] [--module <name>] [--with-graphs]"
 
 # Discover Implicit Architecture
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 Explore an existing codebase to discover implicit architectural decisions and specification-worthy subsystems. Produces a suggestion report -- does NOT create any files.
 
 ## Process
@@ -35,7 +37,7 @@ Explore an existing codebase to discover implicit architectural decisions and sp
    - Build an exclusion list of already-documented decisions and subsystems
    - If neither directory exists, note that no existing artifacts were found (this is expected for first-time discovery)
 
-4. **Analyze the codebase** across four categories. Use the Task tool to spawn parallel Explore agents for each category. Each agent should return a list of findings with evidence.
+4. **Analyze the codebase** across four categories. Use the Task tool to spawn parallel Explore agents for each category; each agent should return a list of findings with evidence. On harnesses without subagents, run the four category analyses sequentially inline — same checklists, same findings format — and keep only each category's findings list in context (not the raw file reads) before starting the next category.
 
    **Agent 1 -- Dependency & Framework Analysis**:
    - Scan for project manifests (e.g., `package.json`, `requirements.txt`, `pyproject.toml`, `Cargo.toml`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, and other ecosystem-specific files).
@@ -214,7 +216,7 @@ This may indicate:
 ## Rules
 
 - This skill is READ-ONLY -- it MUST NOT create, modify, or delete any files
-- This skill is always single-agent at the top level, but MUST use Task tool to spawn parallel Explore agents for the four analysis categories
+- This skill is always single-agent at the top level, but MUST use the Task tool to spawn parallel Explore agents for the four analysis categories when subagents are available; without subagents, MUST run the four analyses sequentially inline, discarding raw file reads between categories
 - Every suggestion MUST cite specific evidence from the codebase -- file paths, dependency declarations, configuration entries, or code patterns
 - Suggestions MUST NOT be based on speculation or assumptions about code that was not read
 - MUST read existing ADRs and specs before producing suggestions to avoid duplicating already-documented decisions

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -8,6 +8,8 @@ context: fork  # Runs in a forked context to avoid polluting the main session wi
 
 # Generate Docusaurus Documentation Site
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 Transform ADRs and OpenSpec specs (located via the **Artifact Path Resolution** pattern from `${CLAUDE_PLUGIN_ROOT}/references/shared-patterns.md`) into a polished documentation website with:
 
 - RFC 2119 keyword highlighting (MUST, SHALL, MAY, etc.)

--- a/skills/enrich/SKILL.md
+++ b/skills/enrich/SKILL.md
@@ -9,6 +9,8 @@ argument-hint: "[SPEC-XXXX or spec-name] [--branch-prefix <prefix>] [--dry-run] 
 
 # Enrich Issues with Developer Workflow Conventions
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 You are retroactively adding `### Branch` and `### PR Convention` sections to existing tracker issues that were created by `/sdd:plan` (or manually) for a given spec. The canonical templates for these sections live in `${CLAUDE_PLUGIN_ROOT}/references/issue-authoring.md` § Enrichment Sections (which references `shared-patterns.md` for the underlying Branch Naming Conventions and PR Close Keywords). This skill is purely additive — it never replaces existing content.
 
 ## Process

--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -9,6 +9,8 @@ argument-hint: "<verb> [<artifact-id>] [--scope <subtree>] [--module <name>] [--
 
 # /sdd:graph — Artifact Graph Skill
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 You are running `/sdd:graph`. This skill builds an in-memory directed graph of the project's ADRs, specs, and governed source files, then answers queries against it.
 
 This skill differs from other SDD skills: instead of orchestrating Claude through markdown instructions, it delegates the deterministic build/validate/traverse work to a Python helper at `lib/graph.py` in this skill's directory. The output of the helper is the contract — JSON output (Story 6) is the stable shape any future MCP would consume. Markdown is reserved for orchestration and review UX (e.g., the `backfill` mode's accept/edit/reject in Story 7).

--- a/skills/index/SKILL.md
+++ b/skills/index/SKILL.md
@@ -9,6 +9,8 @@ argument-hint: "[add|update|embed|status|remove] [--module <name>] [--foreground
 
 # Index Repository into QMD
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 Create per-repository [qmd](https://github.com/tobi/qmd) collections so agents and humans can run hybrid search across a repo's ADRs, OpenSpec specs, source code, and tracker issues from a single query plane. Each repository owns four collections (`{repo}-adrs`, `{repo}-specs`, `{repo}-code`, `{repo}-issues`) so searches can be filtered cleanly with `qmd query "..." -c {repo}-adrs`. The issues collection is populated by syncing the configured tracker into `.sdd/issues/{id}.md` files (per ADR-0025 and `${CLAUDE_PLUGIN_ROOT}/references/tracker-sync.md`). Workspace projects (ADR-0016) get one set of collections per module: `{repo}-{module}-{kind}`.
 
 ## Process
@@ -400,7 +402,7 @@ Auto-routed: collections did not exist → ran `add` then started `embed` ({fore
 {If embed is in-progress: include "Background embed running — log: /tmp/qmd-embed-{repo}.log. Re-run `/sdd:index status` to check progress."}
 {If skipped: include "Run `/sdd:index embed` — semantic and hybrid search are disabled until vectors exist."}
 - After adding new ADRs/specs/code, re-run `/sdd:index update`
-- The qmd MCP server (`mcp__plugin_qmd_qmd__*` tools, if you have the qmd plugin loaded) sees new collections immediately — no Claude Code restart required. Verified empirically against running sessions.
+- The qmd MCP server (`mcp__plugin_qmd_qmd__*` tools, if you have the qmd plugin loaded) sees new collections immediately — no harness restart required. Verified empirically against running sessions.
 - Consider recording this with `/sdd:adr "Adopt qmd for cross-repo semantic search"` — there is no ADR for this yet
 ```
 

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -9,6 +9,8 @@ argument-hint: "[--module <name>]"
 
 # Initialize SDD Plugin
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 Set up the project's `CLAUDE.md` with architecture context so Claude sessions are design-aware. This skill uses **componentized convergence** — each component independently checks its own state and converges. No single gate blocks other components. Running init N times produces the same result as running it once.
 
 Starting v5.0.0, init also enforces a hardware/install precondition: the `qmd` CLI MUST be available on PATH (per ADR-0024). If qmd is missing, init refuses to operate so users discover the dependency at setup, not three skills deep into a workflow.
@@ -18,6 +20,8 @@ Starting v5.0.0, init also enforces a hardware/install precondition: the `qmd` C
 <!-- Governing: ADR-0016 (Workspace Mode), SPEC-0014 REQ "Artifact Path Resolution" -->
 
 **Module support**: If `$ARGUMENTS` contains `--module <name>`, resolve the module root using the Workspace Detection pattern from `${CLAUDE_PLUGIN_ROOT}/references/shared-patterns.md`. All CLAUDE.md reads and writes in the steps below target the module's `CLAUDE.md` at the module root instead of the project root. If workspace detection finds no modules and `--module` is provided, error: "No modules detected. Run `/sdd:init` without `--module` first to set up workspace."
+
+**Memory file selection**: As the config *producer*, init decides which project memory file carries the SDD sections. Resolve per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md` § "Project Memory File": if a memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) already contains the SDD sections, converge into that file; on a fresh init, create your harness's native memory file (Claude Code → `CLAUDE.md`; Codex/OpenCode → `AGENTS.md`; Crush → `CRUSH.md`; unknown → `CLAUDE.md`). Never duplicate the SDD sections across memory files — if the harness auto-loads a different file than the one carrying the sections, add a one-line pointer there instead. All references to "CLAUDE.md" in the steps below mean the memory file selected here.
 
 ### Step -1: qmd Preflight (v5.0.0+)
 
@@ -186,7 +190,9 @@ f. **qmd Assumption Note** (v5.0.0+, per SPEC-0019 REQ "qmd Assumption in Consum
 
 ### Step 3: Permission Auto-Configuration
 
-**Precondition**: Permissions status is `needs-update`.
+**Precondition**: Permissions status is `needs-update`, AND the harness is Claude Code.
+
+`.claude/settings.local.json` is Claude Code's permission store. On other harnesses (Codex, OpenCode, Crush), skip this step entirely — do NOT write `.claude/settings.local.json` (it would be dead config) and do NOT guess another harness's config schema. Instead, include one line in the Step 5 report naming the commands the SDD skills will invoke (`git`, plus the detected tracker CLI: `gh`/`glab`/`tea`, and `qmd`) so the user can pre-approve them in their harness's own mechanism — see `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md` § "Permissions and Approvals" for where each harness keeps approvals.
 
 If `.claude/settings.local.json` already contains broad wildcard patterns for git and the detected tracker, skip this step.
 
@@ -344,7 +350,7 @@ Each component is independently idempotent:
 - MUST preserve all configuration values exactly during migration — no lossy translation
 - MUST delete `.claude-plugin-design.json` after successful migration — no AskUserQuestion needed
 - When merging migrated config into an existing `### SDD Configuration` section, CLAUDE.md values take precedence on conflicts
-- MUST auto-configure `.claude/settings.local.json` with tracker-appropriate permission allowlists — no AskUserQuestion needed
+- MUST auto-configure `.claude/settings.local.json` with tracker-appropriate permission allowlists — no AskUserQuestion needed. Claude Code only: on other harnesses MUST skip the write and instead report the commands to pre-approve (per harness-compat § "Permissions and Approvals")
 - MUST detect `.gitmodules` and offer workspace setup when submodules are found (Governing: ADR-0016, SPEC-0014 REQ "Init Workspace Setup")
 - MUST NOT create submodule CLAUDE.md files without user consent via `AskUserQuestion`
 - MUST write `### Workspace Modules` table in root CLAUDE.md when workspace is detected

--- a/skills/list/SKILL.md
+++ b/skills/list/SKILL.md
@@ -8,6 +8,8 @@ disable-model-invocation: true
 
 # List Architecture Decisions and Specs
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 List all ADRs and specs in the project with their status, date, and title.
 
 ## Process

--- a/skills/organize/SKILL.md
+++ b/skills/organize/SKILL.md
@@ -9,6 +9,8 @@ argument-hint: "[SPEC-XXXX or spec-name] [--project <name>] [--dry-run] [--modul
 
 # Organize Issues into Projects
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 You are retroactively grouping existing tracker issues into tracker-native projects and enriching project workspaces. You use a three-tier intervention model that lets the operator control how invasive the changes are. See ADR-0012 and SPEC-0011.
 
 ## Process

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -10,6 +10,8 @@ argument-hint: "[spec-name or SPEC-XXXX] [--review] [--scrum] [--project <name>]
 
 # Plan Sprint from Specification
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 You are breaking down an existing specification into trackable work items (epics and story-sized issues) in the user's issue tracker. Instead of creating one issue per requirement, you group related requirements into 3-4 story-sized issues by functional area, with task checklists in the issue body for requirement traceability. See ADR-0011 and SPEC-0010.
 
 ## Process
@@ -49,7 +51,7 @@ You are breaking down an existing specification into trackable work items (epics
      - Spawn a **planner** agent (`general-purpose`) to analyze the spec and create the issue breakdown
      - Spawn a **reviewer** agent (`general-purpose`) to review the breakdown for completeness, proper acceptance criteria, and correct dependency ordering
      - The reviewer MUST verify that every spec requirement has at least one corresponding issue
-     - If `TeamCreate` fails, fall back to single-agent mode
+     - If `TeamCreate` fails — or is not a registered tool on this harness — fall back to single-agent mode
    - Maximum 2 revision rounds. After that, the reviewer approves with noted concerns.
 
 ---

--- a/skills/prime/SKILL.md
+++ b/skills/prime/SKILL.md
@@ -7,6 +7,8 @@ argument-hint: "[topic] [--module <name>]"
 
 # Prime Architecture Context
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 Load existing ADRs and specs into the session so Claude can give architecture-aware responses.
 
 ## Process
@@ -42,20 +44,20 @@ Load existing ADRs and specs into the session so Claude can give architecture-aw
    
    <!-- Governing: ADR-0024 (qmd as hard dependency), SPEC-0019 REQ "qmd-Smart Context Loading" -->
    
-   All artifact retrieval now uses qmd hybrid search for consistency, flexibility, and efficiency. Both untargeted and topic-filtered modes use the same code path with different parameters, executed via the `qmd query` CLI.
+   Artifact retrieval routes through qmd, but the two modes use different primitives: untargeted mode is an *exhaustive enumeration* (no ranking involved), topic-filtered mode is a *ranked hybrid search*. Do not use `qmd query` for the exhaustive case — it requires a real query string, and an empty query is not a wildcard (see `${CLAUDE_PLUGIN_ROOT}/references/qmd-helpers.md` § "Exhaustive Retrieval (list-all)").
    
    **For untargeted priming** (`/sdd:prime` with no topic):
-   - Query for all ADRs with `qmd query --json -c {repo}-adrs --limit 10000 --minScore 0` plus a second query for all specs with `qmd query --json -c {repo}-specs --limit 10000 --minScore 0`
+   - Enumerate all ADRs with `qmd ls {repo}-adrs` and all specs with `qmd ls {repo}-specs`, then read each document (via `qmd get`/`qmd multi-get` or directly from disk) per qmd-helpers § "Exhaustive Retrieval (list-all)"
    - In workspace mode, repeat for each module's per-module collections (`{repo}-{module}-adrs`, etc.)
-   - The `--limit 10000` and `--minScore 0` retrieve all matches without filtering
+   - If `qmd ls` is unavailable or errors, fall back to direct file enumeration over `{adr-dir}/*.md` and `{spec-dir}/*/spec.md` (acceptable for exhaustive listing only — no ranking is involved)
    
    **For topic-filtered priming** (`/sdd:prime {topic}`):
    - Construct a hybrid query with both `lex` (keyword match) and `vec` (semantic match) sub-queries per `${CLAUDE_PLUGIN_ROOT}/references/qmd-helpers.md` § "Hybrid Retrieval"
-   - Run: `qmd query --json -c {repo}-adrs -c {repo}-specs --limit 8 --minScore 0.3 '<queries>'`
-   - If zero candidates above `minScore: 0.3`, output: `No ADRs or specs matched the topic "{topic}". Try a broader term, or run `/sdd:prime` without a topic to see all artifacts.`
+   - Run: `qmd query '<queries>' --json -c {repo}-adrs -c {repo}-specs -n 8 --min-score 0.3` — positional query first, kebab-case flags, `-n` for the result cap, per qmd-helpers § "Calling via CLI" (the MCP parameter names `limit`/`minScore` are not CLI flags)
+   - If zero candidates above the 0.3 score floor, output: `No ADRs or specs matched the topic "{topic}". Try a broader term, or run `/sdd:prime` without a topic to see all artifacts.`
    
-   For each retrieved artifact:
-   - Parse the JSON response to extract: ID, title (from first `#` heading), status, superseded-by (from frontmatter)
+   For each retrieved artifact (from the query JSON in topic mode, or the document contents in untargeted mode):
+   - Extract: ID, title (from first `#` heading), status, superseded-by (from frontmatter)
    - For ADRs: extract summary from first 2-3 sentences of `## Decision Outcome`
    - For specs: extract summary from first sentence of `## Overview`; count requirements and scenarios
    - Sort by artifact ID number (natural sort: ADR-0001, ADR-0002, ..., SPEC-0001, ...)
@@ -237,6 +239,6 @@ Primed session with {N} ADRs and {M} specs matching "{topic}".
 - In topic-filtered mode, MUST surface non-authoritative artifacts that match the topic with a `⚠ {status}` badge in the table and a "superseded by" note in the summary — do NOT silently exclude them, since topic filtering is for historical/investigative use
 - In workspace aggregate mode, MUST prefix non-authoritative footer entries with the module bracket (e.g., `[api] ADR-XXXX: ...`) consistent with main-table prefixing
 - **v5.0.0+**: MUST run Tier 2 session-start update per Step 1a — `qmd update` on entry unless the index was touched within 60s. Surface refresh diff as one-line note when non-zero; otherwise silent. Surface unembedded chunk count as one-line informational note (no AskUserQuestion) (Governing: ADR-0026, SPEC-0019 REQ "Tier 2 Session-Start Update via /sdd:prime")
-- **v5.1.0+**: MUST use unified qmd retrieval for both untargeted and topic-filtered modes (removes the pre-v5.1 dual-path design). Both paths use `qmd query` with different limit/minScore parameters: untargeted uses `limit: 10000, minScore: 0` to retrieve all artifacts; topic-filtered uses `limit: 8, minScore: 0.3` for top-K relevance (Governing: ADR-0024, proposed refinement)
+- **v5.1.0+**: MUST route all artifact retrieval through qmd, using the primitive that matches the mode: untargeted mode enumerates exhaustively via `qmd ls` per qmd-helpers § "Exhaustive Retrieval (list-all)" (`qmd query` with an empty query is NOT a wildcard and MUST NOT be used); topic-filtered mode uses `qmd query '<queries>' -n 8 --min-score 0.3` for top-K relevance (Governing: ADR-0024, proposed refinement; friction report #200)
 - **v5.1.0+**: MUST include an "Artifact Summaries" section in untargeted output — 2-3 sentence summaries for each ADR (from decision outcome) and spec (from overview). This provides context without opening files and is especially valuable for large artifact sets (Governing: proposed enhancement to SPEC-0019)
 - **v5.1.0+**: Summaries are extracted via qmd query responses (no additional file reads needed) — use the JSON response's body/content fields and parse to extract summary sentences using simple heuristics (first 2-3 sentences ending with a period)

--- a/skills/report-friction/SKILL.md
+++ b/skills/report-friction/SKILL.md
@@ -9,6 +9,8 @@ argument-hint: "[skill-name] [--label bug|documentation|enhancement|usability] [
 
 # Report Friction with the SDD Plugin
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 This is a meta-skill: when an SDD plugin skill burns time, breaks, or guides you wrong, you can use this to file a feedback issue against the plugin's own repository (`joestump/claude-plugin-sdd`). The user always sees and approves the entire submission first.
 
 ## When to use this skill

--- a/skills/respond/SKILL.md
+++ b/skills/respond/SKILL.md
@@ -13,6 +13,8 @@ argument-hint: "[PR number(s) or URL | (empty = infer from current branch)] [--r
 
 # Respond to PR Review Feedback
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 You are the **author-side responder** for a pull request. A reviewer — human or
 automated — has left feedback, requested changes, or the PR has failing CI.
 Your job is to work through that feedback like the PR author would: make the
@@ -175,8 +177,10 @@ use `/sdd:respond` to address the review someone left on your PR.
    - **reply** → answer the question directly.
 
    Where the tracker supports it and the item is fully addressed, resolve the
-   review thread (GitHub: `mcp__github__resolve_review_thread`). Be frugal — one
-   substantive reply per thread, not a running commentary.
+   review thread (GitHub: `mcp__github__resolve_review_thread`, or without the
+   MCP, `gh api graphql` with the `resolveReviewThread` mutation on the thread's
+   node ID). Be frugal — one substantive reply per thread, not a running
+   commentary.
 
    **Capturing deferred feedback.** A `defer` item is a single follow-up, so file
    a single issue **directly via the tracker's issue API** — do NOT invoke

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -10,6 +10,8 @@ argument-hint: "[SPEC-XXXX or PR numbers] [--pairs N] [--no-merge] [--dry-run] [
 
 # Review and Merge PRs
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 You are reviewing PRs produced by `/sdd:work` using reviewer-responder agent pairs. Each pair processes PRs through exactly one review-response round: the reviewer checks the diff against spec acceptance criteria, the responder addresses feedback, and the reviewer re-evaluates. Approved PRs are merged; unresolved PRs are left with comments for human follow-up. See ADR-0010 and SPEC-0009.
 
 <!-- Governing: ADR-0028 (/loop Autonomous Mode), SPEC-0020 REQ "Lockfile Schema and Acquisition", SPEC-0020 REQ "Budget Schema and Persistence", SPEC-0020 REQ "Telemetry Schema", SPEC-0020 REQ "Resume Contract", SPEC-0020 REQ "Resume Contract Reconciliation" -->
@@ -143,7 +145,9 @@ You are reviewing PRs produced by `/sdd:work` using reviewer-responder agent pai
    - N **reviewer** agents (`general-purpose`) — one per pair
    - N **responder** agents (`general-purpose`) — one per pair
 
-   If `TeamCreate` fails, fall back to single-agent sequential mode: for each PR, review the diff against acceptance criteria, then address any issues directly (acting as both reviewer and responder). This mode skips the response round — if issues are found, leave review comments for human follow-up instead of auto-fixing.
+   If `TeamCreate` fails — or is not a registered tool on this harness — fall back to single-agent sequential mode: for each PR, review the diff against acceptance criteria, then address any issues directly (acting as both reviewer and responder). This mode skips the response round — if issues are found, leave review comments for human follow-up instead of auto-fixing.
+
+   **Context hygiene in sequential mode** (per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md` § "Single-Agent Sequential Fallback"): everything read in the lead session is resent on every later turn, so inline diff-reading is the dominant token cost of a multi-PR session. If subagents are available, fork each PR's diff-read-and-verify step to a subagent that returns only a verdict + compact summary — never the diff. Without subagents, default to `gh pr diff {N} --name-only` plus targeted per-file excerpts, escalating to a full inline diff only when the targeted read is genuinely insufficient. After each PR, carry forward only the verdict and a few-line summary.
 
 8. **Distribute PRs** (Governing: SPEC-0009 REQ "PR Distribution"):
 
@@ -271,7 +275,7 @@ You are reviewing PRs produced by `/sdd:work` using reviewer-responder agent pai
 |-----------|----------|
 | Single PR review fails (API error) | Log failure, skip that PR, continue with remaining PRs |
 | Merge conflict on merge | Report conflict, leave PR unmerged for human resolution |
-| `TeamCreate` fails | Fall back to single-agent sequential mode |
+| `TeamCreate` fails or is not a registered tool | Fall back to single-agent sequential mode with the context-hygiene rules from step 7 (fork diff reads to subagents, or `--name-only` + targeted excerpts) |
 | No open PRs found | Suggest `/sdd:work` to create PRs |
 | No tracker detected | Error: tracker with PR/MR support is required |
 | Responder cannot resolve feedback | Reply explaining why, report to lead, leave for human |
@@ -302,7 +306,8 @@ You are reviewing PRs produced by `/sdd:work` using reviewer-responder agent pai
 - MUST report all failures with actionable details — never silently skip (Governing: SPEC-0009 REQ "Error Handling")
 - `--dry-run` MUST NOT submit reviews, push commits, or merge PRs
 - Adaptive pair count: reduce pairs to min(PR count, configured pairs) for small batches
-- When `TeamCreate` fails, MUST fall back to single-agent sequential mode — never error out
+- When `TeamCreate` fails or is absent, MUST fall back to single-agent sequential mode — never error out
+- In single-agent sequential mode, MUST NOT pull full PR diffs into the lead session by default — fork the diff-read-and-verify step to a subagent (verdict + summary back only) when subagents exist, otherwise use `--name-only` + targeted excerpts (per harness-compat § "Single-Agent Sequential Fallback"; friction report #201)
 - MUST verify all CI/CD status checks (GitHub Actions, Gitea Actions, GitLab CI) are green before reviewing a PR — never review a PR with failing checks
 - MUST re-verify CI status after responder pushes fixes — never merge with failing checks
 - MUST NOT merge a PR unless ALL status checks are passing

--- a/skills/search/SKILL.md
+++ b/skills/search/SKILL.md
@@ -7,6 +7,8 @@ argument-hint: "[query] [--output markdown|json] [--unfiltered] [--module <name>
 
 # Unified Semantic Search
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 Search ADRs, specs, and code simultaneously using qmd hybrid retrieval, then enrich results with cgg call graphs for deeper code exploration.
 
 ## Process

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -7,6 +7,8 @@ argument-hint: "[capability name or ADR reference] [--review] [--module <name>]"
 
 # Create an OpenSpec Specification
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 You are creating or updating an OpenSpec specification. Every spec is a **paired artifact**: `spec.md` (requirements — what the system does) and `design.md` (architecture and rationale — how and why it does it).
 
 **You MUST ALWAYS create or update BOTH files together. They are a single unit of truth. Never create, edit, or deliver one without the other.**
@@ -63,7 +65,7 @@ When creating a new spec from scratch, both files are created together — align
      - Spawn an **architect** agent (`general-purpose`) to review both documents for completeness, accuracy, RFC 2119 keyword compliance, and proper scenario format. **The architect MUST verify the spec uses `SPEC-XXXX` numbering, not `RFC-XXXX`.**
      - The architect MUST review and approve BOTH documents before they are finalized
      - If converting from an ADR, the spec-writer should read the ADR and use it as the basis
-     - If `TeamCreate` fails, fall back to single-agent mode: draft both files directly, then self-review against the architect's checklist in the Rules section before writing.
+     - If `TeamCreate` fails — or is not a registered tool on this harness — fall back to single-agent mode: draft both files directly, then self-review against the architect's checklist in the Rules section before writing.
 
 4b. **Optional call graph generation** (v5.1.0+):
 

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -8,6 +8,8 @@ disable-model-invocation: true
 
 # Change ADR or Spec Status
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 Update the status of an ADR or spec, **preserving the file's existing status format**. Two formats exist in the wild: YAML frontmatter (canonical SDD template) and inline `- **Status:** {value}` bullets (used by legacy / hand-authored repos that predate the template). This skill detects which format is in use and edits in place — it MUST NOT silently introduce a new format that creates two sources of truth in the same file.
 
 ## Process

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -10,6 +10,8 @@ argument-hint: "[SPEC-XXXX | issue numbers | (empty = propose from backlog)] [--
 
 # Work on Issues
 
+> **Harness portability.** This skill runs on any agent harness that loads Agent Skills — Claude Code, Codex CLI, OpenCode, Crush. Tool names used below (`AskUserQuestion`, `Task`, `TeamCreate`, `SendMessage`, `TaskCreate`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) denote *capabilities*, not hard requirements: map each to your harness's equivalent or use the documented fallback per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md`. References to `CLAUDE.md` mean the project memory file (`CLAUDE.md`, `AGENTS.md`, or `CRUSH.md`) per harness-compat § "Project Memory File".
+
 You are picking up tracker issues and implementing them in parallel using git worktrees. Each issue gets its own worktree and worker agent.
 
 <!-- Governing: ADR-0028 (/loop Autonomous Mode), SPEC-0020 REQ "Lockfile Schema and Acquisition", SPEC-0020 REQ "Budget Schema and Persistence", SPEC-0020 REQ "Telemetry Schema", SPEC-0020 REQ "Resume Contract", SPEC-0020 REQ "Resume Contract Reconciliation" -->
@@ -200,7 +202,9 @@ You are picking up tracker issues and implementing them in parallel using git wo
 
 8. **Create team**: Use `TeamCreate` to create a coordination team following the "Worker Coordination" protocol from `${CLAUDE_PLUGIN_ROOT}/references/shared-patterns.md` § "Multi-Agent Team Protocols". The lead (you) manages the task queue and monitors progress. Spawn up to the resolved parallelism limit (from step 7a) worker agents using `Task` with `subagent_type: "general-purpose"`.
 
-   If `TeamCreate` fails, fall back to single-agent sequential mode: work through each issue one at a time in the main session using `git worktree add` for each.
+   If `TeamCreate` fails — or is not a registered tool on this harness — fall back to single-agent sequential mode: work through each issue one at a time in the main session using `git worktree add` for each.
+
+   **Context hygiene in sequential mode** (per `${CLAUDE_PLUGIN_ROOT}/references/harness-compat.md` § "Single-Agent Sequential Fallback"): everything read in the lead session is resent on every later turn, and a multi-issue epic worked in one continuous session compounds fast. If subagents are available, dispatch each issue's implementation (and any post-PR diff verification) to a subagent that reports back a compact outcome — PR URL, verdict, few-line summary — never raw diffs or full file dumps. Without subagents, read diffs via `--name-only` + targeted excerpts, and after each issue carry forward only its outcome summary.
 
 8a. **Build sibling PR manifest** (Governing: SPEC-0015 REQ "Pre-Flight PR Awareness"):
 
@@ -504,7 +508,7 @@ You are picking up tracker issues and implementing them in parallel using git wo
 |-----------|----------|
 | Worker can't complete implementation | Reports failure to lead, worktree preserved for manual pickup |
 | Tests fail after 2 retries | Worker reports blocked with error details, moves to next issue |
-| `TeamCreate` fails | Falls back to single-agent sequential mode |
+| `TeamCreate` fails or is not a registered tool | Falls back to single-agent sequential mode with the context-hygiene rules from step 8 (subagent dispatch or `--name-only` + targeted excerpts; never full diffs inline) |
 | No workable issues found | Suggest `/sdd:plan` (no issues at all) or `/sdd:enrich` (issues exist but lack `### Branch`) |
 | Uncommitted changes in main tree | Ask user whether to continue or commit first |
 | `git worktree add` fails (branch exists) | Check if the branch already exists remotely. If so, use `git worktree add .claude/worktrees/{branch-name} {branch-name}` (without `-b`) to check out the existing branch |
@@ -550,7 +554,8 @@ You are picking up tracker issues and implementing them in parallel using git wo
 - The lead MUST stay in the main working tree — only workers operate in worktrees
 - `--dry-run` MUST NOT create any worktrees, branches, or PRs
 - Maximum 2 test-fix attempts per worker before reporting blocked
-- When `TeamCreate` fails, MUST fall back to single-agent sequential mode — never error out
+- When `TeamCreate` fails or is absent, MUST fall back to single-agent sequential mode — never error out
+- In single-agent sequential mode, MUST NOT pull full diffs or large file dumps into the lead session by default — dispatch read-heavy verification to subagents (compact outcome back only) when subagents exist, otherwise use `--name-only` + targeted excerpts (per harness-compat § "Single-Agent Sequential Fallback"; friction report #201)
 - For Gitea trackers, MUST query native dependencies via API to determine unblocked stories (Governing: SPEC-0011 REQ "Gitea Native Dependencies")
 - MUST NOT spawn more than `max-parallel-agents` concurrent agents (default: 4); resolve from CLI flag → CLAUDE.md → default (Governing: SPEC-0015 REQ "Parallelism Limits", ADR-0017 Layer 1)
 - MUST read `## SDD Configuration` from CLAUDE.md for `max-parallel-agents` setting before falling back to default
@@ -732,8 +737,9 @@ For each PR a worker opens in an iteration:
    | `"needs-human"` | Apply the `needs-human-follow-up` label to PR #{N}; proceed to step 5 (the maintenance loop may still resolve CI flakes / conflicts independently of the architectural concern) |
    | `"errored"` | Apply the `chain-failed-pre-autofix` label to PR #{N}; **skip** step 5; record `autofix_pr_invoked: false`; **omit** `autofix_pr_invocation_status` (per SPEC-0020 REQ "Post-PR Chain Invocation"); proceed to next PR. The user can rerun `/sdd:review` after fixing the infrastructure issue (e.g., qmd unreachable per ADR-0024). |
 
-5. **Check `/autofix-pr` availability**. The command is a Claude Code built-in (not a plugin-provided skill). Probe by attempting to introspect the runtime's available commands.
-   - **Unavailable** (the build does not ship the command, or introspection returns "not found"): log a one-line warning ("`/autofix-pr` is not available in this Claude Code build — install or upgrade Claude Code to enable post-PR autofix chain"); open a tracker issue tagged `claude-code-version-required` (deduped per `/sdd:work` invocation — open at most one such issue per session); record `autofix_pr_invoked: false` and `autofix_pr_invocation_status: "unavailable"`; proceed to next PR. PR creation is NOT blocked.
+5. **Check `/autofix-pr` availability**. The command is a Claude Code built-in (not a plugin-provided skill), so it only exists at all when running under Claude Code. Probe by attempting to introspect the runtime's available commands.
+   - **Running on another harness** (Codex, OpenCode, Crush — the built-in cannot exist): log a one-line note ("`/autofix-pr` is a Claude Code built-in and is not available on this harness — skipping the autofix stage"); record `autofix_pr_invoked: false` and `autofix_pr_invocation_status: "unavailable"`; proceed to next PR. Do NOT open a tracker issue — the absence is expected, not a version problem.
+   - **Unavailable on Claude Code** (the build does not ship the command, or introspection returns "not found"): log a one-line warning ("`/autofix-pr` is not available in this Claude Code build — install or upgrade Claude Code to enable post-PR autofix chain"); open a tracker issue tagged `claude-code-version-required` (deduped per `/sdd:work` invocation — open at most one such issue per session); record `autofix_pr_invoked: false` and `autofix_pr_invocation_status: "unavailable"`; proceed to next PR. PR creation is NOT blocked.
    - **Available**: continue to step 6.
 
 6. **Invoke `/autofix-pr`** on PR #{N} **fire-and-forget**: `/sdd:work` does NOT wait for `/autofix-pr` to terminate; the built-in runs in its own background lifecycle managed by Claude Code, watching CI failures, review comments, and merge conflicts, and pushing corrective commits until the PR merges or is closed. `/sdd:work` returns once the invocation is **accepted** (the command was parsed and the lifecycle started).
@@ -762,6 +768,7 @@ For each PR a worker opens in an iteration:
 | `/sdd:review` returns `"approve"`, `"changes-requested"` (resolved in round), or `"needs-human"` | Proceed to `/autofix-pr` |
 | `/sdd:review` returns `"errored"` (qmd unreachable per ADR-0024 sub-decision 2, or other infrastructure failure) | Apply `chain-failed-pre-autofix` label; skip `/autofix-pr`; record `autofix_pr_invoked: false`; omit `autofix_pr_invocation_status` |
 | `/autofix-pr` unavailable in current Claude Code build | Log warning; open one tracker issue with `claude-code-version-required` label per `/sdd:work` session (deduped); exit cleanly. PR is NOT blocked. |
+| `/autofix-pr` absent because the harness is not Claude Code | Log a one-line note and skip the stage; NO tracker issue (expected absence, not a version problem). PR is NOT blocked. |
 | `/autofix-pr` invocation parse error | Record `autofix_pr_invocation_status: "errored"`; one-line warning; PR NOT blocked. |
 
 #### Concurrency under `--loop`
@@ -811,6 +818,6 @@ Every iteration appends a line to `.sdd/loop/work.history.jsonl` and emits the s
 - The chain MUST invoke `/sdd:review` exactly once per PR per chain invocation (preserves ADR-0010's bounded one-round invariant)
 - WHEN `/sdd:review` exits with `review_outcome: "errored"` THEN MUST apply the `chain-failed-pre-autofix` label, MUST NOT invoke `/autofix-pr`, and MUST omit `autofix_pr_invocation_status` from the per-iteration telemetry
 - WHEN `/sdd:review` exits with `"needs-human"` THEN MUST apply the `needs-human-follow-up` label AND proceed to `/autofix-pr` (the maintenance loop may resolve CI / conflicts independently)
-- WHEN `/autofix-pr` is unavailable THEN MUST log a warning AND open a tracker issue with the `claude-code-version-required` label (deduped at one issue per session) AND exit cleanly (PR creation MUST NOT be blocked)
+- WHEN `/autofix-pr` is unavailable on Claude Code THEN MUST log a warning AND open a tracker issue with the `claude-code-version-required` label (deduped at one issue per session) AND exit cleanly (PR creation MUST NOT be blocked); WHEN the harness is not Claude Code THEN MUST skip the stage with a one-line note and MUST NOT open a tracker issue
 - The `/autofix-pr` invocation MUST be fire-and-forget — `/sdd:work` MUST NOT wait for `/autofix-pr` to terminate
 - The chain MUST NOT be double-counted in `/sdd:work`'s budget — costs of `/sdd:review` and `/autofix-pr` accrue under their own tool accounting; `/sdd:work` records only the invocation events in `history.jsonl`


### PR DESCRIPTION
## What

Up-levels the skill set per the open friction issues and makes every skill portable across Codex CLI, OpenCode, and Crush in addition to Claude Code.

**Harness portability (new):**
- New `references/harness-compat.md`: capability map for every Claude Code tool surface the skills name (`AskUserQuestion`, `Task`, `TeamCreate`/`SendMessage`, `Task*`, `ToolSearch`, `mcp__*`, `${CLAUDE_PLUGIN_ROOT}`) with per-harness equivalents and documented fallbacks; project memory file resolution (`CLAUDE.md`/`AGENTS.md`/`CRUSH.md`); plugin-root resolution; permissions equivalents; worktree placement; single-agent sequential fallback hygiene.
- All 20 skills carry a standard portability note under their title: tool names denote capabilities, not hard requirements.
- `shared-patterns.md` Config Resolution generalized to the project memory file; TeamCreate guidance now covers harnesses where teams never existed (sequential fallback, never uncoordinated parallel agents).
- `/sdd:init` selects the harness-native memory file, never duplicates SDD sections across memory files, and gates the `.claude/settings.local.json` write to Claude Code (other harnesses get a report line naming the commands to pre-approve).
- `/sdd:work`'s `/autofix-pr` stage skips cleanly on non-Claude-Code harnesses without filing `claude-code-version-required` issues.
- `/sdd:discover` gains an inline-sequential path when subagents are absent; `/sdd:respond` gains a `gh api graphql` fallback for review-thread resolution; qmd-helpers documents the no-ToolSearch MCP-detection path.

**Closes #200** — `/sdd:prime` untargeted priming: `--minScore` → `--min-score`, positional query first, result cap is `-n`, and the empty-query "retrieve all" pattern is replaced with `qmd ls` enumeration via a new `qmd-helpers.md` § "Exhaustive Retrieval (list-all)".

**Closes #201** — `/sdd:work`/`/sdd:review` single-agent fallback now carries explicit context-hygiene rules: fork per-PR diff verification to a subagent (verdict + compact summary only) when available, otherwise `--name-only` + targeted excerpts; never full diffs inline by default.

## Verification

- qmd CLI syntax verified empirically against qmd 2.1.0 (`qmd query --help`, live `qmd ls`/`qmd query` runs): `--min-score` kebab-case, `-n` result cap, `qmd ls {collection}` deterministic enumeration; combined with the 2.5.3 behavior documented in #200 (query-first ordering).
- `grep` sweeps confirm no remaining `--minScore`/`--limit` qmd CLI usages (remaining `--limit` hits are `gh` CLI, correct there), all 20 skills carry the portability note, and no eval/CI assertions reference the changed wording.
- This repo has no `make test`/`make lint` targets (markdown-only, eval-driven CI); change is documentation-only across `skills/` and `references/`.

Not touched: #182 (eval pipeline, already in-progress) and #94 (eval scenario work).

🤖 Posted on behalf of `@joestump` by [`claude-fable-5`](https://openrouter.ai/anthropic/claude-fable-5) using [Claude Code](https://claude.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)