### PR TITLE
fix(docs): route spec references at the page the transform emits

### DIFF
--- a/docs-site/scripts/__tests__/spec-layout.test.js
+++ b/docs-site/scripts/__tests__/spec-layout.test.js
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for spec domain layout resolution.
+ *
+ * transform-openspecs.js emits a domain directory one of two ways — nested
+ * under the domain when it holds both spec.md and design.md, flat at the
+ * domain itself when it holds only one of them — and build-spec-mapping.js
+ * and generate-index.js have to link at whichever it emitted. Both now read
+ * the layout from spec-layout.js instead of assuming; these tests pin the
+ * shared answer, and the mapping value that falls out of it.
+ *
+ * Run with `node --test`:
+ *
+ *   node --test docs-site/scripts/__tests__/spec-layout.test.js
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const INTEGRATION_LIB = path.join(REPO_ROOT, 'templates/integration/sync-spec-docs/lib');
+
+const LAYOUT_COPIES = [
+  ['docs-site/scripts', require('../spec-layout')],
+  ['templates/integration/sync-spec-docs/lib', require(path.join(INTEGRATION_LIB, 'spec-layout'))],
+];
+
+function writeSpecsTree() {
+  const specsSource = fs.mkdtempSync(path.join(os.tmpdir(), 'sdd-spec-layout-'));
+  const spec = (id, title) =>
+    `---\nstatus: active\ndate: 2026-01-01\n---\n\n# ${id}: ${title}\n\n## Overview\n\nBody.\n`;
+
+  const write = (domain, files) => {
+    const dir = path.join(specsSource, domain);
+    fs.mkdirSync(dir, { recursive: true });
+    for (const [file, content] of Object.entries(files)) {
+      fs.writeFileSync(path.join(dir, file), content);
+    }
+  };
+
+  write('both', { 'spec.md': spec('SPEC-0001', 'Both'), 'design.md': spec('SPEC-0001', 'Both Design') });
+  write('spec-only', { 'spec.md': spec('SPEC-0002', 'Spec Only') });
+  write('design-only', { 'design.md': spec('SPEC-0003', 'Design Only') });
+  write('empty', { 'README.md': 'Not a spec.\n' });
+
+  return specsSource;
+}
+
+for (const [label, { getSpecLayout }] of LAYOUT_COPIES) {
+  test(`${label}: a domain with both files is nested`, () => {
+    const specsSource = writeSpecsTree();
+    const layout = getSpecLayout(specsSource, 'both');
+    assert.equal(layout.nested, true);
+    assert.equal(layout.specSlug, 'both/spec');
+    assert.equal(layout.designSlug, 'both/design');
+    fs.rmSync(specsSource, { recursive: true, force: true });
+  });
+
+  test(`${label}: a spec.md-only domain is flat`, () => {
+    const specsSource = writeSpecsTree();
+    const layout = getSpecLayout(specsSource, 'spec-only');
+    assert.equal(layout.nested, false);
+    assert.equal(layout.specSlug, 'spec-only');
+    assert.equal(layout.designSlug, null);
+    fs.rmSync(specsSource, { recursive: true, force: true });
+  });
+
+  test(`${label}: a design.md-only domain is flat`, () => {
+    const specsSource = writeSpecsTree();
+    const layout = getSpecLayout(specsSource, 'design-only');
+    assert.equal(layout.nested, false);
+    assert.equal(layout.specSlug, null);
+    assert.equal(layout.designSlug, 'design-only');
+    fs.rmSync(specsSource, { recursive: true, force: true });
+  });
+
+  test(`${label}: a domain with neither file has no slugs`, () => {
+    const specsSource = writeSpecsTree();
+    const layout = getSpecLayout(specsSource, 'empty');
+    assert.deepEqual(
+      { hasSpec: layout.hasSpec, hasDesign: layout.hasDesign, specSlug: layout.specSlug, designSlug: layout.designSlug },
+      { hasSpec: false, hasDesign: false, specSlug: null, designSlug: null }
+    );
+    fs.rmSync(specsSource, { recursive: true, force: true });
+  });
+}
+
+test('integration lib: the mapping routes each domain at the page it renders as', () => {
+  const specsSource = writeSpecsTree();
+  const { buildSpecMapping } = require(path.join(INTEGRATION_LIB, 'build-spec-mapping'));
+
+  const { specMapping } = buildSpecMapping({ specsSource, pathPrefix: '/architecture' });
+
+  assert.equal(specMapping['SPEC-0001'], '/architecture/specs/both/spec');
+  // The regression: this was '/architecture/specs/spec-only/spec', which the
+  // transform never writes for a domain carrying no design.md.
+  assert.equal(specMapping['SPEC-0002'], '/architecture/specs/spec-only');
+  // A design.md-only domain contributes no spec entry at all.
+  assert.equal(specMapping['SPEC-0003'], undefined);
+
+  fs.rmSync(specsSource, { recursive: true, force: true });
+});

