### PR TITLE
docs: update release process for branch-protected main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,12 +76,14 @@ Run `make check` (`make test` + `make lint` + `make scan`) before pushing.
 
 The LLM-graded skill evals under `evals/` run only in CI; `make test` does not invoke them.
 
-`.github/workflows/ci.yml` runs the same targets on every PR, so keep new checks in the `Makefile` rather than inlining them into the workflow.
+`.github/workflows/ci.yml` runs the same targets on every PR, so keep new checks in the `Makefile` rather than inlining them into the workflow. Its `lint`, `test`, and `gitleaks` jobs are required status checks on `main` — if you add a job that should gate merges, add it to the required list too, or it runs without gating anything.
 
 ### Release Process
 
+`main` is protected: direct pushes are rejected, and `lint`, `test`, and `gitleaks` must pass before anything merges. Enforcement includes admins, so the version bump goes through a PR like any other change.
+
 When releasing a new version:
 1. Bump the version in `.claude-plugin/plugin.json`
-2. Commit and push to `main`
+2. Open a PR with the bump and merge it once CI is green (squash — `main` requires linear history)
 3. Create a GitHub release with `gh release create vX.Y.Z --title "vX.Y.Z" --notes "..."` using a haiku as the release summary
 4. Always tag releases as `vX.Y.Z` (e.g., `v1.5.0`)


### PR DESCRIPTION
## Summary

Follow-up to #208. While adding the `gitleaks` job I found `main` had **no branch protection at all** — `lint`, `test`, and `gitleaks` all ran but gated nothing, so a red PR stayed mergeable and direct pushes to `main` were allowed. #208's last bullet assumed protection existed and only needed `gitleaks` added to it.

Protection is now enabled (`lint` + `test` + `gitleaks` required, strict/up-to-date, linear history, no force pushes or deletions, **enforced for admins**). That makes the documented release process wrong: step 2 was "commit and push to `main`", which is now rejected.

- Release process goes through a PR, squash-merged.
- Added a note that a new CI job must also be added to the required-checks list, or it runs without gating anything — the exact gap this PR came out of.

This PR is also the first thing through the new protection, so it doubles as a check that the required contexts are named correctly and the gate actually passes.

## Test plan

- [x] `./scripts/check-structure.sh` passes.
- [x] Verified the protection is live: `GET /branches/main/protection` returns the three contexts with `strict: true` and `enforce_admins: true`.
- [ ] Docs-only change.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).