### PR TITLE
spec: allow security topics to be satisfied by governing-artifact references

### DIFF
--- a/docs/openspec/specs/security-and-quality-guardrails/design.md
+++ b/docs/openspec/specs/security-and-quality-guardrails/design.md
@@ -75,6 +75,17 @@ Governing: ADR-0018 (Security-by-Default), ADR-0019 (Frontend Quality Standards)
 - External traceability matrix: Loses co-location; line numbers go stale with every edit; a single matrix file is an even worse merge conflict hotspot
 - Remove governing comments entirely: Loses code-level traceability; `/sdd:check` and `/sdd:audit` lose their primary signal for verifying implementation alignment
 
+### Governing-Artifact References Satisfy Security Topics
+
+**Choice**: Each of the six mandatory security topics may be satisfied either inline or by an explicit reference to a governing artifact (an ADR or spec) that already fixes that topic project-wide. Topics with no governing artifact, and any deviation from the governed baseline, MUST still be written inline.
+
+**Rationale**: The six topics were mandatory-inline, so a project with a security-posture ADR restated the same six paragraphs in every web-facing spec. Copies drift: the third spec's CSP list stops matching the ADR's, and neither one is obviously wrong to a reader. The reference form gives one editable source of truth, and the deviation carve-out keeps the thing the inline rule was actually protecting — a spec that *changes* the baseline cannot hide that change behind a citation. The security-headers topic already permitted "or reference an existing security headers ADR", so this generalizes an allowance the spec had already made once.
+
+**Alternatives considered**:
+- Keep every topic mandatory-inline: The status quo. Correct in a project with no security ADR, wasteful and drift-prone in one that has it, and the drift is silent
+- Allow a whole-section reference: Loses per-topic granularity — a single "see ADR-0010" cannot show which of the six topics the ADR actually covers, so an uncovered topic disappears rather than being flagged
+- Generate the inline text from the governing artifact: Same drift with extra machinery, and it needs a regeneration step nothing currently runs
+
 ### Go-Specific Quality as Conditional Injection
 
 **Choice**: Go quality guidelines are injected only when `go.mod` is detected, making them conditional on project technology.
@@ -231,6 +242,7 @@ The detection is intentionally broad — it is better to inject a section that t
 ## Risks / Trade-offs
 
 - **Mandatory sections add spec length** -> For simple internal tools, the security and accessibility sections may feel heavy-handed. Mitigation: spec authors can pare down the sections to match their threat model, but the sections are present as a starting point rather than absent by default.
+- **A governing-artifact reference can hide a deviation** -> A spec may cite an ADR for a topic while quietly doing something the ADR does not sanction, and a reader following the citation sees the baseline rather than the exception. Mitigation: the spec requires deviations to be written inline even when the topic otherwise has a governing artifact, and the reference must name the artifact (and section where applicable) so a reviewer can check the claim rather than take it on faith.
 - **False positives in lint patterns** -> Text-based matching will flag safe usages (e.g., `io.ReadAll` on an already-bounded body, `innerHTML` with pre-sanitized content). Mitigation: findings are for human review with remediation suggestions, not automated blocking. Projects can add suppression comments (e.g., `// nosec: body already bounded by MaxBytesReader`).
 - **Companion test stories increase sprint volume** -> Creating test stories for every UI-touching feature adds 30-50% more issues per sprint. Mitigation: test stories are estimated at half the effort of feature stories; they can be batched or deprioritized by the team if capacity is limited.
 - **Go-specific guidelines may not cover all Go patterns** -> The initial set (slog, %w, sentinel errors, context propagation) addresses findings from three repos but is not exhaustive. Mitigation: the pattern set is additive — new patterns can be added in future spec revisions without breaking existing behavior.