--- a/docs-site/scripts/__tests__/spec-references.test.js
+++ b/docs-site/scripts/__tests__/spec-references.test.js
@@ -112,11 +112,13 @@ function writeFixture() {
   const spec = (id, title, body) =>
     `---\nstatus: active\ndate: 2026-01-01\n---\n\n# ${id}: ${title}\n\n## Overview\n\n${body}\n`;
 
-  const domain = (name, id, title, body) => {
+  // `design: false` leaves the domain with a spec.md only, which the transform
+  // emits as a flat page rather than a category directory.
+  const domain = (name, id, title, body, { design = true } = {}) => {
     const dir = path.join(root, 'docs/openspec/specs', name);
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, 'spec.md'), spec(id, title, body));
-    fs.writeFileSync(path.join(dir, 'design.md'), spec(id, `${title} Design`, body));
+    if (design) fs.writeFileSync(path.join(dir, 'design.md'), spec(id, `${title} Design`, body));
   };
 
   domain('alpha', 'SPEC-0001', 'Alpha', 'Alpha stands alone.');
@@ -131,8 +133,12 @@ function writeFixture() {
     'gamma',
     'SPEC-0003',
     'Gamma',
-    'Gamma needs SPEC-0001 and SPEC-0002.\n\nOne issue per ### Requirement: section, per ADR-0001.'
+    'Gamma needs SPEC-0001, SPEC-0002 and SPEC-0004.\n\nOne issue per ### Requirement: section, per ADR-0001.'
   );
+  // Only a spec.md, no design.md — this domain renders as the flat page
+  // /specs/delta, so references to SPEC-0004 must not be sent to
+  // /specs/delta/spec, which nothing writes.
+  domain('delta', 'SPEC-0004', 'Delta', 'Delta stands alone.', { design: false });
 
   return { root, site };
 }
