### PR TITLE
fix(docs): key spec cross-references by artifact ID, not by prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .DS_Store
 .claude/settings.local.json
+.claude/worktrees/
 docs-generated/
 docs-site/node_modules/
 docs-site/build/

--- a/docs-site/scripts/__tests__/spec-references.test.js
+++ b/docs-site/scripts/__tests__/spec-references.test.js
@@ -1,0 +1,199 @@
+/**
+ * Unit tests for spec cross-reference resolution.
+ *
+ * A `SPEC-0008` mention in an ADR or spec body is linkified by
+ * transformSpecReferences() against a mapping built from the specs tree. The
+ * mapping holds two kinds of key, and conflating them is the regression these
+ * tests pin:
+ *
+ *   "SPEC-0008"  a spec's own artifact ID  -> that spec's page, no fragment
+ *   "ARCH"       a domain requirement prefix -> the domain page + #arch-001
+ *
+ * Keying the artifact ID by its prefix ("SPEC") gave every domain the same key,
+ * so the last domain read owned every SPEC-NNNN reference site-wide.
+ *
+ * Three copies of the transform ship from this repo — the docs-site scripts,
+ * the vendored Docusaurus plugin under templates/, and the sync-spec-docs
+ * integration lib — so all three are exercised here.
+ *
+ * Run with `node --test`:
+ *
+ *   node --test docs-site/scripts/__tests__/spec-references.test.js
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+
+// The two library copies expose transformSpecReferences directly; the plugin
+// template only exports the Docusaurus plugin factory and is driven end-to-end
+// below.
+const TRANSFORM_COPIES = [
+  ['docs-site/scripts', require('../transform-utils')],
+  [
+    'templates/integration/sync-spec-docs/lib',
+    require(path.join(REPO_ROOT, 'templates/integration/sync-spec-docs/lib/transform-utils')),
+  ],
+];
+
+// One entry per artifact ID, plus a domain-scoped requirement prefix.
+const MAPPING = {
+  'SPEC-0001': '/specs/alpha/spec',
+  'SPEC-0002': '/specs/beta/spec',
+  ARCH: '/specs/alpha/spec',
+};
+
+for (const [label, { transformSpecReferences }] of TRANSFORM_COPIES) {
+  const transform = (content, specEmojis = {}) =>
+    transformSpecReferences(content, { specMapping: MAPPING, specEmojis, baseUrl: '' });
+
+  test(`${label}: each artifact ID resolves to its own spec page`, () => {
+    assert.match(transform('See SPEC-0001.'), /href="\/specs\/alpha\/spec"/);
+    assert.match(transform('See SPEC-0002.'), /href="\/specs\/beta\/spec"/);
+  });
+
+  test(`${label}: artifact IDs in one line do not collapse onto one page`, () => {
+    const out = transform('SPEC-0001 is extended by SPEC-0002.');
+    assert.match(out, /href="\/specs\/alpha\/spec"[^>]*>SPEC-0001</);
+    assert.match(out, /href="\/specs\/beta\/spec"[^>]*>SPEC-0002</);
+  });
+
+  test(`${label}: artifact IDs get no fragment`, () => {
+    // A spec page's H1 anchor is derived from the whole heading text
+    // ("spec-0001-alpha"), so `#spec-0001` pointed at nothing.
+    assert.doesNotMatch(transform('See SPEC-0001.'), /#spec-0001/);
+  });
+
+  test(`${label}: requirement IDs still resolve to their prefix's page anchor`, () => {
+    assert.match(transform('See ARCH-001.'), /href="\/specs\/alpha\/spec#arch-001"/);
+  });
+
+  test(`${label}: unmapped IDs are left as plain text`, () => {
+    assert.equal(transform('See SPEC-9999 and NOPE-001.'), 'See SPEC-9999 and NOPE-001.');
+  });
+
+  test(`${label}: emoji overrides are keyed by prefix, for both kinds`, () => {
+    assert.match(transform('See SPEC-0001.', { SPEC: '📘' }), />📘 SPEC-0001</);
+    assert.match(transform('See ARCH-001.', { ARCH: '🏛' }), />🏛 ARCH-001</);
+  });
+
+  test(`${label}: baseUrl prefixes both kinds`, () => {
+    const out = transformSpecReferences('SPEC-0002 and ARCH-001.', {
+      specMapping: MAPPING,
+      specEmojis: {},
+      baseUrl: '/docs',
+    });
+    assert.match(out, /href="\/docs\/specs\/beta\/spec"/);
+    assert.match(out, /href="\/docs\/specs\/alpha\/spec#arch-001"/);
+  });
+
+  test(`${label}: code fences and inline code are left alone`, () => {
+    assert.equal(transform('```\nSPEC-0001\n```'), '```\nSPEC-0001\n```');
+  });
+}
+
+// --- The vendored Docusaurus plugin, end to end ----------------------------
+
+function writeFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-spec-refs-'));
+  const site = path.join(root, 'site');
+  fs.mkdirSync(site, { recursive: true });
+  const adrs = path.join(root, 'docs/adrs');
+  fs.mkdirSync(adrs, { recursive: true });
+  fs.writeFileSync(
+    path.join(adrs, 'ADR-0001-example.md'),
+    '---\nstatus: accepted\ndate: 2026-01-01\n---\n\n# ADR-0001: Example\n\n## Context\n\nSomething.\n'
+  );
+
+  const spec = (id, title, body) =>
+    `---\nstatus: active\ndate: 2026-01-01\n---\n\n# ${id}: ${title}\n\n## Overview\n\n${body}\n`;
+
+  const domain = (name, id, title, body) => {
+    const dir = path.join(root, 'docs/openspec/specs', name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'spec.md'), spec(id, title, body));
+    fs.writeFileSync(path.join(dir, 'design.md'), spec(id, `${title} Design`, body));
+  };
+
+  domain('alpha', 'SPEC-0001', 'Alpha', 'Alpha stands alone.');
+  domain('beta', 'SPEC-0002', 'Beta', 'Beta builds on SPEC-0001.');
+  // The prose here mentions `### Requirement:` and then cites an ADR on the
+  // same line — the shape that used to register "ADR" as a spec prefix.
+  domain(
+    'gamma',
+    'SPEC-0003',
+    'Gamma',
+    'Gamma needs SPEC-0001 and SPEC-0002.\n\nOne issue per ### Requirement: section, per ADR-0001.'
+  );
+
+  return { root, site };
+}
+
+// The plugin template requires `lib-artifact-transforms`, which only a
+// consumer's docs-site installs (see templates/docusaurus/package.json).
+// Resolution runs from the plugin's own directory upward, so no install under
+// this repo's docs-site can satisfy it — point the request at the stub, which
+// delegates the actual parsing to graph-data.js.
+function withArtifactTransformsStub(fn) {
+  const Module = require('node:module');
+  const original = Module._resolveFilename;
+  Module._resolveFilename = function (request, ...rest) {
+    if (request === 'lib-artifact-transforms') {
+      return require.resolve('./stubs/lib-artifact-transforms');
+    }
+    return original.call(this, request, ...rest);
+  };
+  try {
+    return fn();
+  } finally {
+    Module._resolveFilename = original;
+  }
+}
+
+test('plugin template: every SPEC reference resolves to its own spec directory', async () => {
+  const { root, site } = writeFixture();
+  const plugin = withArtifactTransformsStub(() =>
+    require(path.join(REPO_ROOT, 'templates/docusaurus/plugins/sdd-content'))
+  );
+
+  await plugin({ siteDir: site }, {}).loadContent();
+
+  const generated = path.join(root, 'docs-generated');
+  const beta = fs.readFileSync(path.join(generated, 'specs/beta/spec.mdx'), 'utf-8');
+  assert.match(beta, /href="\/specs\/alpha\/spec"/);
+
+  const gamma = fs.readFileSync(path.join(generated, 'specs/gamma/spec.mdx'), 'utf-8');
+  assert.match(gamma, /href="\/specs\/alpha\/spec"/);
+  assert.match(gamma, /href="\/specs\/beta\/spec"/);
+
+  // The regression: with the artifact ID keyed by prefix, every one of these
+  // pointed at whichever domain was read last.
+  assert.doesNotMatch(gamma, /href="\/specs\/gamma\/spec[^"]*"[^>]*>SPEC-000[12]</);
+
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('plugin template: a spec citing an ADR does not claim the ADR prefix', async () => {
+  const { root, site } = writeFixture();
+  const plugin = withArtifactTransformsStub(() =>
+    require(path.join(REPO_ROOT, 'templates/docusaurus/plugins/sdd-content'))
+  );
+
+  await plugin({ siteDir: site }, {}).loadContent();
+
+  const gamma = fs.readFileSync(
+    path.join(root, 'docs-generated/specs/gamma/spec.mdx'),
+    'utf-8'
+  );
+  assert.match(gamma, /href="\/decisions\/ADR-0001-example"/);
+  // With "ADR" registered as a spec prefix the spec transform got there first
+  // and wrapped the ADR link in a second anchor pointing at a spec page.
+  assert.doesNotMatch(gamma, /href="[^"]*#adr-0001"/);
+  assert.doesNotMatch(gamma, /<a [^>]*><a /);
+
+  fs.rmSync(root, { recursive: true, force: true });
+});

--- a/docs-site/scripts/__tests__/spec-references.test.js
+++ b/docs-site/scripts/__tests__/spec-references.test.js
@@ -120,6 +120,10 @@ function writeFixture() {
   };
 
   domain('alpha', 'SPEC-0001', 'Alpha', 'Alpha stands alone.');
+  // A spec.md converted from an ADR whose H1 was never renumbered. Its ID must
+  // not be registered in the spec mapping: transformSpecReferences runs first,
+  // so it would capture every ADR-0001 mention on the site.
+  domain('stale', 'ADR-0001', 'Stale Conversion', 'Converted, never renumbered.');
   domain('beta', 'SPEC-0002', 'Beta', 'Beta builds on SPEC-0001.');
   // The prose here mentions `### Requirement:` and then cites an ADR on the
   // same line — the shape that used to register "ADR" as a spec prefix.
@@ -173,6 +177,28 @@ test('plugin template: every SPEC reference resolves to its own spec directory',
   // The regression: with the artifact ID keyed by prefix, every one of these
   // pointed at whichever domain was read last.
   assert.doesNotMatch(gamma, /href="\/specs\/gamma\/spec[^"]*"[^>]*>SPEC-000[12]</);
+
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('plugin template: a spec H1 carrying an ADR number does not claim that ID', async () => {
+  const { root, site } = writeFixture();
+  const plugin = withArtifactTransformsStub(() =>
+    require(path.join(REPO_ROOT, 'templates/docusaurus/plugins/sdd-content'))
+  );
+
+  await plugin({ siteDir: site }, {}).loadContent();
+
+  const gamma = fs.readFileSync(
+    path.join(root, 'docs-generated/specs/gamma/spec.mdx'),
+    'utf-8'
+  );
+  // Still the ADR page, and no spec route claims the ID. Registering it
+  // produced `<a href="/specs/stale/spec"><a href="/decisions/...">ADR-0001</a></a>`,
+  // so the nested-anchor shape is the assertion that actually bites.
+  assert.match(gamma, /href="\/decisions\/ADR-0001-example"/);
+  assert.doesNotMatch(gamma, /href="\/specs\/stale/);
+  assert.doesNotMatch(gamma, /<a [^>]*><a /);
 
   fs.rmSync(root, { recursive: true, force: true });
 });

--- a/docs-site/scripts/__tests__/stubs/lib-artifact-transforms.js
+++ b/docs-site/scripts/__tests__/stubs/lib-artifact-transforms.js
@@ -1,0 +1,25 @@
+/**
+ * Stand-in for the `lib-artifact-transforms` package.
+ *
+ * templates/docusaurus/plugins/sdd-content requires that package, and it is
+ * declared in templates/docusaurus/package.json — a consumer's docs-site
+ * installs it, this repo's docs-site does not. Node resolves the request from
+ * the plugin's own directory upward, so nothing installed under docs-site/
+ * would satisfy it either.
+ *
+ * The frontmatter parsing itself is real: it delegates to graph-data.js, whose
+ * parser mirrors the same YAML-ish grammar, and only reshapes the return value
+ * to the `{ metadata }` form the plugin destructures.
+ */
+
+const { parseFrontmatter: parseMetadata } = require('../../graph-data');
+
+function parseFrontmatter(text) {
+  return { metadata: parseMetadata(text) || {} };
+}
+
+function extractStatus(text) {
+  return (parseMetadata(text) || {}).status || null;
+}
+
+module.exports = { parseFrontmatter, extractStatus };