--- a/docs/openspec/specs/security-and-quality-guardrails/spec.md
+++ b/docs/openspec/specs/security-and-quality-guardrails/spec.md
@@ -14,16 +14,26 @@ This spec formalizes requirements from ADR-0018 (Security-by-Default for Web Spe
 
 ### Requirement: Mandatory Security Section in Web Specs
 
-When `/sdd:spec` creates or updates a specification that involves HTTP endpoints, web server routes, API definitions, or browser-facing UI, the skill MUST inject a "Security Requirements" section into the spec. The section MUST cover all of the following topics:
+When `/sdd:spec` creates or updates a specification that involves HTTP endpoints, web server routes, API definitions, or browser-facing UI, the skill MUST inject a "Security Requirements" section into the spec. The section MUST cover all of the following topics — each topic either written inline or satisfied by an explicit reference to a governing artifact (an ADR or spec) that fixes that topic project-wide and governs the surfaces this spec touches; a topic with no governing artifact, and any deviation from the governed baseline, MUST be written inline:
 
 - **Authentication**: All endpoints MUST require authentication by default. Any endpoint declared as public (unauthenticated) MUST include an explicit justification for why authentication is not required.
 - **Rate limiting**: The spec MUST declare a rate limiting strategy or explicitly state that rate limiting is deferred with justification.
-- **Security headers**: The spec MUST require baseline security headers (Content-Security-Policy, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) or reference an existing security headers ADR.
+- **Security headers**: The spec MUST require baseline security headers (Content-Security-Policy, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) or reference an existing security headers ADR. This reference form is the model for the governing-artifact allowance above.
 - **Request body size limits**: The spec MUST require bounded request body reading (e.g., `http.MaxBytesReader` in Go) for all endpoints that accept request bodies.
 - **CSRF protection**: The spec MUST declare a CSRF protection strategy for state-changing endpoints.
 - **Redirect validation**: The spec MUST require validation of redirect targets for any endpoint that performs HTTP redirects with user-supplied URLs.
 
 The security section MUST NOT be injected for specs that do not involve web-facing characteristics (e.g., CLI tools, internal libraries, batch processing).
+
+#### Scenario: Governing-artifact reference satisfies a topic
+
+- **WHEN** a web-facing spec is created in a project that has a security-posture ADR fixing, e.g., security headers and CSRF strategy for all UI surfaces, and this spec changes nothing about those topics
+- **THEN** the Security Requirements section satisfies those topics by naming the ADR (with a section pointer where applicable) rather than restating its rules inline, while topics with no governing artifact remain inline
+
+#### Scenario: Reference form must not mask a deviation
+
+- **WHEN** a web-facing spec introduces an endpoint or behavior that deviates from the governing ADR's baseline (a new public endpoint, a relaxed body limit)
+- **THEN** the deviation is written inline in that spec's Security Requirements section even though the topic otherwise has a governing artifact
 
 #### Scenario: Web-facing spec creation
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -190,6 +190,8 @@ A spec is **NOT web-facing** if it exclusively involves: CLI tools, internal lib
 
 You MUST inject a **## Security Requirements** section into spec.md, placed after the functional `## Requirements` section. This section MUST cover all six topics below. Use the template in the "Security Requirements Section Template" below.
 
+Each topic MAY be satisfied one of two ways: written inline, or by an **explicit reference to a governing artifact** (an ADR or spec) that already fixes that topic project-wide — provided the reference names the artifact (e.g., "per [ADR-0010] §2") and that artifact genuinely governs the surfaces this spec touches. Prefer the reference form when the project has a security-posture ADR: restating the same six paragraphs in every web-facing spec is how copies drift apart and the baseline silently rots. Topics with no governing artifact, and anything this spec changes about the baseline, MUST be written inline.
+
 You MUST also apply **auth-by-default**: when generating endpoint tables or lists, every endpoint MUST default to "Auth: Required". Any endpoint the spec author wants to be public MUST be listed as "Auth: Public" with an explicit justification (e.g., "Health check — required for load balancer probes"). Do NOT leave any endpoint without an auth designation.
 
 ### When the spec is NOT web-facing

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -202,6 +202,12 @@ Do NOT inject the Security Requirements section. Proceed with the standard spec 
 
 Read the Security Requirements template from `references/security-requirements-template.md` and inject it into the spec after the functional requirements. The template covers all six required topics: authentication, rate limiting, security headers, request body size limits, CSRF protection, and redirect validation.
 
+The template writes every topic inline. Where a governing artifact already fixes a topic (per the two-ways rule above), replace that topic's body with the citation rather than deleting the topic — the six headings stay, so an uncovered topic is visible as an empty one instead of disappearing:
+
+```markdown
+- **CSRF protection**: Per [ADR-0010](../../adrs/ADR-0010-security-posture.md) §3 — double-submit cookie on all state-changing routes. No deviation in this capability.
+```
+
 ## UI-Facing Detection and Accessibility Injection
 
 <!-- Governing: ADR-0019 (Frontend Quality Standards), SPEC-0016 REQ "Accessibility Requirements for UI Specs" -->


### PR DESCRIPTION
Fourth of five authoring-skill hardening PRs from the downstream audit.

## Problem

SPEC-0016 mandates that every web-facing spec's Security Requirements section covers six topics, with exactly one escape hatch: security headers *may* be satisfied "by reference to an existing security headers ADR." The other five topics must be restated inline every time. Downstream consequence observed in the audit: msgbrowse carries the identical CSP/loopback/nosniff posture text in six different specs — six copies that drift apart silently the first time the baseline changes and one of them isn't updated.

## Change

- **`skills/spec/SKILL.md`**: the injection rule now allows each of the six topics to be satisfied either inline or by an explicit reference to a governing artifact (ADR or spec) that fixes the topic project-wide — provided the reference names the artifact (e.g., "per [ADR-0010] §2") and the artifact governs the surfaces the spec touches. Deviations from the governed baseline and topics with no governing artifact stay inline. The skill is instructed to prefer the reference form when a security-posture ADR exists.
- **SPEC-0016** (the plugin's own spec, dogfooded): the "Mandatory Security Section in Web Specs" requirement gains the matching wording, plus two scenarios — one establishing that a governing reference satisfies a topic, and one establishing that a reference must not mask a deviation (a new public endpoint or relaxed limit is written inline even when the topic has a governing artifact).

This generalizes an allowance the spec already made for headers, rather than inventing a new mechanism.

## Verification
- `scripts/check-structure.sh` passes

🤖 This was posted autonomously by [`glm-5.3`](https://openrouter.ai/z-ai/glm-5.3) using [Crush](https://github.com/charmbracelet/crush).