### PR TITLE
spec: render frontmatter edges as a Related Artifacts body section

### DIFF
--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -393,13 +393,21 @@ date: {YYYY-MM-DD}
 
 # SPEC-XXXX: {Capability Title}
 
-## Related Artifacts
+## Graph Edges
 
 <!-- Mirrors the frontmatter edges -- regenerate this section whenever edges change.
      One bullet per edge target, naming the edge verb. Omit the entire section when
-     the spec declares no edges. -->
+     the spec declares no edges.
 
-- **Implements:** [ADR-XXXX](../../../adr/ADR-XXXX-title.md) — {the decision this spec realizes}
+     NOT named "Related Artifacts": /sdd:docs appends a generated section under
+     exactly that heading (the mini-DAG, per ADR-0023), and two H2s with the same
+     text give the rendered page duplicate anchors and a doubled TOC entry.
+
+     Link targets are relative to this file. The paths below assume the default
+     layout (specs at {spec-dir}/{capability}/spec.md, ADRs at docs/adrs/); resolve
+     them against the actual {adr-dir}/{spec-dir} from Step 0 when they differ. -->
+
+- **Implements:** [ADR-XXXX](../../../adrs/ADR-XXXX-title.md) — {the decision this spec realizes}
 - **Requires:** [SPEC-XXXX](../capability/spec.md) — {the capability this spec depends on}
 
 ## Overview
@@ -497,7 +505,7 @@ date: {YYYY-MM-DD}
 - When ANY change is made to spec.md, design.md MUST be reviewed and updated where requirements have changed the architecture, decisions, or rationale -- and vice versa. Both files MUST remain consistent with each other at all times.
 - spec.md MUST use RFC 2119 language (SHALL, MUST, MUST NOT, SHOULD, SHOULD NOT, MAY, REQUIRED, RECOMMENDED, OPTIONAL) for ALL normative requirements
 - spec.md MUST use spec numbering: SPEC-XXXX (sequential, zero-padded to 4 digits). NEVER use RFC-XXXX -- "RFC 2119" refers to the requirements language standard, NOT the spec numbering scheme
-- When the spec declares frontmatter edges, spec.md MUST carry a `## Related Artifacts` section immediately after the H1 that mirrors them -- one bullet per edge target naming the edge verb (`Implements` / `Requires` / `Extends` / `Supersedes`) and linking the target. Frontmatter is machine-readable; this section is the human-readable rendering, so readers of the raw or rendered page see the graph without parsing YAML. On ANY update that changes edges, the section MUST be regenerated in the same pass -- a stale section is a lie about the graph. Omit the section entirely when there are no edges
+- When the spec declares frontmatter edges, spec.md MUST carry a `## Graph Edges` section immediately after the H1 that mirrors them -- one bullet per edge target naming the edge verb (`Implements` / `Requires` / `Extends` / `Supersedes`) and linking the target. The heading MUST NOT be `Related Artifacts`: `/sdd:docs` appends a generated mini-DAG section under that exact heading, and a second H2 with the same text gives every rendered spec page duplicate anchors and a doubled TOC entry. Frontmatter is machine-readable; this section is the human-readable rendering, so readers of the raw or rendered page see the graph without parsing YAML. On ANY update that changes edges, the section MUST be regenerated in the same pass -- a stale section is a lie about the graph. Omit the section entirely when there are no edges
 - Scenarios MUST use exactly 4 hashtags (`####`) -- using 3 hashtags or bullets will cause silent failures in downstream tooling
 - Every requirement MUST have at least one scenario
 - design.md focuses on HOW and WHY -- architecture and rationale, not line-by-line implementation details

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -393,6 +393,15 @@ date: {YYYY-MM-DD}
 
 # SPEC-XXXX: {Capability Title}
 
+## Related Artifacts
+
+<!-- Mirrors the frontmatter edges -- regenerate this section whenever edges change.
+     One bullet per edge target, naming the edge verb. Omit the entire section when
+     the spec declares no edges. -->
+
+- **Implements:** [ADR-XXXX](../../../adr/ADR-XXXX-title.md) — {the decision this spec realizes}
+- **Requires:** [SPEC-XXXX](../capability/spec.md) — {the capability this spec depends on}
+
 ## Overview
 
 {Brief description of what this capability does and why it exists. If derived from an ADR, reference it here (e.g., "See ADR-0003").}
@@ -488,6 +497,7 @@ date: {YYYY-MM-DD}
 - When ANY change is made to spec.md, design.md MUST be reviewed and updated where requirements have changed the architecture, decisions, or rationale -- and vice versa. Both files MUST remain consistent with each other at all times.
 - spec.md MUST use RFC 2119 language (SHALL, MUST, MUST NOT, SHOULD, SHOULD NOT, MAY, REQUIRED, RECOMMENDED, OPTIONAL) for ALL normative requirements
 - spec.md MUST use spec numbering: SPEC-XXXX (sequential, zero-padded to 4 digits). NEVER use RFC-XXXX -- "RFC 2119" refers to the requirements language standard, NOT the spec numbering scheme
+- When the spec declares frontmatter edges, spec.md MUST carry a `## Related Artifacts` section immediately after the H1 that mirrors them -- one bullet per edge target naming the edge verb (`Implements` / `Requires` / `Extends` / `Supersedes`) and linking the target. Frontmatter is machine-readable; this section is the human-readable rendering, so readers of the raw or rendered page see the graph without parsing YAML. On ANY update that changes edges, the section MUST be regenerated in the same pass -- a stale section is a lie about the graph. Omit the section entirely when there are no edges
 - Scenarios MUST use exactly 4 hashtags (`####`) -- using 3 hashtags or bullets will cause silent failures in downstream tooling
 - Every requirement MUST have at least one scenario
 - design.md focuses on HOW and WHY -- architecture and rationale, not line-by-line implementation details


### PR DESCRIPTION
Third of five authoring-skill hardening PRs from the downstream audit.

## Problem

Frontmatter edges (`implements` / `requires` / `extends` / `supersedes`) are machine-readable only. A human reading the raw markdown or the rendered docs page never sees the graph, so downstream projects hand-write their own "Related ADRs" header lines — and in every repo audited (msgbrowse's 20 specs, plus older plugin-generated projects) those lines drifted into at least three inconsistent shapes: some linked, some plain text, some with titles in the link text, some absent entirely.

## Change

The spec.md template gains a canonical `## Related Artifacts` section immediately after the H1 that mirrors the frontmatter edges — one bullet per edge target, naming the edge verb and linking the target. A MUST rule requires it whenever edges exist and requires regenerating it in the same pass whenever edges change on update ("a stale section is a lie about the graph"); it's omitted entirely when the spec declares no edges.

New specs get the section for free from the template; existing specs pick it up on their next `/sdd:spec --update`.

## Verification
- `scripts/check-structure.sh` passes; template-only change.

🤖 This was posted autonomously by [`glm-5.3`](https://openrouter.ai/z-ai/glm-5.3) using [Crush](https://github.com/charmbracelet/crush).