@@ -220,6 +226,34 @@ test('plugin template: a spec citing an ADR does not claim the ADR prefix', asyn
   // and wrapped the ADR link in a second anchor pointing at a spec page.
   assert.doesNotMatch(gamma, /href="[^"]*#adr-0001"/);
   assert.doesNotMatch(gamma, /<a [^>]*><a /);
+
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('plugin template: a design-less domain is referenced at its flat page', async () => {
+  const { root, site } = writeFixture();
+  const plugin = withArtifactTransformsStub(() =>
+    require(path.join(REPO_ROOT, 'templates/docusaurus/plugins/sdd-content'))
+  );
+
+  await plugin({ siteDir: site }, {}).loadContent();
+
+  const generated = path.join(root, 'docs-generated');
+
+  // What the transform actually emits for a spec.md-only domain.
+  assert.ok(fs.existsSync(path.join(generated, 'specs/delta.mdx')));
+  assert.ok(!fs.existsSync(path.join(generated, 'specs/delta/spec.mdx')));
+
+  // The regression: the mapping assumed every domain was nested, so this
+  // cross-reference pointed at /specs/delta/spec — a route with no page.
+  const gamma = fs.readFileSync(path.join(generated, 'specs/gamma/spec.mdx'), 'utf-8');
+  assert.match(gamma, /href="\/specs\/delta"[^>]*>SPEC-0004</);
+  assert.doesNotMatch(gamma, /href="\/specs\/delta\/spec"/);
+
+  // The specs index links the same page the transform wrote.
+  const index = fs.readFileSync(path.join(generated, 'specs/index.mdx'), 'utf-8');
+  assert.match(index, /\[Specification\]\(\.\/delta\)/);
+  assert.doesNotMatch(index, /\(\.\/delta\/spec\)/);
 
   fs.rmSync(root, { recursive: true, force: true });
 });

--- a/docs-site/scripts/build-spec-mapping.js
+++ b/docs-site/scripts/build-spec-mapping.js
@@ -11,6 +11,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { getSpecLayout } = require('./spec-layout');
 
 const SPECS_SOURCE = path.join(__dirname, '../../docs/openspec/specs');
 const MAPPING_DEST = path.join(__dirname, '../src/data/spec-mapping.json');
@@ -32,10 +33,15 @@ function buildMapping() {
     const domainPath = path.join(SPECS_SOURCE, domain);
     if (!fs.statSync(domainPath).isDirectory()) continue;
 
-    const specPath = path.join(domainPath, 'spec.md');
-    if (!fs.existsSync(specPath)) continue;
+    // The route depends on the layout transform-openspecs.js emits for this
+    // domain: nested under the domain when it also has a design.md, flat at
+    // the domain itself when it does not. Both keys below point at the same
+    // page, so the slug is resolved once here.
+    const layout = getSpecLayout(SPECS_SOURCE, domain);
+    if (!layout.hasSpec) continue;
+    const specRoute = `/specs/${layout.specSlug}`;
 
-    const content = fs.readFileSync(specPath, 'utf-8');
+    const content = fs.readFileSync(path.join(domainPath, 'spec.md'), 'utf-8');
 
     const prefixes = new Set();
 
@@ -53,7 +59,7 @@ function buildMapping() {
     // reason `prefixes.delete('ADR')` exists below; the full-ID key bypasses
     // the prefix set, so it needs the guard too.
     if (h1Match && !h1Match[1].startsWith('ADR-')) {
-      mapping[h1Match[1]] = `/specs/${domain}/spec`;
+      mapping[h1Match[1]] = specRoute;
     }
 
     // Also match spec IDs in table format: | ARCH-001 | ... |
@@ -63,7 +69,7 @@ function buildMapping() {
     }
 
     // Also match spec IDs in requirement headings: ### Requirement: ARCH-001
-// /gm and the ^ anchor: unanchored, this matched a paragraph that merely
+    // /gm and the ^ anchor: unanchored, this matched a paragraph that merely
     // mentioned `### Requirement:` and went on to cite an ADR later in the same
     // line, adding "ADR" as a spec prefix. transformSpecReferences runs before
     // transformAdrReferences, so that one stray key sent every ADR-NNNN link on
@@ -78,7 +84,7 @@ function buildMapping() {
     prefixes.delete('ADR');
 
     for (const prefix of prefixes) {
-      mapping[prefix] = `/specs/${domain}/spec`;
+      mapping[prefix] = specRoute;
     }
   }
 

--- a/docs-site/scripts/generate-index.js
+++ b/docs-site/scripts/generate-index.js
@@ -9,6 +9,7 @@
 const fs = require('fs');
 const path = require('path');
 const { getGraph, renderFullMermaid } = require('./graph-data');
+const { getSpecLayout } = require('./spec-layout');
 
 const ADRS_SOURCE = path.join(__dirname, '../../docs/adrs');
 const SPECS_SOURCE = path.join(__dirname, '../../docs/openspec/specs');
@@ -94,9 +95,7 @@ function generateSpecsIndex() {
 
   const rows = [];
   for (const domain of domains) {
-    const domainPath = path.join(SPECS_SOURCE, domain);
-    const hasSpec = fs.existsSync(path.join(domainPath, 'spec.md'));
-    const hasDesign = fs.existsSync(path.join(domainPath, 'design.md'));
+    const { domainPath, hasSpec, hasDesign, specSlug, designSlug } = getSpecLayout(SPECS_SOURCE, domain);
 
     if (!hasSpec && !hasDesign) continue;
 
@@ -110,11 +109,11 @@ function generateSpecsIndex() {
 
     let docs;
     if (hasSpec && hasDesign) {
-      docs = `[Specification](./${domain}/spec) / [Design](./${domain}/design)`;
+      docs = `[Specification](./${specSlug}) / [Design](./${designSlug})`;
     } else if (hasSpec) {
-      docs = `[Specification](./${domain})`;
+      docs = `[Specification](./${specSlug})`;
     } else {
-      docs = `[Design](./${domain})`;
+      docs = `[Design](./${designSlug})`;
     }
 
     rows.push(`| ${label} | ${docs} |`);

--- a/docs-site/scripts/spec-layout.js
+++ b/docs-site/scripts/spec-layout.js
@@ -1,0 +1,52 @@
+/**
+ * Spec Domain Layout
+ *
+ * A spec domain directory renders one of two ways, and every consumer of the
+ * generated site has to agree on which. A domain holding both spec.md and
+ * design.md becomes a category directory, so its pages live at
+ * `/specs/<domain>/spec` and `/specs/<domain>/design`. A domain holding only
+ * one of the two becomes a single flat page at `/specs/<domain>`.
+ *
+ * The transform decides the layout per domain while writing files; the spec-ID
+ * mapping and the specs index have to link at whatever it decided. This module
+ * is where that decision is made, so the others read it instead of re-deriving
+ * it and disagreeing.
+ *
+ * @joestump-agent 08/19/2026 - Extracted from transform-openspecs.js. The
+ * mapping hardcoded the nested `/specs/<domain>/spec` route for every domain,
+ * so every cross-reference to a spec whose directory carries no design.md
+ * resolved to a page the transform never wrote.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Describe how one spec domain directory renders.
+ *
+ * `specSlug` and `designSlug` are route segments relative to the specs root —
+ * `auth/spec` when the domain is nested, `auth` when it is flat — and are null
+ * when the corresponding source file is absent.
+ *
+ * @param {string} specsSource - Absolute path to the specs source directory
+ * @param {string} domain - Domain directory name
+ * @returns {{domainPath: string, hasSpec: boolean, hasDesign: boolean,
+ *            nested: boolean, specSlug: string|null, designSlug: string|null}}
+ */
+function getSpecLayout(specsSource, domain) {
+  const domainPath = path.join(specsSource, domain);
+  const hasSpec = fs.existsSync(path.join(domainPath, 'spec.md'));
+  const hasDesign = fs.existsSync(path.join(domainPath, 'design.md'));
+  const nested = hasSpec && hasDesign;
+
+  return {
+    domainPath,
+    hasSpec,
+    hasDesign,
+    nested,
+    specSlug: hasSpec ? (nested ? `${domain}/spec` : domain) : null,
+    designSlug: hasDesign ? (nested ? `${domain}/design` : domain) : null,
+  };
+}
+
+module.exports = { getSpecLayout };

--- a/docs-site/scripts/transform-openspecs.js
+++ b/docs-site/scripts/transform-openspecs.js
@@ -19,6 +19,7 @@ const {
   fixMarkdownLinks,
 } = require('./transform-utils');
 const { getGraph, buildMiniDagSection } = require('./graph-data');
+const { getSpecLayout } = require('./spec-layout');
 
 const SPECS_SOURCE = path.join(__dirname, '../../docs/openspec/specs');
 const SPECS_DEST = path.join(__dirname, '../../docs-generated/specs');
@@ -263,12 +264,13 @@ function main() {
     const domainPath = path.join(SPECS_SOURCE, domain);
     if (!fs.statSync(domainPath).isDirectory()) continue;
 
-    const hasSpec = fs.existsSync(path.join(domainPath, 'spec.md'));
-    const hasDesign = fs.existsSync(path.join(domainPath, 'design.md'));
+    // Nested vs flat is decided in spec-layout.js, which build-spec-mapping.js
+    // and generate-index.js read too -- they link at the pages written below.
+    const { hasSpec, hasDesign, nested } = getSpecLayout(SPECS_SOURCE, domain);
 
     if (!hasSpec && !hasDesign) continue;
 
-    if (hasSpec && hasDesign) {
+    if (nested) {
       // Both docs: create subdirectory with _category_.json
       const destDomainPath = path.join(SPECS_DEST, domain);
       fs.mkdirSync(destDomainPath, { recursive: true });

--- a/templates/docusaurus/plugins/sdd-content/index.js
+++ b/templates/docusaurus/plugins/sdd-content/index.js
@@ -342,6 +342,39 @@ function buildMiniDagSection(artifactId, graph) {
 }
 
 // ============================================================================
+// Spec Domain Layout (from spec-layout.js)
+// ============================================================================
+
+/**
+ * Describe how one spec domain directory renders.
+ *
+ * A domain holding both spec.md and design.md becomes a category directory —
+ * `/specs/<domain>/spec` and `/specs/<domain>/design`. A domain holding only
+ * one of the two becomes a single flat page at `/specs/<domain>`. The
+ * transform below writes those files, and the spec-ID mapping and the specs
+ * index link at them, so the decision is made here once rather than
+ * re-derived in three places that can disagree.
+ *
+ * `specSlug`/`designSlug` are route segments relative to the specs root, and
+ * are null when the corresponding source file is absent.
+ */
+function getSpecLayout(specsSource, domain) {
+  const domainPath = path.join(specsSource, domain);
+  const hasSpec = fs.existsSync(path.join(domainPath, 'spec.md'));
+  const hasDesign = fs.existsSync(path.join(domainPath, 'design.md'));
+  const nested = hasSpec && hasDesign;
+
+  return {
+    domainPath,
+    hasSpec,
+    hasDesign,
+    nested,
+    specSlug: hasSpec ? (nested ? `${domain}/spec` : domain) : null,
+    designSlug: hasDesign ? (nested ? `${domain}/design` : domain) : null,
+  };
+}
+
+// ============================================================================
 // Spec Mapping (from build-spec-mapping.js)
 // ============================================================================
 
@@ -359,10 +392,13 @@ function buildSpecMapping(specsSource) {
     const domainPath = path.join(specsSource, domain);
     if (!fs.statSync(domainPath).isDirectory()) continue;
 
-    const specPath = path.join(domainPath, 'spec.md');
-    if (!fs.existsSync(specPath)) continue;
+    // Both keys registered below point at this domain's spec page, whose
+    // route depends on the layout the transform emits for it.
+    const layout = getSpecLayout(specsSource, domain);
+    if (!layout.hasSpec) continue;
+    const specRoute = `/specs/${layout.specSlug}`;
 
-    const content = fs.readFileSync(specPath, 'utf-8');
+    const content = fs.readFileSync(path.join(domainPath, 'spec.md'), 'utf-8');
 
     const prefixes = new Set();
 
@@ -380,7 +416,7 @@ function buildSpecMapping(specsSource) {
     // reason `prefixes.delete('ADR')` exists below; the full-ID key bypasses
     // the prefix set, so it needs the guard too.
     if (h1Match && !h1Match[1].startsWith('ADR-')) {
-      mapping[h1Match[1]] = `/specs/${domain}/spec`;
+      mapping[h1Match[1]] = specRoute;
     }
 
     const tableMatches = content.matchAll(/\|\s*([A-Z]+)-\d{3,4}\s*\|/g);
@@ -388,7 +424,7 @@ function buildSpecMapping(specsSource) {
       prefixes.add(match[1]);
     }
 
-// /gm and the ^ anchor: unanchored, this matched a paragraph that merely
+    // /gm and the ^ anchor: unanchored, this matched a paragraph that merely
     // mentioned `### Requirement:` and went on to cite an ADR later in the same
     // line, adding "ADR" as a spec prefix. transformSpecReferences runs before
     // transformAdrReferences, so that one stray key sent every ADR-NNNN link on
@@ -403,7 +439,7 @@ function buildSpecMapping(specsSource) {
     prefixes.delete('ADR');
 
     for (const prefix of prefixes) {
-      mapping[prefix] = `/specs/${domain}/spec`;
+      mapping[prefix] = specRoute;
     }
   }
 
@@ -846,9 +882,7 @@ function generateSpecsIndex(specsSource, docsDest, graph, baseUrl) {
 
   const rows = [];
   for (const domain of domains) {
-    const domainPath = path.join(specsSource, domain);
-    const hasSpec = fs.existsSync(path.join(domainPath, 'spec.md'));
-    const hasDesign = fs.existsSync(path.join(domainPath, 'design.md'));
+    const { domainPath, hasSpec, hasDesign, specSlug, designSlug } = getSpecLayout(specsSource, domain);
 
     if (!hasSpec && !hasDesign) continue;
 
@@ -861,11 +895,11 @@ function generateSpecsIndex(specsSource, docsDest, graph, baseUrl) {
 
     let docs;
     if (hasSpec && hasDesign) {
-      docs = `[Specification](./${domain}/spec) / [Design](./${domain}/design)`;
+      docs = `[Specification](./${specSlug}) / [Design](./${designSlug})`;
     } else if (hasSpec) {
-      docs = `[Specification](./${domain})`;
+      docs = `[Specification](./${specSlug})`;
     } else {
-      docs = `[Design](./${domain})`;
+      docs = `[Design](./${designSlug})`;
     }
 
     rows.push(`| ${label} | ${docs} |`);
@@ -1170,12 +1204,13 @@ module.exports = function(context, options) {
           const domainPath = path.join(specsSource, domain);
           if (!fs.statSync(domainPath).isDirectory()) continue;
 
-          const hasSpec = fs.existsSync(path.join(domainPath, 'spec.md'));
-          const hasDesign = fs.existsSync(path.join(domainPath, 'design.md'));
+          // Nested vs flat comes from getSpecLayout(), which buildSpecMapping()
+          // and generateSpecsIndex() read too -- they link at what is written here.
+          const { hasSpec, hasDesign, nested } = getSpecLayout(specsSource, domain);
 
           if (!hasSpec && !hasDesign) continue;
 
-          if (hasSpec && hasDesign) {
+          if (nested) {
             const destDomainPath = path.join(SPECS_DEST, domain);
             fs.mkdirSync(destDomainPath, { recursive: true });
             generateCategoryJson(destDomainPath, domain, domainConfig);

--- a/templates/integration/sync-spec-docs/lib/build-spec-mapping.js
+++ b/templates/integration/sync-spec-docs/lib/build-spec-mapping.js
@@ -16,6 +16,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { getSpecLayout } = require('./spec-layout');
 
 function buildSpecMapping({ specsSource, pathPrefix = '' }) {
   const specMapping = {};
@@ -31,10 +32,13 @@ function buildSpecMapping({ specsSource, pathPrefix = '' }) {
     const domainPath = path.join(specsSource, domain);
     if (!fs.statSync(domainPath).isDirectory()) continue;
 
-    const specPath = path.join(domainPath, 'spec.md');
-    if (!fs.existsSync(specPath)) continue;
+    // Both keys registered below point at this domain's spec page, whose route
+    // depends on the layout transform-openspecs.js emits for the domain.
+    const layout = getSpecLayout(specsSource, domain);
+    if (!layout.hasSpec) continue;
+    const specRoute = `${pathPrefix}/specs/${layout.specSlug}`;
 
-    const content = fs.readFileSync(specPath, 'utf-8');
+    const content = fs.readFileSync(path.join(domainPath, 'spec.md'), 'utf-8');
 
     const prefixes = new Set();
 
@@ -52,7 +56,7 @@ function buildSpecMapping({ specsSource, pathPrefix = '' }) {
     // reason `prefixes.delete('ADR')` exists below; the full-ID key bypasses
     // the prefix set, so it needs the guard too.
     if (h1Match && !h1Match[1].startsWith('ADR-')) {
-      specMapping[h1Match[1]] = `${pathPrefix}/specs/${domain}/spec`;
+      specMapping[h1Match[1]] = specRoute;
     }
 
     // Also match spec IDs in table format: | ARCH-001 | ... |
@@ -62,7 +66,7 @@ function buildSpecMapping({ specsSource, pathPrefix = '' }) {
     }
 
     // Also match spec IDs in requirement headings: ### Requirement: ARCH-001
-// /gm and the ^ anchor: unanchored, this matched a paragraph that merely
+    // /gm and the ^ anchor: unanchored, this matched a paragraph that merely
     // mentioned `### Requirement:` and went on to cite an ADR later in the same
     // line, adding "ADR" as a spec prefix. transformSpecReferences runs before
     // transformAdrReferences, so that one stray key sent every ADR-NNNN link on
@@ -77,7 +81,7 @@ function buildSpecMapping({ specsSource, pathPrefix = '' }) {
     prefixes.delete('ADR');
 
     for (const prefix of prefixes) {
-      specMapping[prefix] = `${pathPrefix}/specs/${domain}/spec`;
+      specMapping[prefix] = specRoute;
     }
   }
 

--- a/templates/integration/sync-spec-docs/lib/generate-index.js
+++ b/templates/integration/sync-spec-docs/lib/generate-index.js
@@ -15,6 +15,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { getSpecLayout } = require('./spec-layout');
 
 function countAdrs(adrsSource) {
   if (!fs.existsSync(adrsSource)) return 0;
@@ -45,9 +46,7 @@ function generateSpecsIndex(specsSource, outputDir) {
 
   const rows = [];
   for (const domain of domains) {
-    const domainPath = path.join(specsSource, domain);
-    const hasSpec = fs.existsSync(path.join(domainPath, 'spec.md'));
-    const hasDesign = fs.existsSync(path.join(domainPath, 'design.md'));
+    const { domainPath, hasSpec, hasDesign, specSlug, designSlug } = getSpecLayout(specsSource, domain);
 
     if (!hasSpec && !hasDesign) continue;
 
@@ -61,11 +60,11 @@ function generateSpecsIndex(specsSource, outputDir) {
 
     let docs;
     if (hasSpec && hasDesign) {
-      docs = `[Specification](./${domain}/spec) / [Design](./${domain}/design)`;
+      docs = `[Specification](./${specSlug}) / [Design](./${designSlug})`;
     } else if (hasSpec) {
-      docs = `[Specification](./${domain})`;
+      docs = `[Specification](./${specSlug})`;
     } else {
-      docs = `[Design](./${domain})`;
+      docs = `[Design](./${designSlug})`;
     }
 
     rows.push(`| ${label} | ${docs} |`);

--- a/templates/integration/sync-spec-docs/lib/spec-layout.js
+++ b/templates/integration/sync-spec-docs/lib/spec-layout.js
@@ -1,0 +1,53 @@
+/**
+ * Spec Domain Layout (Integration Mode)
+ *
+ * A spec domain directory renders one of two ways, and every consumer of the
+ * generated site has to agree on which. A domain holding both spec.md and
+ * design.md becomes a category directory, so its pages live at
+ * `<prefix>/specs/<domain>/spec` and `<prefix>/specs/<domain>/design`. A domain
+ * holding only one of the two becomes a single flat page at
+ * `<prefix>/specs/<domain>`.
+ *
+ * transform-openspecs.js decides the layout per domain while writing files;
+ * build-spec-mapping.js and generate-index.js have to link at whatever it
+ * decided. This module is where that decision is made, so the others read it
+ * instead of re-deriving it and disagreeing.
+ *
+ * @joestump-agent 08/19/2026 - Extracted from transform-openspecs.js. The
+ * mapping hardcoded the nested `/specs/<domain>/spec` route for every domain,
+ * so every cross-reference to a spec whose directory carries no design.md
+ * resolved to a page the transform never wrote.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Describe how one spec domain directory renders.
+ *
+ * `specSlug` and `designSlug` are route segments relative to the specs root --
+ * `auth/spec` when the domain is nested, `auth` when it is flat -- and are null
+ * when the corresponding source file is absent.
+ *
+ * @param {string} specsSource - Absolute path to the specs source directory
+ * @param {string} domain - Domain directory name
+ * @returns {{domainPath: string, hasSpec: boolean, hasDesign: boolean,
+ *            nested: boolean, specSlug: string|null, designSlug: string|null}}
+ */
+function getSpecLayout(specsSource, domain) {
+  const domainPath = path.join(specsSource, domain);
+  const hasSpec = fs.existsSync(path.join(domainPath, 'spec.md'));
+  const hasDesign = fs.existsSync(path.join(domainPath, 'design.md'));
+  const nested = hasSpec && hasDesign;
+
+  return {
+    domainPath,
+    hasSpec,
+    hasDesign,
+    nested,
+    specSlug: hasSpec ? (nested ? `${domain}/spec` : domain) : null,
+    designSlug: hasDesign ? (nested ? `${domain}/design` : domain) : null,
+  };
+}
+
+module.exports = { getSpecLayout };

--- a/templates/integration/sync-spec-docs/lib/transform-openspecs.js
+++ b/templates/integration/sync-spec-docs/lib/transform-openspecs.js
@@ -27,6 +27,7 @@ const {
   transformAdrReferences,
   fixMarkdownLinks,
 } = require('./transform-utils');
+const { getSpecLayout } = require('./spec-layout');
 
 const ADR_EMOJI = '\ud83d\udcdd';
 
@@ -233,12 +234,13 @@ function transformOpenspecs(config) {
     const domainPath = path.join(specsSource, domain);
     if (!fs.statSync(domainPath).isDirectory()) continue;
 
-    const hasSpec = fs.existsSync(path.join(domainPath, 'spec.md'));
-    const hasDesign = fs.existsSync(path.join(domainPath, 'design.md'));
+    // Nested vs flat is decided in spec-layout.js, which build-spec-mapping.js
+    // and generate-index.js read too -- they link at the pages written below.
+    const { hasSpec, hasDesign, nested } = getSpecLayout(specsSource, domain);
 
     if (!hasSpec && !hasDesign) continue;
 
-    if (hasSpec && hasDesign) {
+    if (nested) {
       // Both docs: create subdirectory with _category_.json
       const destDomainPath = path.join(specsDest, domain);
       fs.mkdirSync(destDomainPath, { recursive: true });


### PR DESCRIPTION
## What

`buildSpecMapping` mapped every spec to `/specs/<domain>/spec`, but `transform-openspecs` only writes that nested layout when a domain directory holds **both** `spec.md` and `design.md`. A domain with only one of them is emitted as the flat page `/specs/<domain>` — so every cross-reference to such a spec resolved to a route nothing writes.

It is a 404, and a silent one: `onBrokenLinks` is `'warn'`.

Dormant today only because every spec directory in this repo (and in the consumers vendoring this plugin) happens to carry both files. The first spec authored without a `design.md` breaks every inbound reference to it.

## How

The flat-vs-nested decision now lives in one module — `spec-layout.js` — which returns the route slugs alongside `hasSpec` / `hasDesign`. The mapping builder, the transform, and the specs index all read it instead of each re-deriving the layout from the filesystem and disagreeing.

Applied to all three copies that ship from this repo:

| Copy | Files |
|---|---|
| docs-site scripts | `spec-layout.js` (new), `build-spec-mapping.js`, `transform-openspecs.js`, `generate-index.js` |
| Vendored Docusaurus plugin | `templates/docusaurus/plugins/sdd-content/index.js` (inline section, same shape) |
| sync-spec-docs integration lib | `spec-layout.js` (new), `build-spec-mapping.js`, `transform-openspecs.js`, `generate-index.js` |

Also fixes a comment's indentation in all three mapping builders, left over from the commit below.

## Stacked on #222

Based on `bug/spec-refs-keyed-by-prefix`, which touches the same mapping lines and adds the test suite this extends. **Merge #222 first**, then this retargets to `main` cleanly.

## Verification

- `make check` — green (the two `skills/index` broken-link warnings pre-date this branch).
- `spec-references.test.js`: the fixture gained a `delta` domain with a `spec.md` and no `design.md`, plus a case asserting the transform writes `specs/delta.mdx`, that a cross-reference to `SPEC-0004` points at `/specs/delta` and never `/specs/delta/spec`, and that the specs index links the same page. Reverting the plugin's mapping line fails exactly that case and nothing else.
- `spec-layout.test.js` (new): the resolver's four shapes (both files, spec-only, design-only, neither) across both library copies, plus the integration mapping's value for a flat domain under a `pathPrefix`.

## Downstream

`stump.wtf/harness` and `stump.wtf/binnacle` vendor this plugin and carry the same bug; syncing those is a follow-up in each repo.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).

