### PR TITLE
chore: add make test/lint/check targets and wire them into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: docs-site/package-lock.json
+
+      - name: make lint
+        run: make lint
+
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: docs-site/package-lock.json
+
+      - name: make test
+        run: make test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,12 @@ When orchestrating multiple SDD plugin skills in a single session (e.g., running
 - Epic Prefix: `epic`
 - Slug Max Length: 50
 
+### Tests and Linting
+
+Run `make check` (`make lint` + `make test`) before pushing. `make lint` runs `scripts/check-structure.sh` — plugin manifests, SKILL.md frontmatter, `skills/_index.json` consistency, and eval definition shape — plus a docs-site typecheck. `make test` runs the docs-site build-script unit tests. The LLM-graded skill evals under `evals/` run only in CI; `make test` does not invoke them.
+
+`.github/workflows/ci.yml` runs the same targets on every PR, so keep new checks in the Makefile rather than inlining them into the workflow.
+
 ### Release Process
 
 When releasing a new version:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+# SDD plugin — test and lint entry points.
+#
+# This repo is a Claude Code plugin: markdown skills, JSON manifests, eval
+# definitions, and a Docusaurus docs site. `make test` and `make lint` wrap the
+# native tooling for each of those, and .github/workflows/ci.yml runs the same
+# targets so local and CI cannot drift.
+#
+# The skill evals under evals/ are graded by an LLM in CI (see
+# .github/workflows/skill-evals.yml) and are deliberately NOT run here — `make
+# lint` validates that their definitions are well-formed and reference real
+# skills, which is the part that can be checked deterministically.
+
+NPM ?= npm
+DOCS_DIR := docs-site
+DOCS_MODULES := $(DOCS_DIR)/node_modules
+
+.DEFAULT_GOAL := help
+.PHONY: help check test lint deps structure docs-test docs-typecheck docs-build clean
+
+help: ## Show this help
+	@printf 'Targets:\n'
+	@grep -hE '^[a-z][a-z-]*:.*?## ' $(MAKEFILE_LIST) \
+		| sed 's/:.*## /\t/' \
+		| awk -F'\t' '{ printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2 }'
+
+check: lint test ## Run lint and test
+
+test: docs-test ## Run the deterministic test suites
+
+lint: structure docs-typecheck ## Validate repo structure and typecheck the docs site
+
+structure: ## Validate plugin manifests, skill frontmatter, and eval definitions
+	@./scripts/check-structure.sh
+
+docs-test: $(DOCS_MODULES) ## Run the docs-site build-script unit tests
+	@files=$$(find $(DOCS_DIR)/scripts -name '*.test.js' -not -path '*/node_modules/*'); \
+		if [ -z "$$files" ]; then echo "no test files found under $(DOCS_DIR)/scripts"; exit 1; fi; \
+		node --test $$files
+
+docs-typecheck: $(DOCS_MODULES) ## Typecheck the docs-site TypeScript sources
+	@$(NPM) --prefix $(DOCS_DIR) run typecheck
+
+docs-build: $(DOCS_MODULES) ## Build the docs site (what deploy-docs.yml runs)
+	@$(NPM) --prefix $(DOCS_DIR) run build
+
+deps: $(DOCS_MODULES) ## Install docs-site dependencies
+
+$(DOCS_MODULES): $(DOCS_DIR)/package-lock.json
+	@$(NPM) --prefix $(DOCS_DIR) ci
+	@touch $@
+
+clean: ## Remove generated docs output and installed dependencies
+	@rm -rf $(DOCS_MODULES) $(DOCS_DIR)/build $(DOCS_DIR)/.docusaurus docs-generated

--- a/README.md
+++ b/README.md
@@ -120,6 +120,26 @@ claude
 
 The `.claude/settings.json` in this repo registers the local directory as a marketplace and enables the plugin automatically. Any changes to skills or templates are picked up on the next Claude Code launch.
 
+### Tests and linting
+
+```bash
+make check
+```
+
+| Target | What it does |
+|--------|--------------|
+| `make check` | `lint` + `test` -- run this before pushing |
+| `make lint` | Structural validation (`scripts/check-structure.sh`) plus a docs-site TypeScript typecheck |
+| `make test` | The docs-site build-script unit tests (`node --test`) |
+| `make deps` | `npm ci` in `docs-site/` (the other targets do this on demand) |
+| `make docs-build` | Build the docs site locally, the same way `deploy-docs.yml` does |
+
+`scripts/check-structure.sh` validates what can be checked without an LLM: every tracked JSON file parses, the plugin and marketplace manifests carry their required fields, every `skills/<name>/SKILL.md` has frontmatter whose `name` matches its directory and a non-empty `description`, `skills/_index.json` is bidirectionally consistent with the `skills/` directory, and the eval definitions in `evals/` are well-formed and reference skills that exist. Skills missing evals or a trigger set are reported as advisories and do not fail the run.
+
+The skill evals themselves are graded by an LLM and run only in CI ([`skill-evals.yml`](.github/workflows/skill-evals.yml)) -- `make test` does not invoke them. See [`evals/README.md`](evals/README.md) for running individual eval prompts locally with `claude -p`.
+
+[`ci.yml`](.github/workflows/ci.yml) runs `make lint` and `make test` on every pull request and on pushes to `main`, so local and CI cannot drift.
+
 ## What It Does
 
 ### `/sdd:adr` -- Architecture Decision Records

--- a/docs-site/src/components/DateBadge.tsx
+++ b/docs-site/src/components/DateBadge.tsx
@@ -7,7 +7,7 @@ interface DateBadgeProps {
 
 const CALENDAR_EMOJI = '\uD83D\uDCC5';
 
-export default function DateBadge({date, className}: DateBadgeProps): JSX.Element {
+export default function DateBadge({date, className}: DateBadgeProps): React.JSX.Element {
   return (
     <span className={`date-badge ${className || ''}`}>
       {CALENDAR_EMOJI} {date}

--- a/docs-site/src/components/DomainBadge.tsx
+++ b/docs-site/src/components/DomainBadge.tsx
@@ -8,7 +8,7 @@ interface DomainBadgeProps {
 
 const DOMAIN_EMOJI = '\uD83D\uDCE6';
 
-export default function DomainBadge({domain, className}: DomainBadgeProps): JSX.Element {
+export default function DomainBadge({domain, className}: DomainBadgeProps): React.JSX.Element {
   return (
     <span className={clsx('domain-badge', className)}>
       {DOMAIN_EMOJI} {domain}

--- a/docs-site/src/components/PriorityBadge.tsx
+++ b/docs-site/src/components/PriorityBadge.tsx
@@ -16,7 +16,7 @@ const priorityEmojis: Record<string, string> = {
   'P4': '\u26aa',
 };
 
-export default function PriorityBadge({priority, className}: PriorityBadgeProps): JSX.Element {
+export default function PriorityBadge({priority, className}: PriorityBadgeProps): React.JSX.Element {
   const normalizedPriority = priority.toUpperCase() as PriorityType;
   const emoji = priorityEmojis[normalizedPriority] || priorityEmojis['P4'];
 

--- a/docs-site/src/components/SeverityBadge.tsx
+++ b/docs-site/src/components/SeverityBadge.tsx
@@ -17,7 +17,7 @@ const severityEmojis: Record<string, string> = {
   'unknown': '\u26aa',
 };
 
-export default function SeverityBadge({severity, className}: SeverityBadgeProps): JSX.Element {
+export default function SeverityBadge({severity, className}: SeverityBadgeProps): React.JSX.Element {
   const normalizedSeverity = severity.toLowerCase() as SeverityType;
   const emoji = severityEmojis[normalizedSeverity] || severityEmojis['unknown'];
 

--- a/docs-site/src/components/StatusBadge.tsx
+++ b/docs-site/src/components/StatusBadge.tsx
@@ -21,7 +21,7 @@ const statusEmojis: Record<string, string> = {
   'unknown': '\ud83e\udd37',
 };
 
-export default function StatusBadge({status, className}: StatusBadgeProps): JSX.Element {
+export default function StatusBadge({status, className}: StatusBadgeProps): React.JSX.Element {
   const normalizedStatus = status.toLowerCase() as StatusType;
   const emoji = statusEmojis[normalizedStatus] || statusEmojis['unknown'];
 

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+#
+# Structural validation for the SDD plugin repo.
+#
+# This is the deterministic half of `make lint`: everything that can be
+# checked without an LLM. The skill evals in evals/ are graded by
+# anthropics/claude-code-action in CI and are NOT run here.
+#
+# Checks:
+#   1. Every tracked *.json file parses.
+#   2. .claude-plugin/plugin.json and marketplace.json carry required fields.
+#   3. Every skills/<name>/SKILL.md has frontmatter with a name matching its
+#      directory and a non-empty description.
+#   4. skills/_index.json matches the schema shape and is bidirectionally
+#      consistent with the skills/ directory.
+#   5. evals/evals.json, evals/triggers/*.json and evals/pipeline/*.json are
+#      well-formed and reference skills that exist.
+#
+# Coverage gaps (a skill with no evals or no trigger file) are reported as
+# advisories and do not fail the run.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+ERRORS=0
+NOTES=0
+
+err() {
+	printf '  \033[31mFAIL\033[0m %s\n' "$1"
+	ERRORS=$((ERRORS + 1))
+}
+
+note() {
+	printf '  \033[33mNOTE\033[0m %s\n' "$1"
+	NOTES=$((NOTES + 1))
+}
+
+section() {
+	printf '\n\033[1m%s\033[0m\n' "$1"
+}
+
+command -v jq >/dev/null 2>&1 || {
+	echo "check-structure.sh requires jq (brew install jq / apt-get install jq)" >&2
+	exit 2
+}
+
+# Print the YAML frontmatter block of a markdown file (contents between the
+# leading '---' and the next '---'). Empty output means no frontmatter.
+frontmatter() {
+	awk 'NR == 1 && $0 != "---" { exit } NR > 1 { if ($0 == "---") exit; print }' "$1"
+}
+
+# Value of a top-level scalar key in a frontmatter block, with surrounding
+# whitespace and quotes stripped.
+fm_value() {
+	printf '%s\n' "$1" | sed -n "s/^$2:[[:space:]]*//p" | head -1 | sed 's/^["'\'']//; s/["'\'']$//'
+}
+
+SKILL_DIRS=()
+for dir in skills/*/; do
+	SKILL_DIRS+=("$(basename "$dir")")
+done
+
+skill_exists() {
+	local candidate="$1" name
+	for name in "${SKILL_DIRS[@]}"; do
+		[[ "$name" == "$candidate" ]] && return 0
+	done
+	return 1
+}
+
+# --- 1. JSON syntax ----------------------------------------------------------
+
+section "JSON syntax"
+json_count=0
+while IFS= read -r file; do
+	json_count=$((json_count + 1))
+	jq empty "$file" >/dev/null 2>&1 || err "$file is not valid JSON"
+done < <(git ls-files '*.json')
+echo "  checked $json_count tracked JSON files"
+
+# --- 2. Plugin manifests -----------------------------------------------------
+
+section "Plugin manifests"
+PLUGIN_MANIFEST=.claude-plugin/plugin.json
+if [[ -f "$PLUGIN_MANIFEST" ]]; then
+	jq -e '.name | type == "string" and length > 0' "$PLUGIN_MANIFEST" >/dev/null ||
+		err "$PLUGIN_MANIFEST: missing or empty name"
+	version=$(jq -r '.version // ""' "$PLUGIN_MANIFEST")
+	[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$ ]] ||
+		err "$PLUGIN_MANIFEST: version '$version' is not semver"
+	jq -e '.description | type == "string" and length > 0' "$PLUGIN_MANIFEST" >/dev/null ||
+		err "$PLUGIN_MANIFEST: missing or empty description"
+	echo "  $PLUGIN_MANIFEST declares version $version"
+else
+	err "$PLUGIN_MANIFEST is missing"
+fi
+
+MARKETPLACE=.claude-plugin/marketplace.json
+if [[ -f "$MARKETPLACE" ]]; then
+	jq -e '.name | type == "string" and length > 0' "$MARKETPLACE" >/dev/null ||
+		err "$MARKETPLACE: missing or empty name"
+	jq -e '.plugins | type == "array" and length > 0' "$MARKETPLACE" >/dev/null ||
+		err "$MARKETPLACE: plugins must be a non-empty array"
+	jq -e 'all(.plugins[]; (.name | type == "string" and length > 0) and (.source.repo | type == "string" and length > 0))' \
+		"$MARKETPLACE" >/dev/null ||
+		err "$MARKETPLACE: every plugin entry needs a name and source.repo"
+else
+	err "$MARKETPLACE is missing"
+fi
+
+# --- 3. SKILL.md frontmatter -------------------------------------------------
+
+section "Skill frontmatter"
+for name in "${SKILL_DIRS[@]}"; do
+	file="skills/$name/SKILL.md"
+	if [[ ! -f "$file" ]]; then
+		err "skills/$name/ has no SKILL.md"
+		continue
+	fi
+	block=$(frontmatter "$file")
+	if [[ -z "$block" ]]; then
+		err "$file: no YAML frontmatter block"
+		continue
+	fi
+	fm_name=$(fm_value "$block" name)
+	fm_desc=$(fm_value "$block" description)
+	[[ -n "$fm_name" ]] || err "$file: frontmatter is missing 'name'"
+	[[ -z "$fm_name" || "$fm_name" == "$name" ]] ||
+		err "$file: frontmatter name '$fm_name' does not match directory '$name'"
+	[[ -n "$fm_desc" ]] || err "$file: frontmatter is missing 'description'"
+done
+echo "  checked ${#SKILL_DIRS[@]} skills"
+
+# --- 4. skills/_index.json ---------------------------------------------------
+
+section "Skills manifest"
+MANIFEST=skills/_index.json
+if [[ -f "$MANIFEST" ]]; then
+	jq -e 'type == "object" and length > 0' "$MANIFEST" >/dev/null ||
+		err "$MANIFEST: must be a non-empty object of group -> [skill]"
+	jq -e 'all(.[]; type == "array" and length > 0 and (all(.[]; type == "string" and test("^[a-z0-9][a-z0-9-]*$"))))' \
+		"$MANIFEST" >/dev/null ||
+		err "$MANIFEST: every group must be a non-empty array of kebab-case skill names"
+
+	listed=$(jq -r '[.[][]] | .[]' "$MANIFEST")
+	duplicates=$(printf '%s\n' "$listed" | sort | uniq -d)
+	[[ -z "$duplicates" ]] ||
+		err "$MANIFEST: skill listed in more than one group: $(echo "$duplicates" | tr '\n' ' ')"
+
+	while IFS= read -r name; do
+		[[ -n "$name" ]] || continue
+		skill_exists "$name" || err "$MANIFEST lists '$name' but skills/$name/ does not exist"
+	done <<<"$listed"
+
+	for name in "${SKILL_DIRS[@]}"; do
+		printf '%s\n' "$listed" | grep -qx "$name" ||
+			err "skills/$name/ exists but is not listed in $MANIFEST"
+	done
+	echo "  $(printf '%s\n' "$listed" | grep -c .) skills across $(jq -r 'length' "$MANIFEST") groups"
+else
+	err "$MANIFEST is missing"
+fi
+
+# --- 5. Evals ----------------------------------------------------------------
+
+section "Eval definitions"
+EVALS=evals/evals.json
+if [[ -f "$EVALS" ]]; then
+	if jq -e '.evals | type == "array" and length > 0' "$EVALS" >/dev/null; then
+		jq -e '[.evals[].id] | length == (unique | length)' "$EVALS" >/dev/null ||
+			err "$EVALS: eval ids are not unique"
+		bad=$(jq -r '[.evals[] | select(
+				(.id | type) != "number"
+				or (.skill | type != "string" or length == 0)
+				or (.prompt | type != "string" or length == 0)
+				or (.assertions | type != "array" or length == 0)
+				or (any(.assertions[]; (.text | type != "string" or length == 0)))
+			) | (.id // "?" | tostring)] | join(", ")' "$EVALS")
+		[[ -z "$bad" ]] ||
+			err "$EVALS: entries missing id/skill/prompt/assertions[].text: $bad"
+
+		while IFS= read -r name; do
+			[[ -n "$name" ]] || continue
+			skill_exists "$name" || err "$EVALS references unknown skill '$name'"
+		done < <(jq -r '[.evals[].skill] | unique | .[]' "$EVALS")
+		echo "  $(jq -r '.evals | length' "$EVALS") evals across $(jq -r '[.evals[].skill] | unique | length' "$EVALS") skills"
+	else
+		err "$EVALS: .evals must be a non-empty array"
+	fi
+else
+	err "$EVALS is missing"
+fi
+
+for file in evals/triggers/*.json; do
+	[[ -e "$file" ]] || break
+	name=$(basename "$file" .json)
+	skill_exists "$name" || err "$file has no matching skills/$name/"
+	jq -e 'type == "array" and length > 0 and all(.[];
+			(.query | type == "string" and length > 0) and (.should_trigger | type == "boolean"))' \
+		"$file" >/dev/null ||
+		err "$file: must be a non-empty array of {query, should_trigger}"
+done
+
+for file in evals/pipeline/*.json; do
+	[[ -e "$file" ]] || break
+	jq -e '(.id | type == "string" and length > 0)
+			and (.description | type == "string" and length > 0)
+			and (.setup.repo_strategy | . == "local-tmp-init" or . == "gh-disposable")
+			and ((.cost_class // "low") | . == "low" or . == "high")
+			and (.steps | type == "array" and length > 0)
+			and all(.steps[];
+				(.skill | type == "string" and length > 0)
+				and (.prompt | type == "string" and length > 0)
+				and (.verify | type == "array" and length > 0))
+			and (.final_assertions | type == "array" and length > 0)' \
+		"$file" >/dev/null ||
+		err "$file: malformed scenario (needs id, description, setup.repo_strategy, steps[].{skill,prompt,verify}, final_assertions)"
+
+	while IFS= read -r name; do
+		[[ -n "$name" ]] || continue
+		skill_exists "$name" || err "$file: step references unknown skill '$name'"
+	done < <(jq -r '[.steps[].skill] | unique | .[]' "$file" 2>/dev/null)
+done
+echo "  checked $(find evals/triggers -name '*.json' | wc -l | tr -d ' ') trigger sets and $(find evals/pipeline -name '*.json' | wc -l | tr -d ' ') pipeline scenarios"
+
+# --- Advisories --------------------------------------------------------------
+
+section "Eval coverage (advisory)"
+for name in "${SKILL_DIRS[@]}"; do
+	has_eval=$(jq -r --arg s "$name" '[.evals[] | select(.skill == $s)] | length' "$EVALS" 2>/dev/null || echo 0)
+	[[ "$has_eval" != "0" ]] || note "skills/$name/ has no entry in $EVALS"
+	[[ -f "evals/triggers/$name.json" ]] || note "skills/$name/ has no evals/triggers/$name.json"
+done
+[[ "$NOTES" -gt 0 ]] || echo "  every skill has evals and a trigger set"
+
+# --- Result ------------------------------------------------------------------
+
+echo
+if [[ "$ERRORS" -eq 0 ]]; then
+	printf '\033[32mStructure checks passed\033[0m (%d advisories)\n' "$NOTES"
+	exit 0
+fi
+printf '\033[31m%d structure check(s) failed\033[0m\n' "$ERRORS"
+exit 1


### PR DESCRIPTION
## What

Adds a `Makefile` exposing `test`, `lint`, and `check`, a structural validation script behind `make lint`, and a `ci.yml` workflow that runs the same two targets on every PR and push to `main`.

This repo had no Makefile, so there was no uniform entry point for verification and nothing ran on a PR that didn't touch `skills/`, `references/`, or `evals/` — `skill-evals.yml` is path-filtered, and `deploy-docs.yml` only builds on pushes to `main`.

## Targets

| Target | What it does |
|--------|--------------|
| `make check` | `lint` + `test` |
| `make lint` | `scripts/check-structure.sh` + the docs-site TypeScript typecheck |
| `make test` | `node --test` over the docs-site build-script unit tests (12 tests) |
| `make deps` | `npm ci` in `docs-site/`; the other targets do this on demand via a make prerequisite |
| `make docs-build` | Builds the docs site the same way `deploy-docs.yml` does |
| `make clean` | Removes `node_modules`, `build/`, `.docusaurus/`, `docs-generated/` |

`make help` lists them.

## What `scripts/check-structure.sh` validates

Everything deterministic — bash + `jq`, no LLM:

1. Every tracked `*.json` file parses.
2. `.claude-plugin/plugin.json` has a name, a semver version, and a description; `.claude-plugin/marketplace.json` has a name and plugin entries with `name` + `source.repo`.
3. Every `skills/<name>/SKILL.md` has a frontmatter block whose `name` matches its directory and a non-empty `description`.
4. `skills/_index.json` is well-shaped (non-empty kebab-case arrays, no skill in two groups) and bidirectionally consistent with `skills/` — nothing listed that doesn't exist, nothing on disk that isn't listed.
5. `evals/evals.json` entries have unique ids, a `skill` that exists, a prompt, and non-empty assertions with text; `evals/triggers/*.json` are `{query, should_trigger}` arrays whose filename maps to a real skill; `evals/pipeline/*.json` scenarios have an id, description, a known `repo_strategy`, steps with `skill`/`prompt`/`verify`, and final assertions.

Skills with no eval entry or no trigger set are reported as **advisories** and do not fail the run. Today that surfaces three real gaps — `graph`, `search`, and `report-friction` have no evals — without blocking the build on them.

## Evals stay CI-only

The skill evals are graded by an LLM via `anthropics/claude-code-action`, so `make test` does not invoke them. `make lint` checks that their *definitions* are well-formed, which is the part that can be verified locally. This is documented in `README.md` and `CLAUDE.md`.

## Drive-by fix

`make lint` includes `npm run typecheck`, which was failing on `main`: `@types/react` resolves to v19 through the Docusaurus dependency tree and React 19 dropped the global `JSX` namespace, so all five badge components reported `TS2503`. Nothing surfaced it because no CI job ran `tsc`. Fixed in its own commit (`JSX.Element` → `React.JSX.Element`, five lines).

## Verification

```
$ make check
Structure checks passed (6 advisories)
> tsc
✔ 12 tests, 0 failures
$ echo $?
0
```

Negative-tested the lint script by breaking a tracked JSON file and by adding a skill directory with no frontmatter and no manifest entry — both produce named failures and exit 1.

Also created the `toil` label on this repo, which didn't exist yet.

## Follow-ups not in this PR

- The repo-root `plugin.json` is a stale duplicate of `.claude-plugin/plugin.json` pinned at `4.0.0` (the real manifest is `5.2.1`). Nothing references it. Deleting it is its own concern, so lint only checks that it parses.
- CI does not yet run gitleaks or `make docs-build` on PRs.

🤖 Posted on behalf of `@joestump` by [`claude-fable-5`](https://openrouter.ai/anthropic/claude-fable-5) using [Claude Code](https://claude.ai).