--- a/docs-site/scripts/build-spec-mapping.js
+++ b/docs-site/scripts/build-spec-mapping.js
@@ -46,7 +46,13 @@ function buildMapping() {
     // gave every domain the identical "SPEC" key, and whichever domain was
     // read last then owned every SPEC-NNNN cross-reference on the site.
     const h1Match = content.match(/^#\s+([A-Z]+-\d{4}):/m);
-    if (h1Match) {
+    // Not `ADR-NNNN`: a spec.md whose H1 still carries an ADR number -- a
+    // conversion that was never renumbered -- would register that ID here, and
+    // transformSpecReferences runs before transformAdrReferences, so every
+    // ADR-NNNN mention on the site would resolve to this spec page. Same
+    // reason `prefixes.delete('ADR')` exists below; the full-ID key bypasses
+    // the prefix set, so it needs the guard too.
+    if (h1Match && !h1Match[1].startsWith('ADR-')) {
       mapping[h1Match[1]] = `/specs/${domain}/spec`;
     }
 

--- a/docs-site/scripts/build-spec-mapping.js
+++ b/docs-site/scripts/build-spec-mapping.js
@@ -2,8 +2,9 @@
 /**
  * Build Spec ID Mapping
  *
- * Scans all OpenSpec files to extract spec ID prefixes and generates
- * a mapping from prefix to spec URL path.
+ * Scans all OpenSpec files and generates the mapping the reference
+ * transforms resolve against: one entry per spec artifact ID (SPEC-0008), plus
+ * one per domain-scoped requirement prefix (ARCH).
  *
  * Output: src/data/spec-mapping.json
  */
@@ -38,10 +39,15 @@ function buildMapping() {
 
     const prefixes = new Set();
 
-    // Match spec number from H1 heading: # SPEC-XXXX: {Title}
-    const h1Match = content.match(/^#\s+([A-Z]+)-\d{4}:/m);
+    // The H1 declares the spec's own artifact ID — `# SPEC-0008: {Title}`.
+    // That ID is unique across the whole project, so it is keyed by the full
+    // ID. The requirement IDs collected below really are domain-scoped, so
+    // those stay keyed by their prefix; keying the artifact ID the same way
+    // gave every domain the identical "SPEC" key, and whichever domain was
+    // read last then owned every SPEC-NNNN cross-reference on the site.
+    const h1Match = content.match(/^#\s+([A-Z]+-\d{4}):/m);
     if (h1Match) {
-      prefixes.add(h1Match[1]);
+      mapping[h1Match[1]] = `/specs/${domain}/spec`;
     }
 
     // Also match spec IDs in table format: | ARCH-001 | ... |
@@ -51,10 +57,19 @@ function buildMapping() {
     }
 
     // Also match spec IDs in requirement headings: ### Requirement: ARCH-001
-    const headingMatches = content.matchAll(/###\s+Requirement:.*?([A-Z]+)-\d{3,4}/g);
+// /gm and the ^ anchor: unanchored, this matched a paragraph that merely
+    // mentioned `### Requirement:` and went on to cite an ADR later in the same
+    // line, adding "ADR" as a spec prefix. transformSpecReferences runs before
+    // transformAdrReferences, so that one stray key sent every ADR-NNNN link on
+    // the site to a spec page.
+    const headingMatches = content.matchAll(/^###\s+Requirement:.*?([A-Z]+)-\d{3,4}/gm);
     for (const match of headingMatches) {
       prefixes.add(match[1]);
     }
+
+    // ADR-NNNN belongs to transformAdrReferences. A spec that tabulates ADR
+    // numbers must not claim the prefix out from under it.
+    prefixes.delete('ADR');
 
     for (const prefix of prefixes) {
       mapping[prefix] = `/specs/${domain}/spec`;
@@ -69,7 +84,7 @@ function buildMapping() {
     fs.writeFileSync(EMOJIS_DEST, JSON.stringify({}, null, 2));
   }
 
-  console.log(`  Generated spec mapping with ${Object.keys(mapping).length} prefixes`);
+  console.log(`  Generated spec mapping with ${Object.keys(mapping).length} entries`);
   return mapping;
 }
 

--- a/docs-site/scripts/transform-utils.js
+++ b/docs-site/scripts/transform-utils.js
@@ -85,12 +85,18 @@ function transformSpecReferences(content, { specMapping, specEmojis, baseUrl }) 
     if (line.trim().startsWith('<') && !line.includes('className="rfc-keyword')) return line;
 
     return line.replace(specPattern, (match, prefix, number) => {
-      const specPath = specMapping[prefix];
-      const emoji = specEmojis[prefix];
+      // Two kinds of key live in specMapping. A full artifact ID (SPEC-0008)
+      // names one spec page; a bare prefix (ARCH) names the domain page that
+      // hosts ARCH-NNN requirements, where each ID is a RequirementBox anchor.
+      // Only the latter gets a fragment: a spec page's H1 anchor is derived
+      // from the whole heading text, so `#spec-0008` never resolved.
+      const artifactPath = specMapping[match];
+      const specPath = artifactPath || specMapping[prefix];
       if (!specPath) return match;
+      const emoji = specEmojis[prefix];
       const displayText = emoji ? `${emoji} ${match}` : match;
-      const anchorId = match.toLowerCase();
-      return `<a href="${baseUrl}${specPath}#${anchorId}" className="rfc-ref">${displayText}</a>`;
+      const fragment = artifactPath ? '' : `#${match.toLowerCase()}`;
+      return `<a href="${baseUrl}${specPath}${fragment}" className="rfc-ref">${displayText}</a>`;
     });
   }).join('\n');
 }

--- a/docs-site/src/data/spec-mapping.json
+++ b/docs-site/src/data/spec-mapping.json
@@ -1,3 +1,26 @@
 {
-  "SPEC": "/specs/init-and-priming/spec"
+  "SPEC-0018": "/specs/artifact-graph/spec",
+  "SPEC-0034": "/specs/cgg-sdd-integration/spec",
+  "SPEC-0005": "/specs/codebase-discovery/spec",
+  "SPEC-0004": "/specs/docs-generation/spec",
+  "SPEC-0021": "/specs/docusaurus-skill-pages/spec",
+  "SPEC-0001": "/specs/drift-introspection/spec",
+  "SPEC-0003": "/specs/foundational-artifacts/spec",
+  "SPEC-0002": "/specs/init-and-priming/spec",
+  "SPEC-0020": "/specs/loop-autonomous-mode/spec",
+  "SPEC-0014": "/specs/markdown-native-config-and-workspace/spec",
+  "SPEC-0015": "/specs/parallel-agent-coordination/spec",
+  "SPEC-0009": "/specs/parallel-pr-review/spec",
+  "SPEC-0011": "/specs/project-workspace-enrichment/spec",
+  "SPEC-0019": "/specs/qmd-native-skills/spec",
+  "SPEC-0035": "/specs/respond-to-pr-feedback/spec",
+  "SPEC-0008": "/specs/retroactive-issue-management/spec",
+  "SPEC-0013": "/specs/scrum-mode-audit-triage/spec",
+  "SPEC-0012": "/specs/scrum-mode-sprint-planning/spec",
+  "SPEC-0016": "/specs/security-and-quality-guardrails/spec",
+  "SPEC-0036": "/specs/skill-distillation/spec",
+  "SPEC-0017": "/specs/skill-evaluation-and-ci-testing/spec",
+  "SPEC-0007": "/specs/sprint-planning/spec",
+  "SPEC-0010": "/specs/story-sized-issue-granularity/spec",
+  "SPEC-0006": "/specs/tasks-md-fallback/spec"
 }

--- a/templates/docusaurus/plugins/sdd-content/index.js
+++ b/templates/docusaurus/plugins/sdd-content/index.js
@@ -366,9 +366,15 @@ function buildSpecMapping(specsSource) {
 
     const prefixes = new Set();
 
-    const h1Match = content.match(/^#\s+([A-Z]+)-\d{4}:/m);
+    // The H1 declares the spec's own artifact ID — `# SPEC-0008: {Title}`.
+    // That ID is unique across the whole project, so it is keyed by the full
+    // ID. The requirement IDs collected below really are domain-scoped, so
+    // those stay keyed by their prefix; keying the artifact ID the same way
+    // gave every domain the identical "SPEC" key, and whichever domain was
+    // read last then owned every SPEC-NNNN cross-reference on the site.
+    const h1Match = content.match(/^#\s+([A-Z]+-\d{4}):/m);
     if (h1Match) {
-      prefixes.add(h1Match[1]);
+      mapping[h1Match[1]] = `/specs/${domain}/spec`;
     }
 
     const tableMatches = content.matchAll(/\|\s*([A-Z]+)-\d{3,4}\s*\|/g);
@@ -376,10 +382,19 @@ function buildSpecMapping(specsSource) {
       prefixes.add(match[1]);
     }
 
-    const headingMatches = content.matchAll(/###\s+Requirement:.*?([A-Z]+)-\d{3,4}/g);
+// /gm and the ^ anchor: unanchored, this matched a paragraph that merely
+    // mentioned `### Requirement:` and went on to cite an ADR later in the same
+    // line, adding "ADR" as a spec prefix. transformSpecReferences runs before
+    // transformAdrReferences, so that one stray key sent every ADR-NNNN link on
+    // the site to a spec page.
+    const headingMatches = content.matchAll(/^###\s+Requirement:.*?([A-Z]+)-\d{3,4}/gm);
     for (const match of headingMatches) {
       prefixes.add(match[1]);
     }
+
+    // ADR-NNNN belongs to transformAdrReferences. A spec that tabulates ADR
+    // numbers must not claim the prefix out from under it.
+    prefixes.delete('ADR');
 
     for (const prefix of prefixes) {
       mapping[prefix] = `/specs/${domain}/spec`;
@@ -456,12 +471,18 @@ function transformSpecReferences(content, { specMapping, specEmojis, baseUrl }) 
     if (line.trim().startsWith('<') && !line.includes('className="rfc-keyword')) return line;
 
     return line.replace(specPattern, (match, prefix, number) => {
-      const specPath = specMapping[prefix];
-      const emoji = specEmojis[prefix];
+      // Two kinds of key live in specMapping. A full artifact ID (SPEC-0008)
+      // names one spec page; a bare prefix (ARCH) names the domain page that
+      // hosts ARCH-NNN requirements, where each ID is a RequirementBox anchor.
+      // Only the latter gets a fragment: a spec page's H1 anchor is derived
+      // from the whole heading text, so `#spec-0008` never resolved.
+      const artifactPath = specMapping[match];
+      const specPath = artifactPath || specMapping[prefix];
       if (!specPath) return match;
+      const emoji = specEmojis[prefix];
       const displayText = emoji ? `${emoji} ${match}` : match;
-      const anchorId = match.toLowerCase();
-      return `<a href="${baseUrl}${specPath}#${anchorId}" className="rfc-ref">${displayText}</a>`;
+      const fragment = artifactPath ? '' : `#${match.toLowerCase()}`;
+      return `<a href="${baseUrl}${specPath}${fragment}" className="rfc-ref">${displayText}</a>`;
     });
   }).join('\n');
 }

--- a/templates/docusaurus/plugins/sdd-content/index.js
+++ b/templates/docusaurus/plugins/sdd-content/index.js
@@ -373,7 +373,13 @@ function buildSpecMapping(specsSource) {
     // gave every domain the identical "SPEC" key, and whichever domain was
     // read last then owned every SPEC-NNNN cross-reference on the site.
     const h1Match = content.match(/^#\s+([A-Z]+-\d{4}):/m);
-    if (h1Match) {
+    // Not `ADR-NNNN`: a spec.md whose H1 still carries an ADR number -- a
+    // conversion that was never renumbered -- would register that ID here, and
+    // transformSpecReferences runs before transformAdrReferences, so every
+    // ADR-NNNN mention on the site would resolve to this spec page. Same
+    // reason `prefixes.delete('ADR')` exists below; the full-ID key bypasses
+    // the prefix set, so it needs the guard too.
+    if (h1Match && !h1Match[1].startsWith('ADR-')) {
       mapping[h1Match[1]] = `/specs/${domain}/spec`;
     }
 

--- a/templates/integration/sync-spec-docs/lib/build-spec-mapping.js
+++ b/templates/integration/sync-spec-docs/lib/build-spec-mapping.js
@@ -45,7 +45,13 @@ function buildSpecMapping({ specsSource, pathPrefix = '' }) {
     // gave every domain the identical "SPEC" key, and whichever domain was
     // read last then owned every SPEC-NNNN cross-reference on the site.
     const h1Match = content.match(/^#\s+([A-Z]+-\d{4}):/m);
-    if (h1Match) {
+    // Not `ADR-NNNN`: a spec.md whose H1 still carries an ADR number -- a
+    // conversion that was never renumbered -- would register that ID here, and
+    // transformSpecReferences runs before transformAdrReferences, so every
+    // ADR-NNNN mention on the site would resolve to this spec page. Same
+    // reason `prefixes.delete('ADR')` exists below; the full-ID key bypasses
+    // the prefix set, so it needs the guard too.
+    if (h1Match && !h1Match[1].startsWith('ADR-')) {
       specMapping[h1Match[1]] = `${pathPrefix}/specs/${domain}/spec`;
     }
 

--- a/templates/integration/sync-spec-docs/lib/build-spec-mapping.js
+++ b/templates/integration/sync-spec-docs/lib/build-spec-mapping.js
@@ -1,8 +1,9 @@
 /**
  * Build Spec ID Mapping
  *
- * Scans all OpenSpec files to extract spec ID prefixes and generates
- * a mapping from prefix to spec URL path.
+ * Scans all OpenSpec files and generates the mapping the reference
+ * transforms resolve against: one entry per spec artifact ID (SPEC-0008), plus
+ * one per domain-scoped requirement prefix (ARCH).
  *
  * Adapted for integration mode: accepts specsSource and pathPrefix as
  * parameters and returns mapping data instead of writing to files.
@@ -37,10 +38,15 @@ function buildSpecMapping({ specsSource, pathPrefix = '' }) {
 
     const prefixes = new Set();
 
-    // Match spec number from H1 heading: # SPEC-XXXX: {Title}
-    const h1Match = content.match(/^#\s+([A-Z]+)-\d{4}:/m);
+    // The H1 declares the spec's own artifact ID — `# SPEC-0008: {Title}`.
+    // That ID is unique across the whole project, so it is keyed by the full
+    // ID. The requirement IDs collected below really are domain-scoped, so
+    // those stay keyed by their prefix; keying the artifact ID the same way
+    // gave every domain the identical "SPEC" key, and whichever domain was
+    // read last then owned every SPEC-NNNN cross-reference on the site.
+    const h1Match = content.match(/^#\s+([A-Z]+-\d{4}):/m);
     if (h1Match) {
-      prefixes.add(h1Match[1]);
+      specMapping[h1Match[1]] = `${pathPrefix}/specs/${domain}/spec`;
     }
 
     // Also match spec IDs in table format: | ARCH-001 | ... |
@@ -50,10 +56,19 @@ function buildSpecMapping({ specsSource, pathPrefix = '' }) {
     }
 
     // Also match spec IDs in requirement headings: ### Requirement: ARCH-001
-    const headingMatches = content.matchAll(/###\s+Requirement:.*?([A-Z]+)-\d{3,4}/g);
+// /gm and the ^ anchor: unanchored, this matched a paragraph that merely
+    // mentioned `### Requirement:` and went on to cite an ADR later in the same
+    // line, adding "ADR" as a spec prefix. transformSpecReferences runs before
+    // transformAdrReferences, so that one stray key sent every ADR-NNNN link on
+    // the site to a spec page.
+    const headingMatches = content.matchAll(/^###\s+Requirement:.*?([A-Z]+)-\d{3,4}/gm);
     for (const match of headingMatches) {
       prefixes.add(match[1]);
     }
+
+    // ADR-NNNN belongs to transformAdrReferences. A spec that tabulates ADR
+    // numbers must not claim the prefix out from under it.
+    prefixes.delete('ADR');
 
     for (const prefix of prefixes) {
       specMapping[prefix] = `${pathPrefix}/specs/${domain}/spec`;

--- a/templates/integration/sync-spec-docs/lib/transform-utils.js
+++ b/templates/integration/sync-spec-docs/lib/transform-utils.js
@@ -90,12 +90,18 @@ function transformSpecReferences(content, { specMapping, specEmojis, baseUrl }) 
     if (line.trim().startsWith('<') && !line.includes('className="rfc-keyword')) return line;
 
     return line.replace(specPattern, (match, prefix, number) => {
-      const specPath = specMapping[prefix];
-      const emoji = specEmojis[prefix];
+      // Two kinds of key live in specMapping. A full artifact ID (SPEC-0008)
+      // names one spec page; a bare prefix (ARCH) names the domain page that
+      // hosts ARCH-NNN requirements, where each ID is a RequirementBox anchor.
+      // Only the latter gets a fragment: a spec page's H1 anchor is derived
+      // from the whole heading text, so `#spec-0008` never resolved.
+      const artifactPath = specMapping[match];
+      const specPath = artifactPath || specMapping[prefix];
       if (!specPath) return match;
+      const emoji = specEmojis[prefix];
       const displayText = emoji ? `${emoji} ${match}` : match;
-      const anchorId = match.toLowerCase();
-      return `<a href="${baseUrl}${specPath}#${anchorId}" className="rfc-ref">${displayText}</a>`;
+      const fragment = artifactPath ? '' : `#${match.toLowerCase()}`;
+      return `<a href="${baseUrl}${specPath}${fragment}" className="rfc-ref">${displayText}</a>`;
     });
   }).join('\n');
 }


### PR DESCRIPTION
Every `SPEC-NNNN` cross-reference on a generated docs site resolves to the wrong page.

`buildSpecMapping` stored a spec's page under its ID **prefix** — the literal string `"SPEC"` — so each domain overwrote the last and one entry served the whole site. This repo's checked-in `spec-mapping.json` was literally `{"SPEC": "/specs/init-and-priming/spec"}`: 24 specs, one destination. `transformAdrReferences`, directly below the buggy lookup, already keys on the number.

Found in stump.wtf/harness, where SPEC-0008 referencing SPEC-0003 emitted `href="/harness/specs/tui/spec#spec-0003"`.

## What changed

- A spec's artifact ID is unique project-wide, so it is now its own key: `"SPEC-0008" -> /specs/retroactive-issue-management/spec`. The requirement prefixes the map also carries (`ARCH` -> the domain page hosting `ARCH-001`) really are domain-scoped and stay keyed by prefix.
- Only requirement IDs still get a `#fragment`. A requirement ID is a `RequirementBox` anchor on its domain page; a spec page's H1 anchor is derived from the whole heading text, so `#spec-0008` never resolved to anything.
- The requirement-heading scan is anchored to line start. Unanchored, a paragraph that merely mentioned `` `### Requirement:` `` and cited an ADR later on the same line registered `ADR` as a spec prefix — and since `transformSpecReferences` runs first, that single key wrapped every `ADR-NNNN` link on the site in a second anchor pointing at a spec page (`<a href="/specs/gamma/spec#adr-0001"><a href="/decisions/ADR-0001-example">`). `ADR` is now refused as a spec prefix outright.
- Regenerated `docs-site/src/data/spec-mapping.json`: 24 entries, one per spec, no `ADR` key.

Three copies of the transform ship from this repo and all three had the defect:

| Copy | Consumed by |
|---|---|
| `docs-site/scripts/` | this repo's own site |
| `templates/docusaurus/plugins/sdd-content/index.js` | vendored into consumer repos (harness, binnacle) |
| `templates/integration/sync-spec-docs/lib/` | the integration template |

## Tests

New `docs-site/scripts/__tests__/spec-references.test.js` — a shared suite over both library copies plus a fixture-driven end-to-end run of the plugin template (three spec domains, one ADR, assert every reference lands in its own directory). It fails 9/18 on the pre-fix tree and passes 18/18 after.

The plugin template requires `lib-artifact-transforms`, which only a consumer's docs-site installs, so the test resolves that request to a stub that delegates the real parsing to `graph-data.js`.

## Verification

`make test lint scan` green — 30 unit tests, Docusaurus build, structure/type lint, gitleaks clean. Generated hrefs now spread across all 24 spec pages instead of pointing at one.

Sync of the vendored copy in stump.wtf/harness follows separately.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).