### PR TITLE
adr: pin the status enum in the template and make the diagram rule match SPEC-0003

### DIFF
--- a/skills/adr/SKILL.md
+++ b/skills/adr/SKILL.md
@@ -136,7 +136,7 @@ Follow the standard team handoff protocol from the plugin's `${CLAUDE_PLUGIN_ROO
 
 ```markdown
 ---
-status: proposed
+status: proposed  # one of: proposed | accepted | deprecated | superseded (values enforced by /sdd:status)
 date: {YYYY-MM-DD}
 decision-makers: {list}
 # Optional graph edges (per ADR-0023 / SPEC-0018). All fields are lists of artifact IDs.
@@ -215,6 +215,7 @@ Use flowchart, sequence, or C4 diagrams as appropriate.}
 - ADR numbers MUST be sequential and zero-padded to 4 digits: ADR-0001, ADR-0002, etc.
 - MUST include at least 2 considered options with substantive pros and cons for each
 - Status starts as `proposed` -- the user decides when to mark `accepted`
+- The `status` frontmatter value MUST be exactly one of `proposed`, `accepted`, `deprecated`, `superseded` -- the same enum `/sdd:status` enforces. Free-form or differently-capitalized values (e.g. `Accepted`, `done`) break status filtering and `/sdd:list` rendering
 - Self-review (default) or architect review (`--review`) MUST check for:
   - Completeness of all required sections (Context, Options, Outcome, Pros/Cons)
   - Realistic and balanced pros/cons (not just cheerleading the chosen option)
@@ -223,7 +224,7 @@ Use flowchart, sequence, or C4 diagrams as appropriate.}
 - Keep the title short and descriptive
 - Focus on the "why" -- what problem does this solve and why this solution?
 - Reference existing ADRs if this supersedes or relates to them
-- Every ADR SHOULD include at least one Mermaid diagram illustrating the architecture or decision flow. Use flowchart, sequence, or C4 diagrams as appropriate.
+- Every ADR MUST include at least one Mermaid diagram in its Architecture Diagram section, matching the mandatory section in SPEC-0003 -- use flowchart, sequence, or C4 diagrams as appropriate. When the cgg call-graph opt-in (Step 2b) is declined or unavailable, write a small hand-authored diagram instead of leaving the section empty
 - **v5.0.0+**: MUST run qmd-aware edge pre-search per Step 1a — surface candidate `supersedes`/`extends`/`related` edges to the user via AskUserQuestion before drafting. The user's confirmed edges land in the new ADR's frontmatter (Governing: ADR-0024, SPEC-0019 REQ "qmd-Smart Authoring Skills")
 - **v5.0.0+**: MUST trigger Tier 1 `{repo}-adrs` re-sync after writing the new file per Step 3a — best-effort, silent on success, one-line warning on failure (Governing: ADR-0026, SPEC-0019 REQ "Tier 1 Mutation-Aware Updates")
 - MUST check the `{repo}-adrs` context blurb for drift after the Tier 1 re-sync per Step 3a — the re-sync maintains the index only, and a stale context is asserted to every consumer on every query

--- a/skills/adr/SKILL.md
+++ b/skills/adr/SKILL.md
@@ -68,7 +68,7 @@ You are creating a new ADR using the MADR (Markdown Architectural Decision Recor
 
    **Default to "no"** when: the session is non-interactive (piped input), batch/CI mode is detected, or the question times out. In those cases, proceed directly to Step 3 as if the user answered "no" — no error, no deviation from existing behavior.
 
-   **If the user answers "no" or "skip"**: Proceed to Step 3 with an empty `## Architecture Diagram` section (the template placeholder text is omitted; write the section header with no body, or omit the section entirely). No call graph is generated.
+   **If the user answers "no" or "skip"**: Proceed to Step 3 with no call graph. The `## Architecture Diagram` section is still REQUIRED (SPEC-0003 REQ "Architecture Diagrams") — hand-author a small flowchart, sequence, or C4 diagram of the decision instead. Only the cgg-generated call graph is skipped, never the section.
 
    **If the user answers "yes"**:
 
@@ -101,7 +101,7 @@ You are creating a new ADR using the MADR (Markdown Architectural Decision Recor
       ```
       The caption comment MUST record the exact filter regex used and today's date.
 
-   In every degradation case (cgg missing, timeout, non-zero exit, all files skipped), the skill MUST complete and write the ADR without a call graph. Never surface a hard failure to the user when cgg is the only failing component.
+   In every degradation case (cgg missing, timeout, non-zero exit, all files skipped), the skill MUST complete and write the ADR without a call graph — hand-authoring the `## Architecture Diagram` section as above, since the section itself is not optional. Never surface a hard failure to the user when cgg is the only failing component.
 
 3. **Write the ADR** to `{adr-dir}/ADR-XXXX-short-title.md`. Include the user-confirmed frontmatter edges from Step 1a in the YAML frontmatter (per the canonical edge schema in `${CLAUDE_PLUGIN_ROOT}/references/shared-patterns.md` § "Graph Edge Resolution").
 
@@ -136,7 +136,8 @@ Follow the standard team handoff protocol from the plugin's `${CLAUDE_PLUGIN_ROO
 
 ```markdown
 ---
-status: proposed  # one of: proposed | accepted | deprecated | superseded (values enforced by /sdd:status)
+# status: one of proposed | accepted | deprecated | superseded (enum enforced by /sdd:status)
+status: proposed
 date: {YYYY-MM-DD}
 decision-makers: {list}
 # Optional graph edges (per ADR-0023 / SPEC-0018). All fields are lists of artifact IDs.


### PR DESCRIPTION
Second of five authoring-skill hardening PRs from the downstream audit.

## What changed

1. **Status enum pinned in the template.** The MADR template showed a bare `status: proposed` without naming the valid values, so nothing at authoring time stopped a free-form or differently-capitalized value (`Accepted`, `done`) from landing and breaking `/sdd:status` transitions and `/sdd:list` rendering later. The template comment and a new MUST rule now state the enum explicitly: `proposed | accepted | deprecated | superseded`.

2. **Diagram rule aligned with SPEC-0003.** `docs/openspec/specs/foundational-artifacts/spec.md` already mandates "Every ADR MUST include an Architecture Diagram section containing at least one Mermaid diagram," but the skill's Rules said SHOULD — so whenever the cgg call-graph opt-in is declined or cgg is unavailable (the common case), an ADR could ship with an empty diagram section and the skill was following its own rule while violating the spec. The rule is now MUST, with explicit instruction to hand-author a small diagram when the cgg path is unavailable.

No spec changes needed — both fixes bring the skill in line with what SPEC-0003 already requires.

## Verification
- `scripts/check-structure.sh` passes
- The plugin's own ADR corpus already conforms to the enum (17 `accepted`, 18 `proposed`, 1 unrelated issue-tracking file)

🤖 This was posted autonomously by [`glm-5.3`](https://openrouter.ai/z-ai/glm-5.3) using [Crush](https://github.com/charmbracelet/crush).